### PR TITLE
Add action plan dashboard and milestone filtering

### DIFF
--- a/app/action-plan/page.tsx
+++ b/app/action-plan/page.tsx
@@ -1,0 +1,400 @@
+import Link from "next/link";
+
+import {
+  actionPlanMilestones,
+  actionPlanSynthesis,
+  actionPlanTracker,
+  actionPlanWorkstreams,
+  type ActionPlanIssueRef,
+} from "@/lib/action-plan";
+import { fetchIssues, getPriorityLabel, type GitHubIssue } from "@/lib/github";
+
+type ResolvedIssue = {
+  number: number;
+  title: string;
+  url: string;
+  state: "open" | "closed" | "unknown";
+  milestone: string | null;
+  priority: "high" | "medium" | "low" | null;
+};
+
+function resolveIssue(
+  ref: ActionPlanIssueRef,
+  issueMap: Map<number, GitHubIssue>
+): ResolvedIssue {
+  const liveIssue = issueMap.get(ref.number);
+
+  return {
+    number: ref.number,
+    title: liveIssue?.title ?? ref.title,
+    url:
+      liveIssue?.html_url ??
+      `https://github.com/ui-insight/AISPEG/issues/${ref.number}`,
+    state: liveIssue?.state ?? "unknown",
+    milestone: liveIssue?.milestone?.title ?? null,
+    priority: liveIssue ? getPriorityLabel(liveIssue) : null,
+  };
+}
+
+function uniqueNumbers(numbers: number[]) {
+  return Array.from(new Set(numbers));
+}
+
+function IssueStateBadge({ state }: { state: ResolvedIssue["state"] }) {
+  if (state === "closed") {
+    return (
+      <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+        Closed
+      </span>
+    );
+  }
+
+  if (state === "open") {
+    return (
+      <span className="rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+        Open
+      </span>
+    );
+  }
+
+  return (
+    <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500">
+      Not loaded
+    </span>
+  );
+}
+
+function PriorityBadge({
+  priority,
+}: {
+  priority: ResolvedIssue["priority"];
+}) {
+  if (!priority) return null;
+
+  const styles = {
+    high: "bg-red-100 text-red-700",
+    medium: "bg-yellow-100 text-yellow-700",
+    low: "bg-gray-100 text-gray-600",
+  };
+
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[priority]}`}>
+      {priority}
+    </span>
+  );
+}
+
+function IssueRow({ issue }: { issue: ResolvedIssue }) {
+  return (
+    <a
+      href={issue.url}
+      target="_blank"
+      rel="noreferrer"
+      className="flex items-start justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 transition-colors hover:border-gray-200 hover:bg-white"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            #{issue.number}
+          </span>
+          <IssueStateBadge state={issue.state} />
+          <PriorityBadge priority={issue.priority} />
+        </div>
+        <p className="mt-1 text-sm font-medium text-ui-charcoal">{issue.title}</p>
+        {issue.milestone && (
+          <p className="mt-1 text-xs text-gray-500">Milestone: {issue.milestone}</p>
+        )}
+      </div>
+      <span className="text-sm font-medium text-ui-gold-dark">Open</span>
+    </a>
+  );
+}
+
+export default async function ActionPlanPage() {
+  const issues = await fetchIssues();
+  const issueMap = new Map(issues.map((issue) => [issue.number, issue]));
+
+  const trackerIssue = resolveIssue(actionPlanTracker, issueMap);
+  const trackedIssueNumbers = uniqueNumbers([
+    ...actionPlanMilestones.flatMap((milestone) => milestone.issueNumbers),
+    ...actionPlanSynthesis.inputIssues.map((issue) => issue.number),
+  ]);
+  const trackedIssues = trackedIssueNumbers.map((number) =>
+    resolveIssue(
+      {
+        number,
+        title: `Issue #${number}`,
+      },
+      issueMap
+    )
+  );
+  const openTrackedIssues = trackedIssues.filter(
+    (issue) => issue.state === "open"
+  ).length;
+  const closedTrackedIssues = trackedIssues.filter(
+    (issue) => issue.state === "closed"
+  ).length;
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h1 className="text-3xl font-bold text-ui-charcoal">Action Plan</h1>
+        <p className="mt-2 max-w-3xl text-gray-600">
+          Execution view for the March 2026 OIT AI Next Steps directive,
+          anchored in GitHub issues and milestone windows rather than narrative
+          notes alone.
+        </p>
+      </div>
+
+      <section className="rounded-2xl bg-ui-charcoal p-6 text-white shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <p className="text-sm font-medium text-ui-gold">Top-Level Tracker</p>
+            <h2 className="mt-2 text-2xl font-semibold">{trackerIssue.title}</h2>
+            <p className="mt-2 text-sm text-white/70">
+              Five execution epics, one synthesis issue, and quarter-based
+              milestones now organize the institutional work.
+            </p>
+          </div>
+          <a
+            href={trackerIssue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full bg-ui-gold px-4 py-2 text-sm font-semibold text-ui-black transition-colors hover:bg-ui-gold-light"
+          >
+            View issue #{trackerIssue.number}
+          </a>
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Tracked Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{trackedIssueNumbers.length}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Open Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{openTrackedIssues}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Closed Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{closedTrackedIssues}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Milestones
+            </p>
+            <p className="mt-2 text-3xl font-bold">{actionPlanMilestones.length}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-ui-charcoal">Milestone Windows</h2>
+            <p className="text-sm text-gray-500">
+              Quarterly grouping for review, sequencing, and delivery pressure.
+            </p>
+          </div>
+          <Link
+            href="/roadmap"
+            className="text-sm font-medium text-ui-gold-dark hover:underline"
+          >
+            Compare with roadmap
+          </Link>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {actionPlanMilestones.map((milestone) => {
+            const milestoneIssues = milestone.issueNumbers.map((number) =>
+              resolveIssue({ number, title: `Issue #${number}` }, issueMap)
+            );
+            const openCount = milestoneIssues.filter(
+              (issue) => issue.state === "open"
+            ).length;
+            const closedCount = milestoneIssues.filter(
+              (issue) => issue.state === "closed"
+            ).length;
+            const completion = milestoneIssues.length
+              ? Math.round((closedCount / milestoneIssues.length) * 100)
+              : 0;
+
+            return (
+              <article
+                key={milestone.title}
+                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
+                      {milestone.window}
+                    </p>
+                    <h3 className="mt-1 text-lg font-semibold text-ui-charcoal">
+                      {milestone.title}
+                    </h3>
+                  </div>
+                  <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                    {completion}% complete
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-gray-600">{milestone.description}</p>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-ui-gold"
+                    style={{ width: `${completion}%` }}
+                  />
+                </div>
+                <div className="mt-4 flex flex-wrap gap-4 text-sm text-gray-500">
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">
+                      {milestoneIssues.length}
+                    </span>{" "}
+                    issues
+                  </span>
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">{openCount}</span>{" "}
+                    open
+                  </span>
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">{closedCount}</span>{" "}
+                    closed
+                  </span>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold text-ui-charcoal">Workstreams</h2>
+          <p className="text-sm text-gray-500">
+            Each workstream combines one epic, the older issues already in scope,
+            and the execution issues created to close remaining gaps.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {actionPlanWorkstreams.map((workstream) => {
+            const epic = resolveIssue(workstream.epic, issueMap);
+
+            return (
+              <article
+                key={workstream.name}
+                className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="max-w-3xl">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full bg-ui-charcoal px-2.5 py-0.5 text-xs font-medium text-white">
+                        {workstream.ownerRole}
+                      </span>
+                      <IssueStateBadge state={epic.state} />
+                    </div>
+                    <h3 className="mt-3 text-xl font-semibold text-ui-charcoal">
+                      {workstream.name}
+                    </h3>
+                    <p className="mt-2 text-sm text-gray-600">{workstream.goal}</p>
+                  </div>
+                  <a
+                    href={epic.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
+                  >
+                    Epic #{epic.number}
+                  </a>
+                </div>
+
+                <div className="mt-6 grid gap-6 xl:grid-cols-2">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      Existing Issues Already In Scope
+                    </p>
+                    <div className="mt-3 space-y-3">
+                      {workstream.existingIssues.map((issue) => (
+                        <IssueRow
+                          key={issue.number}
+                          issue={resolveIssue(issue, issueMap)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      New Execution Issues
+                    </p>
+                    <div className="mt-3 space-y-3">
+                      {workstream.executionIssues.map((issue) => (
+                        <IssueRow
+                          key={issue.number}
+                          issue={resolveIssue(issue, issueMap)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
+              {actionPlanSynthesis.ownerRole}
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-ui-charcoal">
+              Roadmap Synthesis Layer
+            </h2>
+            <p className="mt-2 text-sm text-gray-600">
+              {actionPlanSynthesis.goal}
+            </p>
+          </div>
+          <a
+            href={`https://github.com/ui-insight/AISPEG/issues/${actionPlanSynthesis.issue.number}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
+          >
+            Synthesis issue #{actionPlanSynthesis.issue.number}
+          </a>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-3">
+          <div className="rounded-xl bg-gray-50 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Inputs Waiting For Synthesis
+            </p>
+            <div className="mt-3 space-y-3">
+              {actionPlanSynthesis.inputIssues.map((issue) => (
+                <IssueRow key={issue.number} issue={resolveIssue(issue, issueMap)} />
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-xl bg-gray-50 p-4 lg:col-span-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+              How To Use This Page
+            </p>
+            <ul className="mt-3 space-y-2 text-sm text-gray-600">
+              <li>Use the milestone cards to review quarter sequencing and load.</li>
+              <li>Use the workstream cards to see which older issues were folded into each epic.</li>
+              <li>Use the synthesis layer to keep research inputs from becoming a second roadmap.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/action-plan/page.tsx
+++ b/app/action-plan/page.tsx
@@ -1,5 +1,9 @@
-import Link from "next/link";
-
+import ActionPlanDashboard, {
+  type ActionPlanDashboardMilestone,
+  type ActionPlanDashboardSynthesis,
+  type ActionPlanDashboardWorkstream,
+  type ActionPlanResolvedIssue,
+} from "@/components/ActionPlanDashboard";
 import {
   actionPlanMilestones,
   actionPlanSynthesis,
@@ -9,19 +13,10 @@ import {
 } from "@/lib/action-plan";
 import { fetchIssues, getPriorityLabel, type GitHubIssue } from "@/lib/github";
 
-type ResolvedIssue = {
-  number: number;
-  title: string;
-  url: string;
-  state: "open" | "closed" | "unknown";
-  milestone: string | null;
-  priority: "high" | "medium" | "low" | null;
-};
-
 function resolveIssue(
   ref: ActionPlanIssueRef,
   issueMap: Map<number, GitHubIssue>
-): ResolvedIssue {
+): ActionPlanResolvedIssue {
   const liveIssue = issueMap.get(ref.number);
 
   return {
@@ -38,76 +33,6 @@ function resolveIssue(
 
 function uniqueNumbers(numbers: number[]) {
   return Array.from(new Set(numbers));
-}
-
-function IssueStateBadge({ state }: { state: ResolvedIssue["state"] }) {
-  if (state === "closed") {
-    return (
-      <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
-        Closed
-      </span>
-    );
-  }
-
-  if (state === "open") {
-    return (
-      <span className="rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
-        Open
-      </span>
-    );
-  }
-
-  return (
-    <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500">
-      Not loaded
-    </span>
-  );
-}
-
-function PriorityBadge({
-  priority,
-}: {
-  priority: ResolvedIssue["priority"];
-}) {
-  if (!priority) return null;
-
-  const styles = {
-    high: "bg-red-100 text-red-700",
-    medium: "bg-yellow-100 text-yellow-700",
-    low: "bg-gray-100 text-gray-600",
-  };
-
-  return (
-    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[priority]}`}>
-      {priority}
-    </span>
-  );
-}
-
-function IssueRow({ issue }: { issue: ResolvedIssue }) {
-  return (
-    <a
-      href={issue.url}
-      target="_blank"
-      rel="noreferrer"
-      className="flex items-start justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 transition-colors hover:border-gray-200 hover:bg-white"
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-            #{issue.number}
-          </span>
-          <IssueStateBadge state={issue.state} />
-          <PriorityBadge priority={issue.priority} />
-        </div>
-        <p className="mt-1 text-sm font-medium text-ui-charcoal">{issue.title}</p>
-        {issue.milestone && (
-          <p className="mt-1 text-xs text-gray-500">Milestone: {issue.milestone}</p>
-        )}
-      </div>
-      <span className="text-sm font-medium text-ui-gold-dark">Open</span>
-    </a>
-  );
 }
 
 export default async function ActionPlanPage() {
@@ -128,273 +53,44 @@ export default async function ActionPlanPage() {
       issueMap
     )
   );
-  const openTrackedIssues = trackedIssues.filter(
-    (issue) => issue.state === "open"
-  ).length;
-  const closedTrackedIssues = trackedIssues.filter(
-    (issue) => issue.state === "closed"
-  ).length;
+
+  const milestones: ActionPlanDashboardMilestone[] = actionPlanMilestones.map(
+    (milestone) => ({
+      ...milestone,
+      issues: milestone.issueNumbers.map((number) =>
+        resolveIssue({ number, title: `Issue #${number}` }, issueMap)
+      ),
+    })
+  );
+
+  const workstreams: ActionPlanDashboardWorkstream[] = actionPlanWorkstreams.map(
+    (workstream) => ({
+      ...workstream,
+      epic: resolveIssue(workstream.epic, issueMap),
+      existingIssues: workstream.existingIssues.map((issue) =>
+        resolveIssue(issue, issueMap)
+      ),
+      executionIssues: workstream.executionIssues.map((issue) =>
+        resolveIssue(issue, issueMap)
+      ),
+    })
+  );
+
+  const synthesis: ActionPlanDashboardSynthesis = {
+    ...actionPlanSynthesis,
+    issue: resolveIssue(actionPlanSynthesis.issue, issueMap),
+    inputIssues: actionPlanSynthesis.inputIssues.map((issue) =>
+      resolveIssue(issue, issueMap)
+    ),
+  };
 
   return (
-    <div className="space-y-10">
-      <div>
-        <h1 className="text-3xl font-bold text-ui-charcoal">Action Plan</h1>
-        <p className="mt-2 max-w-3xl text-gray-600">
-          Execution view for the March 2026 OIT AI Next Steps directive,
-          anchored in GitHub issues and milestone windows rather than narrative
-          notes alone.
-        </p>
-      </div>
-
-      <section className="rounded-2xl bg-ui-charcoal p-6 text-white shadow-sm">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl">
-            <p className="text-sm font-medium text-ui-gold">Top-Level Tracker</p>
-            <h2 className="mt-2 text-2xl font-semibold">{trackerIssue.title}</h2>
-            <p className="mt-2 text-sm text-white/70">
-              Five execution epics, one synthesis issue, and quarter-based
-              milestones now organize the institutional work.
-            </p>
-          </div>
-          <a
-            href={trackerIssue.url}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-full bg-ui-gold px-4 py-2 text-sm font-semibold text-ui-black transition-colors hover:bg-ui-gold-light"
-          >
-            View issue #{trackerIssue.number}
-          </a>
-        </div>
-
-        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-xl bg-white/5 p-4">
-            <p className="text-xs uppercase tracking-wide text-white/50">
-              Tracked Issues
-            </p>
-            <p className="mt-2 text-3xl font-bold">{trackedIssueNumbers.length}</p>
-          </div>
-          <div className="rounded-xl bg-white/5 p-4">
-            <p className="text-xs uppercase tracking-wide text-white/50">
-              Open Issues
-            </p>
-            <p className="mt-2 text-3xl font-bold">{openTrackedIssues}</p>
-          </div>
-          <div className="rounded-xl bg-white/5 p-4">
-            <p className="text-xs uppercase tracking-wide text-white/50">
-              Closed Issues
-            </p>
-            <p className="mt-2 text-3xl font-bold">{closedTrackedIssues}</p>
-          </div>
-          <div className="rounded-xl bg-white/5 p-4">
-            <p className="text-xs uppercase tracking-wide text-white/50">
-              Milestones
-            </p>
-            <p className="mt-2 text-3xl font-bold">{actionPlanMilestones.length}</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h2 className="text-xl font-semibold text-ui-charcoal">Milestone Windows</h2>
-            <p className="text-sm text-gray-500">
-              Quarterly grouping for review, sequencing, and delivery pressure.
-            </p>
-          </div>
-          <Link
-            href="/roadmap"
-            className="text-sm font-medium text-ui-gold-dark hover:underline"
-          >
-            Compare with roadmap
-          </Link>
-        </div>
-
-        <div className="grid gap-4 lg:grid-cols-2">
-          {actionPlanMilestones.map((milestone) => {
-            const milestoneIssues = milestone.issueNumbers.map((number) =>
-              resolveIssue({ number, title: `Issue #${number}` }, issueMap)
-            );
-            const openCount = milestoneIssues.filter(
-              (issue) => issue.state === "open"
-            ).length;
-            const closedCount = milestoneIssues.filter(
-              (issue) => issue.state === "closed"
-            ).length;
-            const completion = milestoneIssues.length
-              ? Math.round((closedCount / milestoneIssues.length) * 100)
-              : 0;
-
-            return (
-              <article
-                key={milestone.title}
-                className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
-                      {milestone.window}
-                    </p>
-                    <h3 className="mt-1 text-lg font-semibold text-ui-charcoal">
-                      {milestone.title}
-                    </h3>
-                  </div>
-                  <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
-                    {completion}% complete
-                  </span>
-                </div>
-                <p className="mt-2 text-sm text-gray-600">{milestone.description}</p>
-                <div className="mt-4 h-2 overflow-hidden rounded-full bg-gray-100">
-                  <div
-                    className="h-full rounded-full bg-ui-gold"
-                    style={{ width: `${completion}%` }}
-                  />
-                </div>
-                <div className="mt-4 flex flex-wrap gap-4 text-sm text-gray-500">
-                  <span>
-                    <span className="font-semibold text-ui-charcoal">
-                      {milestoneIssues.length}
-                    </span>{" "}
-                    issues
-                  </span>
-                  <span>
-                    <span className="font-semibold text-ui-charcoal">{openCount}</span>{" "}
-                    open
-                  </span>
-                  <span>
-                    <span className="font-semibold text-ui-charcoal">{closedCount}</span>{" "}
-                    closed
-                  </span>
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold text-ui-charcoal">Workstreams</h2>
-          <p className="text-sm text-gray-500">
-            Each workstream combines one epic, the older issues already in scope,
-            and the execution issues created to close remaining gaps.
-          </p>
-        </div>
-
-        <div className="space-y-6">
-          {actionPlanWorkstreams.map((workstream) => {
-            const epic = resolveIssue(workstream.epic, issueMap);
-
-            return (
-              <article
-                key={workstream.name}
-                className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
-              >
-                <div className="flex flex-wrap items-start justify-between gap-4">
-                  <div className="max-w-3xl">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="rounded-full bg-ui-charcoal px-2.5 py-0.5 text-xs font-medium text-white">
-                        {workstream.ownerRole}
-                      </span>
-                      <IssueStateBadge state={epic.state} />
-                    </div>
-                    <h3 className="mt-3 text-xl font-semibold text-ui-charcoal">
-                      {workstream.name}
-                    </h3>
-                    <p className="mt-2 text-sm text-gray-600">{workstream.goal}</p>
-                  </div>
-                  <a
-                    href={epic.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
-                  >
-                    Epic #{epic.number}
-                  </a>
-                </div>
-
-                <div className="mt-6 grid gap-6 xl:grid-cols-2">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-                      Existing Issues Already In Scope
-                    </p>
-                    <div className="mt-3 space-y-3">
-                      {workstream.existingIssues.map((issue) => (
-                        <IssueRow
-                          key={issue.number}
-                          issue={resolveIssue(issue, issueMap)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-                      New Execution Issues
-                    </p>
-                    <div className="mt-3 space-y-3">
-                      {workstream.executionIssues.map((issue) => (
-                        <IssueRow
-                          key={issue.number}
-                          issue={resolveIssue(issue, issueMap)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl">
-            <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
-              {actionPlanSynthesis.ownerRole}
-            </p>
-            <h2 className="mt-2 text-xl font-semibold text-ui-charcoal">
-              Roadmap Synthesis Layer
-            </h2>
-            <p className="mt-2 text-sm text-gray-600">
-              {actionPlanSynthesis.goal}
-            </p>
-          </div>
-          <a
-            href={`https://github.com/ui-insight/AISPEG/issues/${actionPlanSynthesis.issue.number}`}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
-          >
-            Synthesis issue #{actionPlanSynthesis.issue.number}
-          </a>
-        </div>
-
-        <div className="mt-6 grid gap-4 lg:grid-cols-3">
-          <div className="rounded-xl bg-gray-50 p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-              Inputs Waiting For Synthesis
-            </p>
-            <div className="mt-3 space-y-3">
-              {actionPlanSynthesis.inputIssues.map((issue) => (
-                <IssueRow key={issue.number} issue={resolveIssue(issue, issueMap)} />
-              ))}
-            </div>
-          </div>
-
-          <div className="rounded-xl bg-gray-50 p-4 lg:col-span-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
-              How To Use This Page
-            </p>
-            <ul className="mt-3 space-y-2 text-sm text-gray-600">
-              <li>Use the milestone cards to review quarter sequencing and load.</li>
-              <li>Use the workstream cards to see which older issues were folded into each epic.</li>
-              <li>Use the synthesis layer to keep research inputs from becoming a second roadmap.</li>
-            </ul>
-          </div>
-        </div>
-      </section>
-    </div>
+    <ActionPlanDashboard
+      trackerIssue={trackerIssue}
+      trackedIssues={trackedIssues}
+      milestones={milestones}
+      workstreams={workstreams}
+      synthesis={synthesis}
+    />
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import IssueCard from "@/components/IssueCard";
+import { actionPlanWorkstreams } from "@/lib/action-plan";
 import {
   fetchIssues,
   getStrategicIssues,
@@ -22,6 +23,12 @@ import {
 /* Navigation cards data                                       */
 /* ---------------------------------------------------------- */
 const navCards = [
+  {
+    href: "/action-plan",
+    label: "Action Plan",
+    count: `${actionPlanWorkstreams.length} workstreams`,
+    icon: "🎯",
+  },
   {
     href: "/principles",
     label: "Strategic Principles",

--- a/components/ActionPlanDashboard.tsx
+++ b/components/ActionPlanDashboard.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+type IssueState = "open" | "closed" | "unknown";
+type IssuePriority = "high" | "medium" | "low" | null;
+
+export interface ActionPlanResolvedIssue {
+  number: number;
+  title: string;
+  url: string;
+  state: IssueState;
+  milestone: string | null;
+  priority: IssuePriority;
+}
+
+export interface ActionPlanDashboardMilestone {
+  title: string;
+  window: string;
+  description: string;
+  issues: ActionPlanResolvedIssue[];
+}
+
+export interface ActionPlanDashboardWorkstream {
+  name: string;
+  ownerRole: string;
+  goal: string;
+  epic: ActionPlanResolvedIssue;
+  existingIssues: ActionPlanResolvedIssue[];
+  executionIssues: ActionPlanResolvedIssue[];
+}
+
+export interface ActionPlanDashboardSynthesis {
+  ownerRole: string;
+  issue: ActionPlanResolvedIssue;
+  goal: string;
+  inputIssues: ActionPlanResolvedIssue[];
+}
+
+function IssueStateBadge({ state }: { state: IssueState }) {
+  if (state === "closed") {
+    return (
+      <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+        Closed
+      </span>
+    );
+  }
+
+  if (state === "open") {
+    return (
+      <span className="rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+        Open
+      </span>
+    );
+  }
+
+  return (
+    <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500">
+      Not loaded
+    </span>
+  );
+}
+
+function PriorityBadge({ priority }: { priority: IssuePriority }) {
+  if (!priority) return null;
+
+  const styles = {
+    high: "bg-red-100 text-red-700",
+    medium: "bg-yellow-100 text-yellow-700",
+    low: "bg-gray-100 text-gray-600",
+  };
+
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[priority]}`}>
+      {priority}
+    </span>
+  );
+}
+
+function IssueRow({ issue }: { issue: ActionPlanResolvedIssue }) {
+  return (
+    <a
+      href={issue.url}
+      target="_blank"
+      rel="noreferrer"
+      className="flex items-start justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 transition-colors hover:border-gray-200 hover:bg-white"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            #{issue.number}
+          </span>
+          <IssueStateBadge state={issue.state} />
+          <PriorityBadge priority={issue.priority} />
+        </div>
+        <p className="mt-1 text-sm font-medium text-ui-charcoal">{issue.title}</p>
+        {issue.milestone && (
+          <p className="mt-1 text-xs text-gray-500">Milestone: {issue.milestone}</p>
+        )}
+      </div>
+      <span className="text-sm font-medium text-ui-gold-dark">Open</span>
+    </a>
+  );
+}
+
+function matchesMilestone(
+  issue: ActionPlanResolvedIssue,
+  selectedMilestone: string
+) {
+  return selectedMilestone === "All" || issue.milestone === selectedMilestone;
+}
+
+export default function ActionPlanDashboard({
+  trackerIssue,
+  trackedIssues,
+  milestones,
+  workstreams,
+  synthesis,
+}: {
+  trackerIssue: ActionPlanResolvedIssue;
+  trackedIssues: ActionPlanResolvedIssue[];
+  milestones: ActionPlanDashboardMilestone[];
+  workstreams: ActionPlanDashboardWorkstream[];
+  synthesis: ActionPlanDashboardSynthesis;
+}) {
+  const [selectedMilestone, setSelectedMilestone] = useState("All");
+
+  const visibleTrackedIssues = useMemo(() => {
+    return trackedIssues.filter((issue) => matchesMilestone(issue, selectedMilestone));
+  }, [selectedMilestone, trackedIssues]);
+
+  const openTrackedIssues = visibleTrackedIssues.filter(
+    (issue) => issue.state === "open"
+  ).length;
+  const closedTrackedIssues = visibleTrackedIssues.filter(
+    (issue) => issue.state === "closed"
+  ).length;
+
+  const filteredWorkstreams = useMemo(() => {
+    return workstreams
+      .map((workstream) => {
+        const existingIssues = workstream.existingIssues.filter((issue) =>
+          matchesMilestone(issue, selectedMilestone)
+        );
+        const executionIssues = workstream.executionIssues.filter((issue) =>
+          matchesMilestone(issue, selectedMilestone)
+        );
+        const epicMatches =
+          selectedMilestone === "All" ||
+          workstream.epic.milestone === selectedMilestone;
+
+        if (!epicMatches && existingIssues.length === 0 && executionIssues.length === 0) {
+          return null;
+        }
+
+        return {
+          ...workstream,
+          existingIssues,
+          executionIssues,
+        };
+      })
+      .filter(Boolean) as ActionPlanDashboardWorkstream[];
+  }, [selectedMilestone, workstreams]);
+
+  const showSynthesis =
+    selectedMilestone === "All" || synthesis.issue.milestone === selectedMilestone;
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <h1 className="text-3xl font-bold text-ui-charcoal">Action Plan</h1>
+        <p className="mt-2 max-w-3xl text-gray-600">
+          Execution view for the March 2026 OIT AI Next Steps directive,
+          anchored in GitHub issues and milestone windows rather than narrative
+          notes alone.
+        </p>
+      </div>
+
+      <section className="rounded-2xl bg-ui-charcoal p-6 text-white shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <p className="text-sm font-medium text-ui-gold">Top-Level Tracker</p>
+            <h2 className="mt-2 text-2xl font-semibold">{trackerIssue.title}</h2>
+            <p className="mt-2 text-sm text-white/70">
+              Five execution epics, one synthesis issue, and quarter-based
+              milestones now organize the institutional work.
+            </p>
+          </div>
+          <a
+            href={trackerIssue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full bg-ui-gold px-4 py-2 text-sm font-semibold text-ui-black transition-colors hover:bg-ui-gold-light"
+          >
+            View issue #{trackerIssue.number}
+          </a>
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setSelectedMilestone("All")}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              selectedMilestone === "All"
+                ? "bg-ui-gold text-ui-black"
+                : "bg-white/10 text-white/70 hover:bg-white/15 hover:text-white"
+            }`}
+          >
+            All milestones
+          </button>
+          {milestones.map((milestone) => (
+            <button
+              key={milestone.title}
+              type="button"
+              onClick={() => setSelectedMilestone(milestone.title)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                selectedMilestone === milestone.title
+                  ? "bg-ui-gold text-ui-black"
+                  : "bg-white/10 text-white/70 hover:bg-white/15 hover:text-white"
+              }`}
+            >
+              {milestone.window}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Visible Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{visibleTrackedIssues.length}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Open Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{openTrackedIssues}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Closed Issues
+            </p>
+            <p className="mt-2 text-3xl font-bold">{closedTrackedIssues}</p>
+          </div>
+          <div className="rounded-xl bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-wide text-white/50">
+              Active Filter
+            </p>
+            <p className="mt-2 text-lg font-bold">
+              {selectedMilestone === "All" ? "All milestones" : selectedMilestone}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-ui-charcoal">Milestone Windows</h2>
+            <p className="text-sm text-gray-500">
+              Click a milestone to filter the issue view below by quarter or annual scope.
+            </p>
+          </div>
+          <Link
+            href="/roadmap"
+            className="text-sm font-medium text-ui-gold-dark hover:underline"
+          >
+            Compare with roadmap
+          </Link>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {milestones.map((milestone) => {
+            const openCount = milestone.issues.filter(
+              (issue) => issue.state === "open"
+            ).length;
+            const closedCount = milestone.issues.filter(
+              (issue) => issue.state === "closed"
+            ).length;
+            const completion = milestone.issues.length
+              ? Math.round((closedCount / milestone.issues.length) * 100)
+              : 0;
+            const active = selectedMilestone === milestone.title;
+
+            return (
+              <button
+                key={milestone.title}
+                type="button"
+                onClick={() =>
+                  setSelectedMilestone((current) =>
+                    current === milestone.title ? "All" : milestone.title
+                  )
+                }
+                className={`rounded-xl border bg-white p-5 text-left shadow-sm transition-colors ${
+                  active
+                    ? "border-ui-gold bg-ui-gold/5"
+                    : "border-gray-200 hover:border-ui-gold/40"
+                }`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
+                      {milestone.window}
+                    </p>
+                    <h3 className="mt-1 text-lg font-semibold text-ui-charcoal">
+                      {milestone.title}
+                    </h3>
+                  </div>
+                  <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                    {completion}% complete
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-gray-600">{milestone.description}</p>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-ui-gold"
+                    style={{ width: `${completion}%` }}
+                  />
+                </div>
+                <div className="mt-4 flex flex-wrap gap-4 text-sm text-gray-500">
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">
+                      {milestone.issues.length}
+                    </span>{" "}
+                    issues
+                  </span>
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">{openCount}</span>{" "}
+                    open
+                  </span>
+                  <span>
+                    <span className="font-semibold text-ui-charcoal">{closedCount}</span>{" "}
+                    closed
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold text-ui-charcoal">Workstreams</h2>
+          <p className="text-sm text-gray-500">
+            The selected milestone filters the issue lists below, so you can review one delivery
+            window without losing the workstream structure.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {filteredWorkstreams.map((workstream) => (
+            <article
+              key={workstream.name}
+              className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="max-w-3xl">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-ui-charcoal px-2.5 py-0.5 text-xs font-medium text-white">
+                      {workstream.ownerRole}
+                    </span>
+                    <IssueStateBadge state={workstream.epic.state} />
+                  </div>
+                  <h3 className="mt-3 text-xl font-semibold text-ui-charcoal">
+                    {workstream.name}
+                  </h3>
+                  <p className="mt-2 text-sm text-gray-600">{workstream.goal}</p>
+                </div>
+                <a
+                  href={workstream.epic.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
+                >
+                  Epic #{workstream.epic.number}
+                </a>
+              </div>
+
+              <div className="mt-6 grid gap-6 xl:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    Existing Issues Already In Scope
+                  </p>
+                  <div className="mt-3 space-y-3">
+                    {workstream.existingIssues.length > 0 ? (
+                      workstream.existingIssues.map((issue) => (
+                        <IssueRow key={issue.number} issue={issue} />
+                      ))
+                    ) : (
+                      <p className="rounded-lg border border-dashed border-gray-200 px-4 py-3 text-sm text-gray-400">
+                        No existing issues in the selected milestone.
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                    New Execution Issues
+                  </p>
+                  <div className="mt-3 space-y-3">
+                    {workstream.executionIssues.length > 0 ? (
+                      workstream.executionIssues.map((issue) => (
+                        <IssueRow key={issue.number} issue={issue} />
+                      ))
+                    ) : (
+                      <p className="rounded-lg border border-dashed border-gray-200 px-4 py-3 text-sm text-gray-400">
+                        No new execution issues in the selected milestone.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+
+          {filteredWorkstreams.length === 0 && (
+            <div className="rounded-xl border border-dashed border-gray-300 bg-white/60 p-8 text-center">
+              <p className="text-sm text-gray-500">
+                No workstreams match the current milestone filter.
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {showSynthesis && (
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-wide text-ui-gold-dark">
+                {synthesis.ownerRole}
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-ui-charcoal">
+                Roadmap Synthesis Layer
+              </h2>
+              <p className="mt-2 text-sm text-gray-600">{synthesis.goal}</p>
+            </div>
+            <a
+              href={synthesis.issue.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1.5 text-sm font-medium text-ui-gold-dark hover:bg-ui-gold/20"
+            >
+              Synthesis issue #{synthesis.issue.number}
+            </a>
+          </div>
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-3">
+            <div className="rounded-xl bg-gray-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                Inputs Waiting For Synthesis
+              </p>
+              <div className="mt-3 space-y-3">
+                {synthesis.inputIssues.map((issue) => (
+                  <IssueRow key={issue.number} issue={issue} />
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gray-50 p-4 lg:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                How To Use This Page
+              </p>
+              <ul className="mt-3 space-y-2 text-sm text-gray-600">
+                <li>Use milestone chips or cards to isolate one delivery window.</li>
+                <li>Review filtered workstreams without losing the institutional grouping.</li>
+                <li>Use synthesis to keep research inputs tied to execution instead of spawning a second roadmap.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 const navItems = [
   { href: "/", label: "Dashboard", icon: "squares" },
+  { href: "/action-plan", label: "Action Plan", icon: "target" },
   { href: "/principles", label: "Strategic Principles", icon: "lightbulb" },
   { href: "/lessons", label: "Lessons Learned", icon: "book" },
   { href: "/playbook", label: "Agent Playbook", icon: "clipboard" },
@@ -71,6 +72,17 @@ function NavIcon({ icon, className }: { icon: string; className?: string }) {
       return (
         <svg className={c} fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        </svg>
+      );
+    case "target":
+      return (
+        <svg className={c} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364-6.364l-2.121 2.121M7.757 16.243l-2.121 2.121m0-12.728l2.121 2.121m8.486 8.486l2.121 2.121M12 15a3 3 0 100-6 3 3 0 000 6zm0 4a7 7 0 100-14 7 7 0 000 14z"
+          />
         </svg>
       );
     default:

--- a/lib/action-plan.ts
+++ b/lib/action-plan.ts
@@ -1,0 +1,279 @@
+export interface ActionPlanIssueRef {
+  number: number;
+  title: string;
+}
+
+export interface ActionPlanMilestone {
+  title: string;
+  window: string;
+  description: string;
+  issueNumbers: number[];
+}
+
+export interface ActionPlanWorkstream {
+  name: string;
+  ownerRole: string;
+  goal: string;
+  epic: ActionPlanIssueRef;
+  existingIssues: ActionPlanIssueRef[];
+  executionIssues: ActionPlanIssueRef[];
+}
+
+export const actionPlanTracker: ActionPlanIssueRef = {
+  number: 18,
+  title: "[Action Plan] OIT March 2026 AI Next Steps Execution Plan",
+};
+
+export const actionPlanMilestones: ActionPlanMilestone[] = [
+  {
+    title: "2026 Action Plan",
+    window: "Annual",
+    description:
+      "Umbrella milestone for the action-plan tracker and the five major execution epics.",
+    issueNumbers: [18, 19, 20, 21, 22, 23],
+  },
+  {
+    title: "2026 Q2 - Foundation Decisions",
+    window: "Q2 2026",
+    description:
+      "Architecture, governance, and operating decisions needed before broader rollout.",
+    issueNumbers: [1, 2, 14, 26, 27, 29, 30, 32],
+  },
+  {
+    title: "2026 Q3 - Controls and Standards",
+    window: "Q3 2026",
+    description:
+      "Controls, standards, documentation, and synthesis work needed for repeatable delivery.",
+    issueNumbers: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 24, 25, 31, 33, 35, 36, 37],
+  },
+  {
+    title: "2026 Q4 - Modernization and Scale",
+    window: "Q4 2026",
+    description:
+      "Modernization, product-team execution, and scale-out work planned for the end of 2026.",
+    issueNumbers: [3, 28, 34, 38, 39, 40],
+  },
+];
+
+export const actionPlanWorkstreams: ActionPlanWorkstream[] = [
+  {
+    name: "Architecture",
+    ownerRole: "Architecture / Infrastructure Lead",
+    goal:
+      "Define the single enterprise AI architecture, operating model, and platform capacity required to support institutional delivery.",
+    epic: {
+      number: 23,
+      title: "[Architecture] Single enterprise AI architecture and infrastructure",
+    },
+    existingIssues: [
+      {
+        number: 14,
+        title: "Establish governance-ready database for documents and structured data",
+      },
+    ],
+    executionIssues: [
+      {
+        number: 30,
+        title: "[Architecture] Approve canonical enterprise AI reference architecture",
+      },
+      {
+        number: 29,
+        title:
+          "[Architecture] Define on-prem and cloud AI infrastructure operating model and security boundaries",
+      },
+      {
+        number: 28,
+        title: "[Architecture] Publish institutional data lake adoption roadmap",
+      },
+      {
+        number: 26,
+        title:
+          "[Architecture] Produce 2026-2027 GPU, compute, storage, and network capacity roadmap",
+      },
+    ],
+  },
+  {
+    name: "Governance",
+    ownerRole: "Governance Lead with OIT/Security",
+    goal:
+      "Make approved tooling, repository controls, exception handling, and compliance monitoring explicit and reviewable.",
+    epic: {
+      number: 22,
+      title: "[Governance] Controlled tooling, repositories, and development policy",
+    },
+    existingIssues: [
+      {
+        number: 1,
+        title: "Secure enterprise agreement with Anthropic for institutional AI tool use",
+      },
+      {
+        number: 4,
+        title:
+          "Formalize CLAUDE.md rules section — separate context from normative rules",
+      },
+      {
+        number: 6,
+        title: "Create agent coordination documentation",
+      },
+      {
+        number: 8,
+        title: "Expand PR template with agent attribution metadata",
+      },
+      {
+        number: 11,
+        title: "Create skill definition template for new Claude Code skills",
+      },
+      {
+        number: 13,
+        title: "Update onboarding guide to include AI tooling setup",
+      },
+    ],
+    executionIssues: [
+      {
+        number: 27,
+        title:
+          "[Governance] Require approved institutional repositories and toolchain for non-research AI development",
+      },
+      {
+        number: 25,
+        title:
+          "[Governance] Define exception process for decentralized or learning-only AI builds",
+      },
+      {
+        number: 24,
+        title: "[Governance] Build repository compliance dashboard for standards adoption",
+      },
+    ],
+  },
+  {
+    name: "Standards",
+    ownerRole: "Standards Program Lead",
+    goal:
+      "Operationalize the institutional standards roadmap across code, security, QA, accessibility, UX, and integration.",
+    epic: {
+      number: 19,
+      title: "[Standards] Institutional AI development standards rollout",
+    },
+    existingIssues: [
+      {
+        number: 5,
+        title: "Add backend pytest CI gate to prevent silent breakage",
+      },
+      {
+        number: 7,
+        title: "Add SECURITY.md and CODE_OF_CONDUCT.md",
+      },
+      {
+        number: 9,
+        title: "Add GitHub issue templates for bugs and feature requests",
+      },
+      {
+        number: 10,
+        title: "Create Architecture Decision Records (ADRs) for key design decisions",
+      },
+      {
+        number: 12,
+        title: "Enforce linting in CI (Ruff, ESLint)",
+      },
+    ],
+    executionIssues: [
+      {
+        number: 35,
+        title: "[Standards] Publish accessibility standard and runtime testing rollout",
+      },
+      {
+        number: 36,
+        title:
+          "[Standards] Create institutional UX standard and shared design pattern library",
+      },
+      {
+        number: 31,
+        title: "[Standards] Create integration and API standard with review process",
+      },
+    ],
+  },
+  {
+    name: "Operating Model",
+    ownerRole: "AISPEG Chair / Strategic Lead",
+    goal:
+      "Clarify decision rights, planning cadence, and how cross-functional product teams get formed and prioritized.",
+    epic: {
+      number: 21,
+      title: "[Operating Model] AISPEG governance and cross-functional product teams",
+    },
+    existingIssues: [
+      {
+        number: 2,
+        title: "Align AISPEG efforts with University of Idaho strategic plan",
+      },
+    ],
+    executionIssues: [
+      {
+        number: 32,
+        title:
+          "[Operating Model] Define AISPEG charter, decision rights, and review cadence",
+      },
+      {
+        number: 33,
+        title: "[Operating Model] Create AI workflow intake and prioritization rubric",
+      },
+      {
+        number: 34,
+        title: "[Operating Model] Launch first cross-functional AI product team pilot",
+      },
+    ],
+  },
+  {
+    name: "Modernization",
+    ownerRole: "Modernization / Procurement Lead",
+    goal:
+      "Shift the institution toward build-first modernization with disciplined vendor, contract, and data-repatriation decisions.",
+    epic: {
+      number: 20,
+      title: "[Modernization] Vendor, contract, and data repatriation strategy",
+    },
+    existingIssues: [
+      {
+        number: 3,
+        title: "Comprehensive audit of institutional data locked behind vendor contracts",
+      },
+    ],
+    executionIssues: [
+      {
+        number: 40,
+        title:
+          "[Modernization] Rank legacy contracts by replacement value, timing, and repatriation feasibility",
+      },
+      {
+        number: 39,
+        title:
+          "[Modernization] Define institutional build-vs-buy rubric for AI-era software decisions",
+      },
+      {
+        number: 38,
+        title:
+          "[Modernization] Standardize contract clauses for data repatriation and renewal limits",
+      },
+    ],
+  },
+];
+
+export const actionPlanSynthesis = {
+  ownerRole: "Roadmap / Program Lead",
+  issue: {
+    number: 37,
+    title: "[Synthesis] Convert approved roadmap inputs into 2026 execution roadmap",
+  },
+  goal:
+    "Translate research-oriented roadmap inputs into approved execution work without letting parallel roadmaps diverge.",
+  inputIssues: [
+    {
+      number: 15,
+      title: "[Roadmap Input] Intent engineering as a required layer for agent strategy",
+    },
+    {
+      number: 16,
+      title: "[Roadmap Input] Six-axis difficulty mapping for AI workflow strategy",
+    },
+  ],
+};

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -14,6 +14,9 @@ export interface GitHubIssue {
   labels: GitHubLabel[];
   html_url: string;
   created_at: string;
+  milestone?: {
+    title: string;
+  } | null;
 }
 
 const REPO = "ui-insight/AISPEG";


### PR DESCRIPTION
## What changed
- added a new `/action-plan` page that turns the March 2026 OIT action plan into a live GitHub-backed execution view
- added a dedicated action-plan data module to map milestones, workstreams, synthesis issues, and issue relationships
- added milestone filtering so the page can isolate Q2, Q3, Q4, or annual action-plan scope interactively
- added navigation links from the sidebar and dashboard

## Validation
- `npm run lint`
- `npm run build`

## Notes
- this PR follows the GitHub issue structure and milestones created for the action-plan work
- the page uses the existing GitHub issue fetch path and revalidation behavior already present in the app