### PR TITLE
Sprint 2: friction-ledger schema, /portfolio from DB, /internal view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ DATABASE_URL=postgresql://aispeg:aispeg_secret@localhost:5432/aispeg
 POSTGRES_DB=aispeg
 POSTGRES_USER=aispeg
 POSTGRES_PASSWORD=aispeg_secret
+
+# Basic auth for /internal/* (Sprint 2 — replace with UI SSO later)
+BASIC_AUTH_USER=
+BASIC_AUTH_PASS=

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -233,17 +233,25 @@ don't share files.
 **Output:** the site already feels different. Standards Watch is live. Public
 register has shifted. No backend changes required.
 
-### Sprint 2 — The Work rebuild
+### Sprint 2 — The Work rebuild *(complete, May 2026)*
 
-- Migration 005: friction-ledger fields + `blockers` table on Postgres.
-- Migrate `lib/portfolio.ts` entries into `applications` table (one-time script).
-  After migration, `lib/portfolio.ts` deletes.
-- Reconcile `applications.status` with the lifecycle states agreed with Colin.
-- New `/work` route reading from `applications` + `blockers`. Rendering:
-  per-project card with owner, status, active blockers, last-updated date.
-  Filter/sort by home unit, blocker category, status.
-- Auth-gated `/internal/work` view of same data with `internal_text` blocker
-  detail and embargoed-project records visible.
+- ✅ Migration 005: friction-ledger fields on `applications` + `blockers` table
+  + `schema_migrations` tracking table.
+- ✅ Migration runner (`npm run migrate`) and one-shot data seed
+  (`npm run seed:portfolio`) port `lib/portfolio.ts` → `applications` +
+  auto-derive blockers from existing visibility/review-status flags.
+- ✅ `lib/portfolio.ts` retained as the seed source until Sprint 3 ClickUp
+  wiring lands; runtime reads now go through `lib/work.ts`.
+- ✅ `/portfolio` and `/portfolio/[slug]` rebuilt to read from Postgres via
+  `lib/work.ts`. Per-card friction-ledger chips show category, named party,
+  and a day counter from blocker.since.
+- ✅ Auth-gated `/internal`, `/internal/portfolio`, and
+  `/internal/portfolio/[slug]` render the same data with `internal_text`
+  blocker detail, embargoed records visible, and a visibility-tier chip on
+  the detail view. Basic auth via `BASIC_AUTH_USER` / `BASIC_AUTH_PASS`.
+- ℹ️  `/work` URL not introduced — sidebar label is "The Work" but the route
+  stays `/portfolio` to avoid breaking existing inbound links from decks,
+  emails, and the prior portfolio detail pages.
 
 **Output:** The Work is live. Friction ledger is visible to public and internal
 audiences with appropriate detail levels.

--- a/app/internal/page.tsx
+++ b/app/internal/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { listApplications } from "@/lib/work";
+
+export const dynamic = "force-dynamic";
+
+export default async function InternalHome() {
+  const apps = await listApplications({ audience: "internal" });
+  const blockerCount = apps.reduce((sum, a) => sum + a.activeBlockers.length, 0);
+  const internalOnly = apps.filter((a) => a.visibilityTier === "internal").length;
+  const embargoed = apps.filter((a) => a.visibilityTier === "embargoed").length;
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          IIDS Internal
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+          Internal coordination view
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-relaxed text-gray-700">
+          The auth-gated IIDS-only view of the institutional AI inventory.
+          Same data as the public portfolio with sharper blocker detail
+          (named individuals, contact history) and the embargoed and
+          internal-only records visible.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Total interventions
+          </p>
+          <p className="mt-1 text-3xl font-black text-ui-charcoal">{apps.length}</p>
+          <p className="mt-2 text-xs text-gray-500">
+            {embargoed} embargoed · {internalOnly} internal-only
+          </p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Active blockers
+          </p>
+          <p className="mt-1 text-3xl font-black text-amber-700">{blockerCount}</p>
+          <p className="mt-2 text-xs text-gray-500">
+            Across {apps.filter((a) => a.activeBlockers.length > 0).length}{" "}
+            interventions
+          </p>
+        </div>
+        <Link
+          href="/internal/portfolio"
+          className="group rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            Drill in
+          </p>
+          <p className="mt-1 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            Internal portfolio &rarr;
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            Full inventory with internal-text blocker detail
+          </p>
+        </Link>
+      </section>
+
+      <section className="rounded-xl border border-dashed border-gray-300 bg-white/50 p-6">
+        <h2 className="text-base font-semibold text-ui-charcoal">
+          Coming in Sprint 3
+        </h2>
+        <ul className="mt-3 space-y-1 text-sm text-gray-600">
+          <li>&bull; ClickUp wiring — status and blocker data sync from ClickUp tasks</li>
+          <li>&bull; Submitter status pages (<code>/intake/[token]</code>)</li>
+          <li>&bull; Submission similarity surfaced live during the assessment</li>
+          <li>&bull; Named-SLA acknowledgment email on intake</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/internal/portfolio/[slug]/page.tsx
+++ b/app/internal/portfolio/[slug]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from "next/navigation";
+import InterventionDetail from "@/components/InterventionDetail";
+import {
+  getApplicationBySlug,
+  getRelatedApplications,
+} from "@/lib/work";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const app = await getApplicationBySlug(slug, { audience: "internal" });
+  if (!app) return { title: "Not found" };
+  return {
+    title: `${app.name} · IIDS Internal`,
+    description: app.tagline ?? app.description.slice(0, 160),
+  };
+}
+
+export default async function InternalInterventionDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const app = await getApplicationBySlug(slug, { audience: "internal" });
+  if (!app) notFound();
+
+  const related = await getRelatedApplications(app, { audience: "internal" });
+
+  return (
+    <InterventionDetail
+      app={app}
+      related={related}
+      audience="internal"
+      basePath="/internal/portfolio"
+    />
+  );
+}

--- a/app/internal/portfolio/page.tsx
+++ b/app/internal/portfolio/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import PortfolioCard from "@/components/PortfolioCard";
+import { listApplications, groupByHomeUnit } from "@/lib/work";
+
+export const dynamic = "force-dynamic";
+
+export default async function InternalPortfolioPage() {
+  const apps = await listApplications({ audience: "internal" });
+  const groups = groupByHomeUnit(apps);
+
+  const total = apps.length;
+  const blockerCount = apps.reduce((sum, a) => sum + a.activeBlockers.length, 0);
+  const internalOnly = apps.filter((a) => a.visibilityTier === "internal").length;
+  const embargoed = apps.filter((a) => a.visibilityTier === "embargoed").length;
+
+  return (
+    <div className="space-y-10">
+      {/* Header */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          IIDS Internal
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+          Internal portfolio view
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-700">
+          The full IIDS-coordinated AI inventory, including embargoed and
+          internal-only entries, with sharper blocker detail (named
+          individuals, contact history) than the public portfolio shows.
+        </p>
+        <p className="mt-2 text-sm text-gray-500">
+          {total} interventions · {embargoed} embargoed · {internalOnly}{" "}
+          internal-only · {blockerCount} active blocker
+          {blockerCount === 1 ? "" : "s"}
+        </p>
+        <p className="mt-3 text-xs text-gray-500">
+          <Link
+            href="/portfolio"
+            className="text-ui-gold-dark hover:underline"
+          >
+            View the public portfolio &rarr;
+          </Link>
+        </p>
+      </div>
+
+      {/* Groups by home unit */}
+      {groups.map(({ unit, items }) => (
+        <section key={unit} className="space-y-4">
+          <div className="border-l-4 border-ui-gold pl-4">
+            <div className="flex items-baseline gap-3">
+              <h2 className="text-xl font-bold text-ui-charcoal">{unit}</h2>
+              <span className="text-sm text-gray-500">
+                {items.length}{" "}
+                {items.length === 1 ? "intervention" : "interventions"}
+              </span>
+            </div>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((app) => (
+              <PortfolioCard
+                key={app.id}
+                app={app}
+                audience="internal"
+                basePath="/internal/portfolio"
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/portfolio/[slug]/page.tsx
+++ b/app/portfolio/[slug]/page.tsx
@@ -1,17 +1,24 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
+import InterventionDetail from "@/components/InterventionDetail";
 import {
-  interventions,
-  getInterventionBySlug,
-  getRelatedInterventions,
-  type InterventionStatus,
-} from "@/lib/portfolio";
+  getApplicationBySlug,
+  getRelatedApplications,
+  listSlugs,
+} from "@/lib/work";
 
-export function generateStaticParams() {
-  // Only generate pages for entries that are not internal-only
-  return interventions
-    .filter((i) => i.visibility !== "Internal-only")
-    .map((i) => ({ slug: i.slug }));
+export const dynamic = "force-dynamic";
+
+export async function generateStaticParams() {
+  // Build-time: prerender pages for non-internal slugs. Falls back to
+  // dynamic rendering for any slug not in the list at build.
+  try {
+    const slugs = await listSlugs({ audience: "public" });
+    return slugs.map((slug) => ({ slug }));
+  } catch {
+    // DB unavailable at build time (e.g. CI without .env). Fall back to
+    // dynamic rendering.
+    return [];
+  }
 }
 
 export async function generateMetadata({
@@ -20,11 +27,11 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const i = getInterventionBySlug(slug);
-  if (!i) return { title: "Not found" };
+  const app = await getApplicationBySlug(slug, { audience: "public" });
+  if (!app) return { title: "Not found" };
   return {
-    title: `${i.name} · UI AI Portfolio`,
-    description: i.tagline,
+    title: `${app.name} · UI AI Portfolio`,
+    description: app.tagline ?? app.description.slice(0, 160),
   };
 }
 
@@ -34,317 +41,17 @@ export default async function InterventionDetailPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const intervention = getInterventionBySlug(slug);
-  if (!intervention) notFound();
-  if (intervention.visibility === "Internal-only") notFound();
+  const app = await getApplicationBySlug(slug, { audience: "public" });
+  if (!app) notFound();
 
-  const related = getRelatedInterventions(intervention);
-  const isPartial = intervention.visibility === "Partial";
+  const related = await getRelatedApplications(app, { audience: "public" });
 
   return (
-    <div className="space-y-10">
-      {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500">
-        <Link href="/portfolio" className="hover:text-ui-gold-dark">
-          Portfolio
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-gray-400">{intervention.homeUnits[0]}</span>
-        <span className="mx-2">/</span>
-        <span className="text-ui-charcoal">{intervention.name}</span>
-      </nav>
-
-      {/* Header */}
-      <div>
-        <div className="flex flex-wrap items-center gap-2">
-          <StatusBadge status={intervention.status} />
-          {intervention.ai4raRelationship !== "None" && (
-            <span className="rounded-full border border-ui-gold/30 bg-ui-gold/10 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
-              AI4RA {intervention.ai4raRelationship}
-            </span>
-          )}
-          {intervention.dualDestinyPlanned && (
-            <span className="rounded-full border border-gray-200 px-2.5 py-0.5 text-xs text-gray-600">
-              Dual destiny (OSS + UI)
-            </span>
-          )}
-          {intervention.tags?.includes("diffusion") && (
-            <span className="rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700">
-              Capability diffusion
-            </span>
-          )}
-          {intervention.institutionalReviewStatus === "Under OIT review" && (
-            <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs text-amber-800">
-              Under OIT review
-            </span>
-          )}
-          {intervention.trackingOnly && (
-            <span className="rounded-full border border-violet-200 bg-violet-50 px-2.5 py-0.5 text-xs font-medium text-violet-700">
-              Tracked — not built by IIDS
-            </span>
-          )}
-        </div>
-        <h1 className="mt-3 text-3xl font-bold text-ui-charcoal">
-          {intervention.name}
-        </h1>
-        <p className="mt-2 text-lg text-gray-600">{intervention.tagline}</p>
-        {intervention.funding && (
-          <p className="mt-2 text-sm font-medium text-ui-gold-dark">
-            {intervention.funding}
-          </p>
-        )}
-      </div>
-
-      {/* Embargo notice for Partial visibility */}
-      {isPartial && (
-        <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
-          <p className="text-sm font-semibold text-amber-900">
-            UI deployment details embargoed
-          </p>
-          <p className="mt-1 text-sm text-amber-800">
-            This intervention exists in the inventory, but specific details
-            about UI&apos;s operational deployment (pilot scope, timelines, or
-            configuration) are held back from the public site. Contact the
-            operational owner for authorized access.
-          </p>
-        </div>
-      )}
-
-      {/* Ownership */}
-      <div className="grid gap-4 md:grid-cols-3">
-        <OwnershipBlock label="Home unit(s)" values={intervention.homeUnits} />
-        <OwnershipBlock
-          label={intervention.operationalOwners.length === 1 ? "Operational owner" : "Operational owners"}
-          values={intervention.operationalOwners.map((o) =>
-            o.title ? `${o.name} (${o.title})` : o.name
-          )}
-          emptyText={intervention.trackingOnly ? "Awaiting contact with unit" : undefined}
-        />
-        <OwnershipBlock
-          label="Build participants"
-          values={intervention.buildParticipants}
-        />
-      </div>
-
-      {/* Links */}
-      {(intervention.repoUrl || intervention.docsUrl || intervention.liveUrl) && (
-        <div className="flex flex-wrap gap-3">
-          {intervention.repoUrl && (
-            <a
-              href={intervention.repoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg bg-ui-charcoal px-4 py-2 text-sm font-medium text-white hover:bg-ui-charcoal/90"
-            >
-              <GitHubIcon />
-              Repository
-              {intervention.isPrivateRepo && (
-                <span className="rounded bg-white/10 px-1.5 py-0.5 text-xs">Private</span>
-              )}
-            </a>
-          )}
-          {intervention.liveUrl && (
-            <a
-              href={intervention.liveUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
-            >
-              Live site &rarr;
-            </a>
-          )}
-          {intervention.docsUrl && (
-            <a
-              href={intervention.docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
-            >
-              Documentation &rarr;
-            </a>
-          )}
-        </div>
-      )}
-
-      {/* Description */}
-      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="text-base font-semibold text-ui-charcoal">Overview</h2>
-        <p className="mt-3 text-sm leading-relaxed text-gray-700">
-          {intervention.description}
-        </p>
-      </div>
-
-      {/* Operational function + outcome */}
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h2 className="text-base font-semibold text-ui-charcoal">
-            Operational function at UI
-          </h2>
-          <p className="mt-3 text-sm leading-relaxed text-gray-700">
-            {intervention.operationalFunction}
-          </p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h2 className="text-base font-semibold text-ui-charcoal">
-            Operational excellence outcome
-          </h2>
-          <p className="mt-3 text-sm leading-relaxed text-gray-700">
-            {intervention.operationalExcellenceOutcome}
-          </p>
-        </div>
-      </div>
-
-      {/* External deployments */}
-      {intervention.externalDeployments?.length ? (
-        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h2 className="text-base font-semibold text-ui-charcoal">
-            Also deployed at
-          </h2>
-          <ul className="mt-3 space-y-1 text-sm text-gray-700">
-            {intervention.externalDeployments.map((d) => (
-              <li key={d}>&bull; {d}</li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-
-      {/* Features */}
-      {intervention.features?.length ? (
-        <div>
-          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
-            Key features
-          </h2>
-          <ul className="grid gap-2 sm:grid-cols-2">
-            {intervention.features.map((f, i) => (
-              <li
-                key={i}
-                className="flex items-start gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700"
-              >
-                <svg
-                  className="mt-0.5 h-4 w-4 shrink-0 text-ui-gold"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-                <span>{f}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-
-      {/* Tech stack */}
-      {intervention.tech?.length ? (
-        <div>
-          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
-            Tech stack
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {intervention.tech.map((t) => (
-              <span
-                key={t}
-                className="rounded-md border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700"
-              >
-                {t}
-              </span>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      {/* Related */}
-      {related.length > 0 && (
-        <div>
-          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
-            Related interventions
-          </h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {related.map((r) => (
-              <Link
-                key={r.slug}
-                href={`/portfolio/${r.slug}`}
-                className="group rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-ui-gold/40"
-              >
-                <p className="text-sm font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
-                  {r.name}
-                </p>
-                <p className="mt-1 text-xs text-gray-500">{r.tagline}</p>
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function OwnershipBlock({
-  label,
-  values,
-  emptyText,
-}: {
-  label: string;
-  values: string[];
-  emptyText?: string;
-}) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-      <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
-        {label}
-      </p>
-      {values.length > 0 ? (
-        <ul className="mt-2 space-y-1 text-sm text-ui-charcoal">
-          {values.map((v) => (
-            <li key={v}>{v}</li>
-          ))}
-        </ul>
-      ) : (
-        <p className="mt-2 text-sm italic text-gray-400">
-          {emptyText || "—"}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: InterventionStatus }) {
-  const styles: Record<InterventionStatus, string> = {
-    Production: "bg-green-100 text-green-800",
-    Piloting: "bg-blue-100 text-blue-800",
-    Prototype: "bg-amber-100 text-amber-800",
-    Planned: "bg-gray-100 text-gray-700",
-    Tracked: "bg-violet-100 text-violet-800",
-    Archived: "bg-gray-100 text-gray-500",
-  };
-  return (
-    <span
-      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[status]}`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <svg
-      className="h-4 w-4"
-      fill="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.92c.58.1.78-.25.78-.56v-2c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.28 1.18-3.08-.12-.29-.51-1.46.12-3.04 0 0 .97-.31 3.18 1.17a11 11 0 015.78 0C17.27 4.62 18.24 4.93 18.24 4.93c.63 1.58.24 2.75.12 3.04.73.8 1.18 1.82 1.18 3.08 0 4.43-2.7 5.41-5.27 5.69.41.36.77 1.06.77 2.15v3.19c0 .31.2.67.79.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
-      />
-    </svg>
+    <InterventionDetail
+      app={app}
+      related={related}
+      audience="public"
+      basePath="/portfolio"
+    />
   );
 }

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,15 +1,14 @@
 import Link from "next/link";
 import PortfolioCard from "@/components/PortfolioCard";
-import {
-  getPubliclyVisible,
-  groupByHomeUnit,
-  interventions,
-} from "@/lib/portfolio";
+import { listApplications, groupByHomeUnit } from "@/lib/work";
 
-export default function PortfolioPage() {
-  const visible = getPubliclyVisible();
-  const groups = groupByHomeUnit(visible);
-  const internalCount = interventions.length - visible.length;
+export const dynamic = "force-dynamic";
+
+export default async function PortfolioPage() {
+  const apps = await listApplications({ audience: "public" });
+  const groups = groupByHomeUnit(apps);
+  const blockerCount = apps.reduce((sum, a) => sum + a.activeBlockers.length, 0);
+  const embargoedCount = apps.filter((a) => a.visibilityTier === "embargoed").length;
 
   return (
     <div className="space-y-10">
@@ -31,8 +30,9 @@ export default function PortfolioPage() {
           the outcome, not the code.
         </p>
         <p className="mt-3 text-sm text-gray-500">
-          {visible.length} interventions visible
-          {internalCount > 0 ? ` · ${internalCount} internal-only (not listed publicly)` : ""}
+          {apps.length} interventions visible
+          {embargoedCount > 0 && ` · ${embargoedCount} with deployment detail embargoed`}
+          {blockerCount > 0 && ` · ${blockerCount} active blocker${blockerCount === 1 ? "" : "s"}`}
           {" · "}
           <Link href="/builder-guide" className="text-ui-gold-dark hover:underline">
             Submit a new AI project &rarr;
@@ -45,16 +45,18 @@ export default function PortfolioPage() {
         <p className="text-sm font-medium text-gray-500">How to read this inventory</p>
         <p className="mt-2 text-sm leading-relaxed text-gray-700">
           Interventions are grouped by <strong>UI home unit</strong>. Each card
-          shows the operational owner, current status, and tags —{" "}
+          shows the operational owner, current status, and any active blockers
+          (with a counter of days since the block began). Tags signal
+          relationships:{" "}
           <span className="inline-block rounded-full border border-ui-gold/30 bg-ui-gold/10 px-2 py-0.5 text-xs font-medium text-ui-gold-dark">
             AI4RA Core
           </span>{" "}
-          means the work is part of our NSF-funded UI+SUU partnership and has a
+          means the work is part of the NSF-funded UI+SUU partnership and has a
           dual open-source / UI-implementation identity;{" "}
           <span className="inline-block rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
             Capability diffusion
           </span>{" "}
-          flags interventions where a non-IIDS UI unit is co-building; {" "}
+          flags interventions where a non-IIDS UI unit is co-building;{" "}
           <span className="inline-block rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-700">
             Tracked
           </span>{" "}
@@ -74,8 +76,8 @@ export default function PortfolioPage() {
             </div>
           </div>
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((i) => (
-              <PortfolioCard key={i.slug} intervention={i} />
+            {items.map((app) => (
+              <PortfolioCard key={app.id} app={app} audience="public" />
             ))}
           </div>
         </section>
@@ -83,9 +85,7 @@ export default function PortfolioPage() {
 
       {/* AI4RA pointer */}
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <p className="text-sm font-medium text-gray-500">
-          About AI4RA
-        </p>
+        <p className="text-sm font-medium text-gray-500">About AI4RA</p>
         <p className="mt-2 text-sm leading-relaxed text-gray-700">
           <span className="font-semibold text-ui-charcoal">AI4RA</span> is a
           UI + Southern Utah University NSF GRANTED partnership producing

--- a/components/InterventionDetail.tsx
+++ b/components/InterventionDetail.tsx
@@ -1,0 +1,439 @@
+import Link from "next/link";
+import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
+import { blockerCategoryLabels, daysSince } from "@/lib/work";
+
+const statusStyles: Record<string, string> = {
+  Production: "bg-green-100 text-green-800",
+  Piloting: "bg-blue-100 text-blue-800",
+  Prototype: "bg-amber-100 text-amber-800",
+  Planned: "bg-gray-100 text-gray-700",
+  Tracked: "bg-violet-100 text-violet-800",
+  Archived: "bg-gray-100 text-gray-500",
+};
+
+const severityStyles: Record<"low" | "medium" | "high", string> = {
+  low: "border-gray-200 bg-gray-50 text-gray-700",
+  medium: "border-amber-200 bg-amber-50 text-amber-900",
+  high: "border-red-200 bg-red-50 text-red-900",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const cls = statusStyles[status] ?? "bg-gray-100 text-gray-700";
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
+      {status}
+    </span>
+  );
+}
+
+function OwnershipBlock({
+  label,
+  values,
+  emptyText,
+}: {
+  label: string;
+  values: string[];
+  emptyText?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+        {label}
+      </p>
+      {values.length > 0 ? (
+        <ul className="mt-2 space-y-1 text-sm text-ui-charcoal">
+          {values.map((v) => (
+            <li key={v}>{v}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-sm italic text-gray-400">
+          {emptyText || "—"}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.92c.58.1.78-.25.78-.56v-2c-3.2.7-3.87-1.37-3.87-1.37-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.28 1.18-3.08-.12-.29-.51-1.46.12-3.04 0 0 .97-.31 3.18 1.17a11 11 0 015.78 0C17.27 4.62 18.24 4.93 18.24 4.93c.63 1.58.24 2.75.12 3.04.73.8 1.18 1.82 1.18 3.08 0 4.43-2.7 5.41-5.27 5.69.41.36.77 1.06.77 2.15v3.19c0 .31.2.67.79.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
+      />
+    </svg>
+  );
+}
+
+function ActiveBlockerRow({
+  blocker,
+  audience,
+}: {
+  blocker: Blocker;
+  audience: "public" | "internal";
+}) {
+  const days = daysSince(blocker.since);
+  const label = blockerCategoryLabels[blocker.category] ?? blocker.category;
+  const detail =
+    audience === "internal" && blocker.internalText
+      ? blocker.internalText
+      : blocker.publicText;
+
+  return (
+    <article
+      className={`rounded-md border px-4 py-3 ${severityStyles[blocker.severity]}`}
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="text-sm font-semibold">
+          {label}
+          {blocker.namedParty ? ` · ${blocker.namedParty}` : ""}
+        </p>
+        <p className="text-xs">
+          Day {days} · since {blocker.since}
+        </p>
+      </div>
+      {detail && (
+        <p className="mt-1 text-sm leading-relaxed">{detail}</p>
+      )}
+      {audience === "internal" && blocker.publicText && blocker.internalText && (
+        <details className="mt-2 text-xs">
+          <summary className="cursor-pointer opacity-70">
+            Public-facing version of this entry
+          </summary>
+          <p className="mt-1 leading-relaxed opacity-80">
+            {blocker.publicText}
+          </p>
+        </details>
+      )}
+    </article>
+  );
+}
+
+interface RelatedApp {
+  slug: string;
+  name: string;
+  tagline: string | null;
+}
+
+export interface InterventionDetailProps {
+  app: ApplicationWithBlockers;
+  related: RelatedApp[];
+  audience: "public" | "internal";
+  basePath: string; // "/portfolio" or "/internal/portfolio"
+}
+
+export default function InterventionDetail({
+  app,
+  related,
+  audience,
+  basePath,
+}: InterventionDetailProps) {
+  const isEmbargoed = app.visibilityTier === "embargoed";
+  const isInternal = app.visibilityTier === "internal";
+
+  return (
+    <div className="space-y-10">
+      {/* Breadcrumb */}
+      <nav className="text-sm text-gray-500">
+        <Link href={basePath} className="hover:text-ui-gold-dark">
+          {audience === "internal" ? "Internal portfolio" : "Portfolio"}
+        </Link>
+        {app.homeUnits[0] && (
+          <>
+            <span className="mx-2">/</span>
+            <span className="text-gray-400">{app.homeUnits[0]}</span>
+          </>
+        )}
+        <span className="mx-2">/</span>
+        <span className="text-ui-charcoal">{app.name}</span>
+      </nav>
+
+      {/* Header */}
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge status={app.status} />
+          {app.ai4raRelationship !== "None" && (
+            <span className="rounded-full border border-ui-gold/30 bg-ui-gold/10 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+              AI4RA {app.ai4raRelationship}
+            </span>
+          )}
+          {app.dualDestinyPlanned && (
+            <span className="rounded-full border border-gray-200 px-2.5 py-0.5 text-xs text-gray-600">
+              Dual destiny (OSS + UI)
+            </span>
+          )}
+          {app.tags.includes("diffusion") && (
+            <span className="rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700">
+              Capability diffusion
+            </span>
+          )}
+          {app.institutionalReviewStatus === "Under OIT review" && (
+            <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs text-amber-800">
+              Under OIT review
+            </span>
+          )}
+          {app.trackingOnly && (
+            <span className="rounded-full border border-violet-200 bg-violet-50 px-2.5 py-0.5 text-xs font-medium text-violet-700">
+              Tracked — not built by IIDS
+            </span>
+          )}
+          {audience === "internal" && (
+            <span className="rounded-full border border-gray-300 bg-gray-50 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+              Visibility: {app.visibilityTier}
+            </span>
+          )}
+        </div>
+        <h1 className="mt-3 text-3xl font-bold text-ui-charcoal">{app.name}</h1>
+        {app.tagline && (
+          <p className="mt-2 text-lg text-gray-600">{app.tagline}</p>
+        )}
+        {app.funding && (
+          <p className="mt-2 text-sm font-medium text-ui-gold-dark">
+            {app.funding}
+          </p>
+        )}
+      </div>
+
+      {/* Embargo notice for embargoed visibility (public view) */}
+      {audience === "public" && isEmbargoed && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+          <p className="text-sm font-semibold text-amber-900">
+            UI deployment details embargoed
+          </p>
+          <p className="mt-1 text-sm text-amber-800">
+            This intervention exists in the inventory, but specific details
+            about UI&apos;s operational deployment (pilot scope, timelines, or
+            configuration) are held back from the public site. Contact the
+            operational owner for authorized access.
+          </p>
+        </div>
+      )}
+
+      {/* Internal-only banner (only reachable on /internal) */}
+      {audience === "internal" && isInternal && (
+        <div className="rounded-xl border border-brand-huckleberry/30 bg-brand-huckleberry/10 p-5">
+          <p className="text-sm font-semibold text-brand-huckleberry">
+            Internal-only record
+          </p>
+          <p className="mt-1 text-sm text-brand-huckleberry/90">
+            This intervention is not visible on the public portfolio. Visible
+            here because you&apos;re authenticated to the internal view.
+          </p>
+        </div>
+      )}
+
+      {/* Active blockers (friction ledger) */}
+      {app.activeBlockers.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
+            Active blockers
+          </h2>
+          <div className="space-y-2">
+            {app.activeBlockers.map((b) => (
+              <ActiveBlockerRow key={b.id} blocker={b} audience={audience} />
+            ))}
+          </div>
+          {audience === "public" && (
+            <p className="mt-3 text-xs text-gray-500">
+              Showing public-safe detail. Sharper detail (named individuals,
+              contact history) lives on the internal view.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Ownership */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <OwnershipBlock label="Home unit(s)" values={app.homeUnits} />
+        <OwnershipBlock
+          label={
+            app.operationalOwners.length === 1
+              ? "Operational owner"
+              : "Operational owners"
+          }
+          values={app.operationalOwners.map((o) =>
+            o.title ? `${o.name} (${o.title})` : o.name
+          )}
+          emptyText={app.trackingOnly ? "Awaiting contact with unit" : undefined}
+        />
+        <OwnershipBlock
+          label="Build participants"
+          values={app.buildParticipants}
+        />
+      </div>
+
+      {/* Links */}
+      {(app.repoUrl || app.docsUrl || app.liveUrl) && (
+        <div className="flex flex-wrap gap-3">
+          {app.repoUrl && (
+            <a
+              href={app.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-ui-charcoal px-4 py-2 text-sm font-medium text-white hover:bg-ui-charcoal/90"
+            >
+              <GitHubIcon />
+              Repository
+              {app.isPrivateRepo && (
+                <span className="rounded bg-white/10 px-1.5 py-0.5 text-xs">
+                  Private
+                </span>
+              )}
+            </a>
+          )}
+          {app.liveUrl && (
+            <a
+              href={app.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
+            >
+              Live site &rarr;
+            </a>
+          )}
+          {app.docsUrl && (
+            <a
+              href={app.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
+            >
+              Documentation &rarr;
+            </a>
+          )}
+        </div>
+      )}
+
+      {/* Description */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-base font-semibold text-ui-charcoal">Overview</h2>
+        <p className="mt-3 text-sm leading-relaxed text-gray-700">
+          {app.description}
+        </p>
+      </div>
+
+      {/* Operational function + outcome */}
+      {(app.operationalFunction || app.operationalExcellenceOutcome) && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {app.operationalFunction && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-base font-semibold text-ui-charcoal">
+                Operational function at UI
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-gray-700">
+                {app.operationalFunction}
+              </p>
+            </div>
+          )}
+          {app.operationalExcellenceOutcome && (
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-base font-semibold text-ui-charcoal">
+                Operational excellence outcome
+              </h2>
+              <p className="mt-3 text-sm leading-relaxed text-gray-700">
+                {app.operationalExcellenceOutcome}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* External deployments */}
+      {app.externalDeployments.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-ui-charcoal">
+            Also deployed at
+          </h2>
+          <ul className="mt-3 space-y-1 text-sm text-gray-700">
+            {app.externalDeployments.map((d) => (
+              <li key={d}>&bull; {d}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Features */}
+      {app.features.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
+            Key features
+          </h2>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {app.features.map((f, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700"
+              >
+                <svg
+                  className="mt-0.5 h-4 w-4 shrink-0 text-ui-gold"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <span>{f}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Tech stack */}
+      {app.tech.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
+            Tech stack
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {app.tech.map((t) => (
+              <span
+                key={t}
+                className="rounded-md border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Related */}
+      {related.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold text-ui-charcoal">
+            Related interventions
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {related.map((r) => (
+              <Link
+                key={r.slug}
+                href={`${basePath}/${r.slug}`}
+                className="group rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-ui-gold/40"
+              >
+                <p className="text-sm font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+                  {r.name}
+                </p>
+                {r.tagline && (
+                  <p className="mt-1 text-xs text-gray-500">{r.tagline}</p>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -1,12 +1,8 @@
 import Link from "next/link";
-import type {
-  Intervention,
-  InterventionStatus,
-  Visibility,
-  AI4RARelationship,
-} from "@/lib/portfolio";
+import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
+import { blockerCategoryLabels, daysSince } from "@/lib/work";
 
-const statusStyles: Record<InterventionStatus, string> = {
+const statusStyles: Record<string, string> = {
   Production: "bg-green-100 text-green-800",
   Piloting: "bg-blue-100 text-blue-800",
   Prototype: "bg-amber-100 text-amber-800",
@@ -15,49 +11,85 @@ const statusStyles: Record<InterventionStatus, string> = {
   Archived: "bg-gray-100 text-gray-500",
 };
 
-const visibilityNote: Record<Visibility, string | null> = {
-  Public: null,
-  Partial: "Embargoed",
-  "Internal-only": "Internal",
+const visibilityNote: Record<"public" | "embargoed" | "internal", string | null> = {
+  public: null,
+  embargoed: "Embargoed",
+  internal: "Internal",
 };
 
-const ai4raChip: Partial<Record<AI4RARelationship, string>> = {
+const ai4raChip: Record<string, string | undefined> = {
   Core: "AI4RA Core",
   Adjacent: "AI4RA Adjacent",
   Reference: "AI4RA Reference",
 };
 
-export default function PortfolioCard({
-  intervention,
+const severityStyles: Record<"low" | "medium" | "high", string> = {
+  low: "border-gray-200 bg-gray-50 text-gray-700",
+  medium: "border-amber-200 bg-amber-50 text-amber-800",
+  high: "border-red-200 bg-red-50 text-red-800",
+};
+
+function BlockerChip({
+  blocker,
+  audience,
 }: {
-  intervention: Intervention;
+  blocker: Blocker;
+  audience: "public" | "internal";
 }) {
-  const owners = intervention.operationalOwners
+  const days = daysSince(blocker.since);
+  const label = blockerCategoryLabels[blocker.category] ?? blocker.category;
+  const partySuffix = blocker.namedParty ? ` · ${blocker.namedParty}` : "";
+  const detail =
+    audience === "internal" && blocker.internalText
+      ? blocker.internalText
+      : blocker.publicText;
+
+  return (
+    <div
+      className={`relative z-10 rounded-md border px-2.5 py-1.5 text-xs ${severityStyles[blocker.severity]}`}
+    >
+      <p className="font-medium">
+        {label}
+        {partySuffix} · day {days}
+      </p>
+      {detail && (
+        <p className="mt-0.5 leading-snug opacity-80">{detail}</p>
+      )}
+    </div>
+  );
+}
+
+export default function PortfolioCard({
+  app,
+  audience = "public",
+  basePath = "/portfolio",
+}: {
+  app: ApplicationWithBlockers;
+  audience?: "public" | "internal";
+  basePath?: string;
+}) {
+  const owners = app.operationalOwners
     .map((o) => o.name)
     .slice(0, 2)
     .join(", ");
   const extraOwners =
-    intervention.operationalOwners.length > 2
-      ? ` +${intervention.operationalOwners.length - 2}`
+    app.operationalOwners.length > 2
+      ? ` +${app.operationalOwners.length - 2}`
       : "";
 
-  const liveHost = intervention.liveUrl
-    ? hostnameOf(intervention.liveUrl)
-    : null;
+  const liveHost = app.liveUrl ? hostnameOf(app.liveUrl) : null;
+  const ai4raLabel = ai4raChip[app.ai4raRelationship];
 
   return (
-    // Stretched-link pattern: whole card is clickable via the title's
-    // ::before overlay; the live-site anchor uses z-10 to stay clickable
-    // on top of the overlay without nesting anchors.
     <article className="group relative flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-brand-gold hover:shadow-md">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h3 className="text-base font-semibold text-brand-black group-hover:text-brand-gold-dark transition-colors">
             <Link
-              href={`/portfolio/${intervention.slug}`}
+              href={`${basePath}/${app.slug}`}
               className="unstyled before:absolute before:inset-0"
             >
-              {intervention.name}
+              {app.name}
             </Link>
           </h3>
           {owners && (
@@ -68,38 +100,50 @@ export default function PortfolioCard({
           )}
         </div>
         <span
-          className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusStyles[intervention.status]}`}
+          className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+            statusStyles[app.status] ?? "bg-gray-100 text-gray-700"
+          }`}
         >
-          {intervention.status}
+          {app.status}
         </span>
       </div>
 
-      <p className="mt-3 text-sm leading-relaxed text-gray-700">
-        {intervention.tagline}
-      </p>
+      {app.tagline && (
+        <p className="mt-3 text-sm leading-relaxed text-gray-700">
+          {app.tagline}
+        </p>
+      )}
+
+      {app.activeBlockers.length > 0 && (
+        <div className="mt-4 space-y-1.5">
+          {app.activeBlockers.map((b) => (
+            <BlockerChip key={b.id} blocker={b} audience={audience} />
+          ))}
+        </div>
+      )}
 
       <div className="mt-4 flex flex-wrap gap-1.5">
-        {ai4raChip[intervention.ai4raRelationship] && (
+        {ai4raLabel && (
           <span className="rounded-full border border-brand-gold bg-brand-gold/15 px-2 py-0.5 text-xs font-semibold text-brand-gold-dark">
-            {ai4raChip[intervention.ai4raRelationship]}
+            {ai4raLabel}
           </span>
         )}
-        {intervention.dualDestinyPlanned && (
+        {app.dualDestinyPlanned && (
           <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-600">
             Dual destiny
           </span>
         )}
-        {intervention.tags?.includes("diffusion") && (
+        {app.tags.includes("diffusion") && (
           <span className="rounded-full border border-brand-clearwater/40 bg-brand-clearwater/10 px-2 py-0.5 text-xs font-medium text-brand-clearwater">
             Capability diffusion
           </span>
         )}
-        {intervention.externalDeployments?.length ? (
+        {app.externalDeployments.length > 0 && (
           <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-600">
-            Also at {intervention.externalDeployments.join(", ")}
+            Also at {app.externalDeployments.join(", ")}
           </span>
-        ) : null}
-        {intervention.trackingOnly && (
+        )}
+        {app.trackingOnly && (
           <span className="rounded-full border border-brand-huckleberry/30 bg-brand-huckleberry/10 px-2 py-0.5 text-xs font-medium text-brand-huckleberry">
             Tracked (not built by IIDS)
           </span>
@@ -107,7 +151,7 @@ export default function PortfolioCard({
       </div>
 
       <div className="mt-auto flex items-center gap-2 pt-4 text-xs text-gray-500">
-        {visibilityNote[intervention.visibility] && (
+        {visibilityNote[app.visibilityTier] && (
           <span className="inline-flex items-center gap-1 rounded border border-gray-200 px-1.5 py-0.5">
             <svg
               className="h-3 w-3"
@@ -122,29 +166,29 @@ export default function PortfolioCard({
                 d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
               />
             </svg>
-            {visibilityNote[intervention.visibility]}
+            {visibilityNote[app.visibilityTier]}
           </span>
         )}
-        {intervention.institutionalReviewStatus === "Under OIT review" && (
+        {app.institutionalReviewStatus === "Under OIT review" && (
           <span className="font-medium text-amber-700">Under OIT review</span>
         )}
-        {intervention.institutionalReviewStatus === "OIT-endorsed" && (
+        {app.institutionalReviewStatus === "OIT-endorsed" && (
           <span className="font-medium text-green-700">OIT-endorsed</span>
         )}
-        {intervention.funding && (
+        {app.funding && (
           <span className="truncate font-medium text-brand-gold-dark">
-            {intervention.funding}
+            {app.funding}
           </span>
         )}
       </div>
 
-      {intervention.liveUrl && liveHost && (
+      {app.liveUrl && liveHost && (
         <div className="mt-3 border-t border-gray-100 pt-3">
           <a
-            href={intervention.liveUrl}
+            href={app.liveUrl}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label={`Visit the live site for ${intervention.name} at ${liveHost}`}
+            aria-label={`Visit the live site for ${app.name} at ${liveHost}`}
             className="unstyled relative z-10 inline-flex items-center gap-1.5 text-xs font-semibold text-brand-clearwater hover:text-brand-black"
           >
             <LiveDot />

--- a/db/migrations/005_friction_ledger.sql
+++ b/db/migrations/005_friction_ledger.sql
@@ -1,0 +1,190 @@
+-- Migration 005: Friction Ledger
+--
+-- Sprint 2 of the May 2026 refactor. Adds the data shape that lets the
+-- /portfolio surface render projects from Postgres instead of from
+-- lib/portfolio.ts, with first-class support for blockers (the friction
+-- ledger) and a graduated public/internal/embargoed visibility model.
+--
+-- After this migration applies, run scripts/seed-portfolio.ts to port
+-- lib/portfolio.ts entries into the applications + blockers tables.
+
+BEGIN;
+
+-- ── Applications: add intervention-shape columns ─────────────
+
+-- URL slug for /portfolio/[slug] routing. Unique per row.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS slug TEXT UNIQUE;
+
+-- One-line elevator pitch shown in cards.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS tagline TEXT;
+
+-- Home units (typically 1, occasionally several). Replaces the single
+-- `department` column for portfolio rendering; `department` stays for
+-- backward compat with the submission flow.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS home_units TEXT[] NOT NULL DEFAULT '{}';
+
+-- Operational owners as a JSON array of {name, title?} so the title
+-- carries with the name without an extra join table.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS operational_owners JSONB NOT NULL DEFAULT '[]';
+
+-- Units / teams that contributed to building the intervention.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS build_participants TEXT[] NOT NULL DEFAULT '{}';
+
+-- Free-form tags (e.g. "diffusion", "ai4ra-core"). Independent of
+-- the wizard-driven sensitivity/integrations arrays.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS tags TEXT[] NOT NULL DEFAULT '{}';
+
+-- Visibility tier per REFACTOR.md graduated-by-audience model.
+--   'public'    — fully public, all detail visible
+--   'embargoed' — acknowledged on the public site, deployment detail held
+--   'internal'  — not on the public site at all
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS visibility_tier TEXT NOT NULL DEFAULT 'internal'
+    CHECK (visibility_tier IN ('public', 'embargoed', 'internal'));
+
+-- ClickUp linkage for Sprint 3 wiring. Postgres is canonical for
+-- identity/classification; ClickUp is canonical for status/blockers/workflow.
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS clickup_task_id TEXT;
+
+-- AI4RA relationship: 'Core' | 'Adjacent' | 'Reference' | 'UI-parallel' | 'None'
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS ai4ra_relationship TEXT NOT NULL DEFAULT 'None';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS dual_destiny_planned BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS external_deployments TEXT[] NOT NULL DEFAULT '{}';
+
+-- Institutional review status: 'OIT-endorsed' | 'Under OIT review' | 'N/A'
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS institutional_review_status TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS repo_url TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS docs_url TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS live_url TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS is_private_repo BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS funding TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS operational_function TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS operational_excellence_outcome TEXT;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS features TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS tech TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS tracking_only BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS related_slugs TEXT[] NOT NULL DEFAULT '{}';
+
+-- Indexes for the new query patterns
+CREATE INDEX IF NOT EXISTS idx_applications_slug ON applications(slug);
+CREATE INDEX IF NOT EXISTS idx_applications_visibility_tier ON applications(visibility_tier);
+CREATE INDEX IF NOT EXISTS idx_applications_home_units ON applications USING GIN (home_units);
+CREATE INDEX IF NOT EXISTS idx_applications_tags ON applications USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_applications_clickup_task_id ON applications(clickup_task_id);
+
+-- ── Blockers: the friction ledger ─────────────────────────────
+--
+-- Every application carries zero or more blockers. Each blocker has a
+-- category (one of the 14 defined in REFACTOR.md), an optional named
+-- party (OIT, Vendor X, etc.), the date the block began, public-safe
+-- text, internal-only text, and a severity. Resolution closes a blocker
+-- without deleting it so the audit trail persists.
+
+CREATE TABLE IF NOT EXISTS blockers (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  application_id  UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+
+  -- One of the 14 categories from REFACTOR.md:
+  --   oit-review, oit-standards, unit-engagement, legal-embargo,
+  --   hardware-procurement, funding, data-governance, compliance,
+  --   personnel, iids-capacity, inter-unit-politics, communications,
+  --   external-partner, faculty-governance
+  category        TEXT NOT NULL,
+
+  -- The party most directly responsible for unblocking, if any.
+  -- Examples: 'OIT', 'Vendor: Anthropic', 'Unit: SEM'.
+  named_party     TEXT,
+
+  -- Date the block began (when the ball moved into someone else's court).
+  since           DATE NOT NULL,
+
+  -- Public-safe text. Factual, dated, no editorializing. Shown on
+  -- /portfolio.
+  public_text     TEXT,
+
+  -- Sharper detail with named individuals, contact history, severity
+  -- specifics. Shown only on /internal/portfolio. Embargoed records
+  -- live entirely here.
+  internal_text   TEXT,
+
+  severity        TEXT NOT NULL DEFAULT 'medium'
+    CHECK (severity IN ('low', 'medium', 'high')),
+
+  -- Setting resolved_at moves the blocker out of "active." History
+  -- preserved.
+  resolved_at     DATE,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockers_application_id ON blockers(application_id);
+-- Partial index — most queries want active (unresolved) blockers only.
+CREATE INDEX IF NOT EXISTS idx_blockers_category_active
+  ON blockers(category)
+  WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_blockers_since ON blockers(since);
+
+-- updated_at trigger for blockers (mirrors the applications pattern)
+CREATE OR REPLACE FUNCTION update_blockers_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_blockers_updated_at ON blockers;
+CREATE TRIGGER trg_blockers_updated_at
+  BEFORE UPDATE ON blockers
+  FOR EACH ROW
+  EXECUTE FUNCTION update_blockers_updated_at();
+
+-- ── Schema migrations tracking ─────────────────────────────────
+-- Lightweight version table so the migration runner knows what's applied.
+-- Idempotent: re-running this migration is a no-op once the row exists.
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version     TEXT PRIMARY KEY,
+  applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO schema_migrations (version) VALUES ('005_friction_ledger')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,10 @@ services:
     networks:
       aispeg-net:
         ipv4_address: 10.10.9.11
+    ports:
+      # Publish to host port 5433 so local migration / seed scripts can
+      # connect via DATABASE_URL=postgresql://...@localhost:5433/...
+      - "5433:5432"
     profiles:
       - dev
     healthcheck:

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -1,0 +1,372 @@
+// lib/work.ts
+//
+// Query module for the post-Sprint-2 portfolio. Reads from Postgres
+// `applications` + `blockers` tables. Replaces the lib/portfolio.ts
+// runtime queries (the file stays as the seed source until Sprint 3).
+//
+// Visibility model:
+//   - public:    fully public, all detail
+//   - embargoed: acknowledged on the public site, deployment detail held
+//   - internal:  not on the public site at all
+//
+// Blockers carry public_text (safe for /portfolio) and internal_text
+// (sharper detail, only shown on /internal/portfolio).
+
+import "server-only";
+import { query } from "./db";
+
+export type VisibilityTier = "public" | "embargoed" | "internal";
+export type BlockerSeverity = "low" | "medium" | "high";
+
+export type BlockerCategory =
+  | "oit-review"
+  | "oit-standards"
+  | "unit-engagement"
+  | "legal-embargo"
+  | "hardware-procurement"
+  | "funding"
+  | "data-governance"
+  | "compliance"
+  | "personnel"
+  | "iids-capacity"
+  | "inter-unit-politics"
+  | "communications"
+  | "external-partner"
+  | "faculty-governance";
+
+export const blockerCategoryLabels: Record<BlockerCategory, string> = {
+  "oit-review": "OIT review",
+  "oit-standards": "OIT standards",
+  "unit-engagement": "Unit engagement",
+  "legal-embargo": "Legal / vendor embargo",
+  "hardware-procurement": "Hardware / procurement",
+  funding: "Funding / budget",
+  "data-governance": "Data access / governance",
+  compliance: "Compliance / regulatory",
+  personnel: "Personnel / hiring",
+  "iids-capacity": "IIDS capacity",
+  "inter-unit-politics": "Inter-unit politics",
+  communications: "Communications clearance",
+  "external-partner": "External partner / sponsor",
+  "faculty-governance": "Faculty governance",
+};
+
+export interface Blocker {
+  id: string;
+  applicationId: string;
+  category: BlockerCategory;
+  namedParty: string | null;
+  since: string; // ISO date
+  publicText: string | null;
+  internalText: string | null;
+  severity: BlockerSeverity;
+  resolvedAt: string | null;
+}
+
+export interface OperationalOwner {
+  name: string;
+  title?: string;
+}
+
+export interface Application {
+  id: string;
+  slug: string;
+  name: string;
+  tagline: string | null;
+  description: string;
+  homeUnits: string[];
+  operationalOwners: OperationalOwner[];
+  buildParticipants: string[];
+  tags: string[];
+  tier: number;
+  status: string;
+  visibilityTier: VisibilityTier;
+  ai4raRelationship: string;
+  dualDestinyPlanned: boolean;
+  externalDeployments: string[];
+  institutionalReviewStatus: string | null;
+  repoUrl: string | null;
+  docsUrl: string | null;
+  liveUrl: string | null;
+  isPrivateRepo: boolean;
+  funding: string | null;
+  operationalFunction: string | null;
+  operationalExcellenceOutcome: string | null;
+  features: string[];
+  tech: string[];
+  trackingOnly: boolean;
+  relatedSlugs: string[];
+  clickupTaskId: string | null;
+  updatedAt: string;
+}
+
+export interface ApplicationWithBlockers extends Application {
+  activeBlockers: Blocker[];
+}
+
+interface ApplicationRow {
+  id: string;
+  slug: string;
+  name: string;
+  tagline: string | null;
+  description: string;
+  home_units: string[];
+  operational_owners: OperationalOwner[];
+  build_participants: string[];
+  tags: string[];
+  tier: number;
+  status: string;
+  visibility_tier: VisibilityTier;
+  ai4ra_relationship: string;
+  dual_destiny_planned: boolean;
+  external_deployments: string[];
+  institutional_review_status: string | null;
+  repo_url: string | null;
+  docs_url: string | null;
+  live_url: string | null;
+  is_private_repo: boolean;
+  funding: string | null;
+  operational_function: string | null;
+  operational_excellence_outcome: string | null;
+  features: string[];
+  tech: string[];
+  tracking_only: boolean;
+  related_slugs: string[];
+  clickup_task_id: string | null;
+  updated_at: string;
+}
+
+interface BlockerRow {
+  id: string;
+  application_id: string;
+  category: BlockerCategory;
+  named_party: string | null;
+  since: string;
+  public_text: string | null;
+  internal_text: string | null;
+  severity: BlockerSeverity;
+  resolved_at: string | null;
+}
+
+function toApplication(row: ApplicationRow): Application {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    tagline: row.tagline,
+    description: row.description,
+    homeUnits: row.home_units ?? [],
+    operationalOwners: row.operational_owners ?? [],
+    buildParticipants: row.build_participants ?? [],
+    tags: row.tags ?? [],
+    tier: row.tier,
+    status: row.status,
+    visibilityTier: row.visibility_tier,
+    ai4raRelationship: row.ai4ra_relationship,
+    dualDestinyPlanned: row.dual_destiny_planned,
+    externalDeployments: row.external_deployments ?? [],
+    institutionalReviewStatus: row.institutional_review_status,
+    repoUrl: row.repo_url,
+    docsUrl: row.docs_url,
+    liveUrl: row.live_url,
+    isPrivateRepo: row.is_private_repo,
+    funding: row.funding,
+    operationalFunction: row.operational_function,
+    operationalExcellenceOutcome: row.operational_excellence_outcome,
+    features: row.features ?? [],
+    tech: row.tech ?? [],
+    trackingOnly: row.tracking_only,
+    relatedSlugs: row.related_slugs ?? [],
+    clickupTaskId: row.clickup_task_id,
+    updatedAt: row.updated_at,
+  };
+}
+
+// node-postgres returns DATE columns as JS Date objects parsed in local
+// time, which is fragile across server/client boundaries. Coerce to a
+// plain "YYYY-MM-DD" ISO date string.
+function toIsoDate(value: unknown): string {
+  if (value instanceof Date) {
+    const yyyy = value.getUTCFullYear();
+    const mm = String(value.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(value.getUTCDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
+  }
+  return String(value);
+}
+
+function toBlocker(row: BlockerRow): Blocker {
+  return {
+    id: row.id,
+    applicationId: row.application_id,
+    category: row.category,
+    namedParty: row.named_party,
+    since: toIsoDate(row.since),
+    publicText: row.public_text,
+    internalText: row.internal_text,
+    severity: row.severity,
+    resolvedAt: row.resolved_at ? toIsoDate(row.resolved_at) : null,
+  };
+}
+
+const APPLICATION_COLUMNS = `
+  id, slug, name, tagline, description,
+  home_units, operational_owners, build_participants, tags,
+  tier, status, visibility_tier,
+  ai4ra_relationship, dual_destiny_planned, external_deployments,
+  institutional_review_status,
+  repo_url, docs_url, live_url, is_private_repo,
+  funding,
+  operational_function, operational_excellence_outcome,
+  features, tech,
+  tracking_only, related_slugs,
+  clickup_task_id, updated_at
+`;
+
+export interface ListOptions {
+  /**
+   * Which visibility tiers to include.
+   * - "public" — default for the public /portfolio surface; includes
+   *   public + embargoed (embargoed entries render with a held-detail
+   *   notice but are not hidden).
+   * - "internal" — for /internal/portfolio; includes all three tiers.
+   */
+  audience?: "public" | "internal";
+}
+
+function tiersFor(audience: "public" | "internal"): VisibilityTier[] {
+  return audience === "internal"
+    ? ["public", "embargoed", "internal"]
+    : ["public", "embargoed"];
+}
+
+export async function listApplications(
+  opts: ListOptions = {}
+): Promise<ApplicationWithBlockers[]> {
+  const audience = opts.audience ?? "public";
+  const tiers = tiersFor(audience);
+
+  const apps = await query<ApplicationRow>(
+    `SELECT ${APPLICATION_COLUMNS}
+     FROM applications
+     WHERE visibility_tier = ANY($1)
+     ORDER BY name`,
+    [tiers]
+  );
+
+  if (apps.length === 0) return [];
+
+  const ids = apps.map((a) => a.id);
+  const blockers = await query<BlockerRow>(
+    `SELECT * FROM blockers
+     WHERE application_id = ANY($1)
+       AND resolved_at IS NULL
+     ORDER BY since ASC`,
+    [ids]
+  );
+
+  const blockersByApp = new Map<string, Blocker[]>();
+  for (const b of blockers) {
+    const list = blockersByApp.get(b.application_id) ?? [];
+    list.push(toBlocker(b));
+    blockersByApp.set(b.application_id, list);
+  }
+
+  return apps.map((row) => ({
+    ...toApplication(row),
+    activeBlockers: blockersByApp.get(row.id) ?? [],
+  }));
+}
+
+export async function getApplicationBySlug(
+  slug: string,
+  opts: ListOptions = {}
+): Promise<ApplicationWithBlockers | null> {
+  const audience = opts.audience ?? "public";
+  const tiers = tiersFor(audience);
+
+  const apps = await query<ApplicationRow>(
+    `SELECT ${APPLICATION_COLUMNS}
+     FROM applications
+     WHERE slug = $1 AND visibility_tier = ANY($2)
+     LIMIT 1`,
+    [slug, tiers]
+  );
+
+  if (apps.length === 0) return null;
+  const app = apps[0]!;
+
+  const blockers = await query<BlockerRow>(
+    `SELECT * FROM blockers
+     WHERE application_id = $1 AND resolved_at IS NULL
+     ORDER BY since ASC`,
+    [app.id]
+  );
+
+  return {
+    ...toApplication(app),
+    activeBlockers: blockers.map(toBlocker),
+  };
+}
+
+export interface HomeUnitGroup {
+  unit: string;
+  items: ApplicationWithBlockers[];
+}
+
+export function groupByHomeUnit(
+  apps: ApplicationWithBlockers[]
+): HomeUnitGroup[] {
+  const groups = new Map<string, ApplicationWithBlockers[]>();
+  for (const app of apps) {
+    const unit = app.homeUnits[0] ?? "Unassigned";
+    const list = groups.get(unit) ?? [];
+    list.push(app);
+    groups.set(unit, list);
+  }
+  return Array.from(groups.entries())
+    .map(([unit, items]) => ({ unit, items }))
+    .sort((a, b) => a.unit.localeCompare(b.unit));
+}
+
+export function daysSince(isoDate: string): number {
+  const then = new Date(isoDate + "T00:00:00Z").getTime();
+  const ms = Date.now() - then;
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
+export interface RelatedApplication {
+  slug: string;
+  name: string;
+  tagline: string | null;
+}
+
+export async function getRelatedApplications(
+  app: Application,
+  opts: ListOptions = {}
+): Promise<RelatedApplication[]> {
+  if (app.relatedSlugs.length === 0) return [];
+  const audience = opts.audience ?? "public";
+  const tiers = tiersFor(audience);
+
+  const rows = await query<{ slug: string; name: string; tagline: string | null }>(
+    `SELECT slug, name, tagline
+     FROM applications
+     WHERE slug = ANY($1) AND visibility_tier = ANY($2)
+     ORDER BY name`,
+    [app.relatedSlugs, tiers]
+  );
+  return rows;
+}
+
+export async function listSlugs(
+  opts: ListOptions = {}
+): Promise<string[]> {
+  const audience = opts.audience ?? "public";
+  const tiers = tiersFor(audience);
+  const rows = await query<{ slug: string }>(
+    `SELECT slug FROM applications WHERE visibility_tier = ANY($1) AND slug IS NOT NULL`,
+    [tiers]
+  );
+  return rows.map((r) => r.slug);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Basic auth gate for /internal/*. v1 only — replace with UI SSO later.
+//
+// Requires BASIC_AUTH_USER and BASIC_AUTH_PASS in the environment. If
+// either is unset the middleware fails closed (503) rather than letting
+// the route through without authentication.
+
+export function middleware(req: NextRequest) {
+  const user = process.env.BASIC_AUTH_USER;
+  const pass = process.env.BASIC_AUTH_PASS;
+
+  if (!user || !pass) {
+    return new NextResponse(
+      "Internal view is not configured on this deployment.",
+      { status: 503 }
+    );
+  }
+
+  const auth = req.headers.get("authorization");
+  const expected =
+    "Basic " + Buffer.from(`${user}:${pass}`).toString("base64");
+
+  if (auth !== expected) {
+    return new NextResponse("Authentication required", {
+      status: 401,
+      headers: { "WWW-Authenticate": 'Basic realm="IIDS Internal"' },
+    });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/internal/:path*",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,12 @@
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "dotenv": "^17.4.2",
         "eslint": "^9.39.3",
         "eslint-config-next": "^16.1.6",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.2.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }
     },
@@ -331,6 +333,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2842,6 +3286,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3060,6 +3517,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -3661,6 +4160,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6371,6 +6885,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "migrate": "tsx --env-file=.env.local scripts/migrate.ts",
+    "seed:portfolio": "tsx --env-file=.env.local scripts/seed-portfolio.ts"
   },
   "dependencies": {
     "next": "^16.1.6",
@@ -21,10 +23,12 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "dotenv": "^17.4.2",
     "eslint": "^9.39.3",
     "eslint-config-next": "^16.1.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,139 @@
+// scripts/migrate.ts
+//
+// Applies pending SQL migrations from db/migrations/ to the database
+// pointed at by DATABASE_URL. Tracks applied migrations in a
+// schema_migrations table (created by 005 onward).
+//
+// Usage:
+//   npm run migrate
+//
+// Behaviour:
+//   1. Connects to DATABASE_URL.
+//   2. If schema_migrations exists, reads applied versions.
+//   3. If schema_migrations does not exist BUT the applications table does,
+//      backfills 001-004 as already applied (legacy DB; their schemas are
+//      present from the docker-entrypoint-initdb.d auto-load).
+//   4. Applies any *.sql file in db/migrations/ whose stem is not already
+//      in schema_migrations, in lexicographic order.
+//   5. Each migration runs as one PostgreSQL statement batch — the file
+//      itself is responsible for BEGIN / COMMIT.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Pool } from "pg";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, "..", "db", "migrations");
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("DATABASE_URL is not set. Set it in .env.local or the environment.");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+
+async function tableExists(name: string): Promise<boolean> {
+  const result = await pool.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS exists`,
+    [name]
+  );
+  return result.rows[0]?.exists === true;
+}
+
+async function ensureSchemaMigrationsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version    TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function getAppliedVersions(): Promise<Set<string>> {
+  const result = await pool.query<{ version: string }>(
+    `SELECT version FROM schema_migrations`
+  );
+  return new Set(result.rows.map((r) => r.version));
+}
+
+async function backfillLegacyMigrations(): Promise<void> {
+  // If applications table exists but schema_migrations is empty, the DB
+  // was bootstrapped from docker-entrypoint-initdb.d before this runner
+  // existed. Mark 001-004 as already applied so we don't re-run them
+  // (001 in particular uses CREATE TABLE without IF NOT EXISTS and would
+  // fail).
+  const applicationsExists = await tableExists("applications");
+  if (!applicationsExists) return;
+
+  const applied = await getAppliedVersions();
+  const legacy = ["001_initial", "002_extended_questions", "003_application_registry", "004_seed_applications"];
+  for (const version of legacy) {
+    if (!applied.has(version)) {
+      await pool.query(
+        `INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING`,
+        [version]
+      );
+      console.log(`  ↳ marked ${version} as applied (legacy backfill)`);
+    }
+  }
+}
+
+function listMigrations(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+}
+
+async function applyMigration(filename: string): Promise<void> {
+  const version = filename.replace(/\.sql$/, "");
+  const sqlPath = join(MIGRATIONS_DIR, filename);
+  const sql = readFileSync(sqlPath, "utf8");
+
+  console.log(`Applying ${version} ...`);
+  // The migration files wrap themselves in BEGIN / COMMIT, so we just
+  // execute the file content. If it doesn't contain its own COMMIT, the
+  // runner falls back to a single-statement transaction by default.
+  await pool.query(sql);
+
+  // Most migrations from 005 onward record themselves; older ones won't.
+  // Idempotent insert covers both cases.
+  await pool.query(
+    `INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING`,
+    [version]
+  );
+  console.log(`  ↳ ${version} applied`);
+}
+
+async function main(): Promise<void> {
+  console.log(`Connecting to ${databaseUrl?.replace(/\/\/[^@]+@/, "//***@")}`);
+
+  await ensureSchemaMigrationsTable();
+  await backfillLegacyMigrations();
+
+  const applied = await getAppliedVersions();
+  const all = listMigrations();
+  const pending = all.filter((f) => !applied.has(f.replace(/\.sql$/, "")));
+
+  if (pending.length === 0) {
+    console.log("No pending migrations. Database is up to date.");
+    return;
+  }
+
+  console.log(`${pending.length} pending migration(s): ${pending.join(", ")}`);
+  for (const f of pending) {
+    await applyMigration(f);
+  }
+  console.log(`\nDone. Applied ${pending.length} migration(s).`);
+}
+
+main()
+  .catch((err) => {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  })
+  .finally(() => pool.end());

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -1,0 +1,222 @@
+// scripts/seed-portfolio.ts
+//
+// Ports the typed `interventions` array from lib/portfolio.ts into the
+// `applications` table, and auto-derives initial blocker rows from the
+// existing portfolio metadata.
+//
+// Idempotent: TRUNCATEs applications + blockers (CASCADE) and reseeds.
+// Safe to re-run during the Sprint 2 → Sprint 3 transition while
+// lib/portfolio.ts is still the source of truth. Once ClickUp wiring
+// lands in Sprint 3, this script becomes a one-time tool and lib/portfolio.ts
+// retires.
+//
+// Auto-derived blockers (low-fidelity, placeholder until Colin's ClickUp
+// data is the source):
+//   - visibility:"Partial"           → "legal-embargo" blocker
+//   - institutionalReviewStatus:     → "oit-review" blocker
+//     "Under OIT review"
+//
+// Usage:
+//   npm run seed:portfolio
+
+import { Pool } from "pg";
+import {
+  interventions,
+  type Intervention,
+  type Visibility,
+} from "../lib/portfolio.js";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("DATABASE_URL is not set. Set it in .env.local or the environment.");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+
+// Placeholder date for auto-derived blockers. The portfolio doesn't carry
+// per-blocker dates yet; refine entries individually in Sprint 3 via
+// ClickUp wiring or by editing the rows in the DB directly.
+const PLACEHOLDER_BLOCKER_SINCE = "2026-03-01";
+
+function visibilityTier(v: Visibility): "public" | "embargoed" | "internal" {
+  switch (v) {
+    case "Public":
+      return "public";
+    case "Partial":
+      return "embargoed";
+    case "Internal-only":
+      return "internal";
+  }
+}
+
+// Portfolio entries don't carry a tier; default to 2 (Standard Web App)
+// which fits most IIDS-built interventions. Tracked entries get tier 1.
+function inferTier(i: Intervention): number {
+  if (i.trackingOnly) return 1;
+  return 2;
+}
+
+interface BlockerSeed {
+  category: string;
+  named_party: string | null;
+  since: string;
+  public_text: string | null;
+  internal_text: string | null;
+  severity: "low" | "medium" | "high";
+}
+
+function deriveBlockers(i: Intervention): BlockerSeed[] {
+  const blockers: BlockerSeed[] = [];
+
+  if (i.visibility === "Partial") {
+    blockers.push({
+      category: "legal-embargo",
+      named_party: null,
+      since: PLACEHOLDER_BLOCKER_SINCE,
+      public_text:
+        "Deployment details (pilot scope, timelines, configuration) held back from the public site.",
+      internal_text:
+        "Auto-seeded from visibility:Partial during the Sprint 2 portfolio import. Refine with the actual embargo source (vendor terms, legal review, partner request) and the date the embargo took effect.",
+      severity: "medium",
+    });
+  }
+
+  if (i.institutionalReviewStatus === "Under OIT review") {
+    blockers.push({
+      category: "oit-review",
+      named_party: "OIT",
+      since: PLACEHOLDER_BLOCKER_SINCE,
+      public_text:
+        "Awaiting OIT institutional review.",
+      internal_text:
+        "Auto-seeded from institutionalReviewStatus:'Under OIT review'. Refine with the actual submission date, the named OIT contact, and any blocker-specific detail (security review, integration review, etc.).",
+      severity: "medium",
+    });
+  }
+
+  return blockers;
+}
+
+async function seedIntervention(i: Intervention): Promise<{ id: string; blockers: number }> {
+  const tier = inferTier(i);
+  const tierStr = String(tier);
+  const visibility_tier = visibilityTier(i.visibility);
+  const home_unit_primary = i.homeUnits[0] ?? null;
+  const owner_primary = i.operationalOwners[0] ?? null;
+
+  const insert = await pool.query<{ id: string }>(
+    `INSERT INTO applications (
+       slug, name, tagline, description,
+       owner_name, department,
+       home_units, operational_owners, build_participants, tags,
+       tier, status, visibility_tier,
+       ai4ra_relationship, dual_destiny_planned, external_deployments,
+       institutional_review_status,
+       repo_url, docs_url, live_url, is_private_repo,
+       funding,
+       operational_function, operational_excellence_outcome,
+       features, tech,
+       tracking_only, related_slugs
+     )
+     VALUES (
+       $1, $2, $3, $4,
+       $5, $6,
+       $7, $8::jsonb, $9, $10,
+       $11, $12, $13,
+       $14, $15, $16,
+       $17,
+       $18, $19, $20, $21,
+       $22,
+       $23, $24,
+       $25, $26,
+       $27, $28
+     )
+     RETURNING id`,
+    [
+      i.slug,
+      i.name,
+      i.tagline,
+      i.description,
+      owner_primary?.name ?? null,
+      home_unit_primary, // legacy `department` column populated for backward compat
+      i.homeUnits,
+      JSON.stringify(i.operationalOwners),
+      i.buildParticipants,
+      i.tags ?? [],
+      tier,
+      i.status,
+      visibility_tier,
+      i.ai4raRelationship,
+      i.dualDestinyPlanned ?? false,
+      i.externalDeployments ?? [],
+      i.institutionalReviewStatus ?? null,
+      i.repoUrl ?? null,
+      i.docsUrl ?? null,
+      i.liveUrl ?? null,
+      i.isPrivateRepo ?? false,
+      i.funding ?? null,
+      i.operationalFunction,
+      i.operationalExcellenceOutcome,
+      i.features ?? [],
+      i.tech ?? [],
+      i.trackingOnly ?? false,
+      i.relatedSlugs ?? [],
+    ]
+  );
+
+  const applicationId = insert.rows[0]!.id;
+  void tierStr;
+
+  const blockers = deriveBlockers(i);
+  for (const b of blockers) {
+    await pool.query(
+      `INSERT INTO blockers (
+         application_id, category, named_party, since,
+         public_text, internal_text, severity
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [applicationId, b.category, b.named_party, b.since, b.public_text, b.internal_text, b.severity]
+    );
+  }
+
+  return { id: applicationId, blockers: blockers.length };
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Connecting to ${databaseUrl?.replace(/\/\/[^@]+@/, "//***@")}`
+  );
+  console.log(`Seeding ${interventions.length} interventions from lib/portfolio.ts ...\n`);
+
+  // TRUNCATE in a transaction. CASCADE drops dependent blockers automatically;
+  // similarity_matches FK uses ON DELETE CASCADE so those go too. Submissions
+  // have submission_id ON DELETE SET NULL, so they survive.
+  await pool.query("BEGIN");
+  try {
+    await pool.query("TRUNCATE TABLE applications RESTART IDENTITY CASCADE");
+
+    let totalBlockers = 0;
+    for (const i of interventions) {
+      const result = await seedIntervention(i);
+      const blockerNote = result.blockers > 0 ? ` [+${result.blockers} blocker${result.blockers > 1 ? "s" : ""}]` : "";
+      console.log(`  ↳ ${i.slug.padEnd(30)} ${i.name}${blockerNote}`);
+      totalBlockers += result.blockers;
+    }
+
+    await pool.query("COMMIT");
+    console.log(
+      `\nSeeded ${interventions.length} interventions and ${totalBlockers} auto-derived blocker(s).`
+    );
+  } catch (err) {
+    await pool.query("ROLLBACK");
+    throw err;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("Seed failed:", err);
+    process.exit(1);
+  })
+  .finally(() => pool.end());


### PR DESCRIPTION
## Summary

Sprint 2 of the May 2026 refactor. The Work surface now reads from Postgres with first-class blocker support, and an auth-gated `/internal` view shows the same data with sharper internal-only detail and embargoed records visible. See [REFACTOR.md](REFACTOR.md) for the broader plan.

### Schema (Migration 005)

- **`applications`** picks up the intervention shape that previously lived only in `lib/portfolio.ts`: `slug`, `tagline`, `home_units`, `operational_owners` (jsonb), `build_participants`, `tags`, `visibility_tier` (`public | embargoed | internal`), `clickup_task_id`, plus the rest of the Intervention fields.
- **`blockers`** is the friction ledger: one of the 14 categories from REFACTOR.md, optional `named_party`, `since` date, `public_text` and `internal_text` for graduated rendering, severity, and `resolved_at` for clean closure.
- **`schema_migrations`** tracks applied versions so `npm run migrate` can be rerun safely.

### Tooling

- **`npm run migrate`** — applies pending migrations and backfills 001-004 as applied for legacy DBs.
- **`npm run seed:portfolio`** — ports `lib/portfolio.ts` into `applications` + auto-derives blockers from `visibility:Partial` and `institutionalReviewStatus:'Under OIT review'` flags. Idempotent (TRUNCATE + reseed).
- **`tsx` + `dotenv`** added as devDeps; **postgres-dev** in docker-compose now exposes host port `5433` so scripts can connect from the host.

### App

- **`lib/work.ts`** — typed query module. `listApplications({ audience })` and `getApplicationBySlug` filter by visibility tier; internal audience sees all three tiers.
- **`components/PortfolioCard.tsx`** — rebuilt to take `ApplicationWithBlockers`. Each card now renders active blockers as severity-tinted chips with category, named party, and a day counter from `blocker.since`.
- **`components/InterventionDetail.tsx`** (new) — shared detail rendering for both `/portfolio/[slug]` and `/internal/portfolio/[slug]`. Internal view shows `internal_text`; public view shows `public_text`; internal also offers a disclosure to view the public-facing version of each blocker.
- **`/portfolio`** + **`/portfolio/[slug]`** — now read from Postgres via `lib/work.ts`. `lib/portfolio.ts` stays as the seed source.
- **`middleware.ts`** — Basic auth on `/internal/*`. Fails closed at 503 if `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` are unset.
- **`/internal`** — landing with totals (interventions, embargoed/internal counts, active blockers across the inventory).
- **`/internal/portfolio`** + **`/internal/portfolio/[slug]`** — same data, sharper detail, all visibility tiers visible.

### Decisions

- **URL stays `/portfolio`** (not renamed to `/work`). Sidebar label is "The Work"; URL preserved to avoid breaking existing inbound links from decks, emails, and the prior portfolio detail pages.
- **Schema uses Postgres arrays + JSONB** rather than 4 join tables. Pragmatic data fidelity without normalization overhead.
- **Visibility mapping**: `Public → public`, `Partial → embargoed`, `Internal-only → internal`.
- **Status field stays TEXT** (no DB enum). Operational status (`Production | Piloting | …`) and submission status (`idea | approved | …`) are different axes that coexist in the same column for now.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm run migrate` applied 005, backfilled 001-004 as legacy
- [x] `npm run seed:portfolio` populated 14 interventions and 4 auto-derived blockers
- [x] Browser-verified `/portfolio` renders cards with friction-ledger chips
- [x] Browser-verified `/portfolio/audit-dashboard` shows public blocker text
- [x] `curl http://localhost:3000/internal` → 401
- [x] `curl -u iids:changeme http://localhost:3000/internal` → 200
- [x] Browser-verified `/internal/portfolio/audit-dashboard` shows `internal_text` and the public-version disclosure
- [ ] Spot-check: do the auto-derived blockers (legal-embargo for Partial entries, oit-review for Under OIT review entries) match what should actually be there? Refine with hand-edited blockers in the DB or via re-running the seed after editing `lib/portfolio.ts`.
- [ ] Set production `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` before deploying — local default is `iids` / `changeme` and should not survive to prod env.

## Next

Sprint 3 — ClickUp wiring + Submit-a-Project delivery improvements (named-SLA acknowledgment, submitter-visible status page, similarity matching surfaced live during the assessment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)