### PR TITLE
Sprint 3a: Submit-a-Project delivery — named SLA, status page, live similarity

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -256,21 +256,47 @@ register has shifted. No backend changes required.
 **Output:** The Work is live. Friction ledger is visible to public and internal
 audiences with appropriate detail levels.
 
-### Sprint 3 — ClickUp wiring + Submit-a-Project improvements
+### Sprint 3 — Submit-a-Project delivery + ClickUp wiring
 
-*Colin sits in the room for this one.*
+Split into two halves so the customer-facing delivery work can ship while
+ClickUp wiring waits on Colin.
+
+#### Sprint 3a — Submit-a-Project delivery *(complete, May 2026)*
+
+ClickUp-independent. Reads from Postgres directly; ClickUp later replaces
+*who* updates status, not the surfaces.
+
+- ✅ `lib/intake-config.ts` — single source of truth for the named human
+  (Colin Armitage), the SLA wording, and the status-state labels.
+- ✅ `POST /api/similarity/preview` — stateless similarity endpoint that
+  takes a partial assessment profile and returns matches against the
+  registry. Threshold lower than the post-submit endpoint (0.2 vs 0.3) —
+  over-notify rather than miss.
+- ✅ `/intake/[token]` — public status page (token = submission UUID).
+  Shows submission state, named human, SLA, "what happens next."
+- ✅ Builder-guide updates: capture submission ID from POST, fetch
+  similarity preview on entering the review step, surface matches with
+  overlap counts both in review (with a "consider talking to..." nudge)
+  and on the results page.
+- ✅ Results page: new "What happens next" callout with named human, SLA,
+  and the bookmarkable status URL.
+- ✅ Seed enrichment — the portfolio entries seeded by
+  `npm run seed:portfolio` now carry wizard-shape classification fields
+  (sensitivity, data_sources, university_systems, etc.) so the similarity
+  engine actually finds matches. Heuristic mapping per slug; refine in
+  the seed script or via the admin registry.
+
+#### Sprint 3b — ClickUp wiring *(deferred to Colin)*
 
 - ClickUp custom fields setup (in person with Colin).
-- ClickUp API integration: read-side first (sync blocker/status data Postgres
+- ClickUp API integration: read-side (sync blocker/status data Postgres
   ← ClickUp on cron), then write-side (new submissions create CU tasks).
-- Submit-a-Project: named-human acknowledgment email + SLA copy.
-- Submitter status page `/intake/[token]` reading from Postgres + ClickUp.
-- Similarity matches surfaced during the assessment (use existing
-  `lib/similarity.ts`).
 - Once ClickUp wiring is solid, retire `/admin/submissions`.
 
-**Output:** intake portal materially better than TDX in delivery, not just
-intake. Colin's daily ops are in ClickUp; the site is a free projection.
+**Sprint 3a output:** intake portal materially better than TDX in
+delivery — named human, factual SLA, bookmarkable status URL,
+similarity-aware review. Status updates flow from manual edits to
+`submissions.status` for now; ClickUp eventually becomes the source.
 
 ### Sprint 4 — Reports unification + About + cleanup
 

--- a/app/api/similarity/preview/route.ts
+++ b/app/api/similarity/preview/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { findSimilarApplications, type SubmissionProfile } from "@/lib/similarity";
+import { intakeConfig } from "@/lib/intake-config";
+
+// POST /api/similarity/preview
+//
+// Stateless similarity check. Takes a partial assessment profile (the
+// shape produced by the builder-guide wizard's `answers` object) and
+// returns matches against the applications registry without persisting
+// anything. Used to surface similar projects mid-assessment so the
+// submitter can decide whether to coordinate before duplicating effort.
+//
+// Distinct from /api/submissions/[id]/similarity, which persists matches
+// and runs at threshold 0.3 after a real submission. This endpoint runs
+// at a lower threshold (0.2) — over-notify and let the submitter judge.
+
+interface PreviewRequest {
+  sensitivity?: string[];
+  complexity?: string | null;
+  userbase?: string | null;
+  auth?: string | null;
+  integrations?: string[];
+  dataSources?: string[];
+  universitySystems?: string[];
+  outputTypes?: string[];
+}
+
+function toArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+function toStrOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: PreviewRequest = await request.json();
+
+    const profile: SubmissionProfile = {
+      sensitivity: toArray(body.sensitivity),
+      complexity: toStrOrNull(body.complexity),
+      userbase: toStrOrNull(body.userbase),
+      auth_level: toStrOrNull(body.auth),
+      integrations: toArray(body.integrations),
+      data_sources: toArray(body.dataSources),
+      university_systems: toArray(body.universitySystems),
+      output_types: toArray(body.outputTypes),
+    };
+
+    // Skip the query if the profile carries no signal — avoids a full
+    // table scan that would just return zero matches.
+    const hasSignal =
+      profile.data_sources.length > 0 ||
+      profile.university_systems.length > 0 ||
+      profile.integrations.length > 0 ||
+      profile.sensitivity.length > 0 ||
+      profile.output_types.length > 0;
+
+    if (!hasSignal) {
+      return NextResponse.json({ matches: [] });
+    }
+
+    const matches = await findSimilarApplications(
+      profile,
+      intakeConfig.liveSimilarityThreshold
+    );
+
+    // Limit to top 5; the wizard surfaces these as "consider talking to..."
+    // hints, not an exhaustive overlap report.
+    return NextResponse.json({ matches: matches.slice(0, 5) });
+  } catch (error) {
+    console.error("POST /api/similarity/preview error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/builder-guide/page.tsx
+++ b/app/builder-guide/page.tsx
@@ -13,6 +13,27 @@ import {
   type TierRecommendation,
   type ContactInfo,
 } from "@/lib/builder-guide-data";
+import { intakeConfig, statusUrlFor } from "@/lib/intake-config";
+
+// Subset of the similarity engine's SimilarityResult shape — the wizard
+// only renders name + status + overlap counts, not the full overlap detail.
+interface SimilarMatch {
+  application_id: string;
+  application_name: string;
+  application_status: string;
+  application_department: string | null;
+  score: number;
+  overlap_details: {
+    sensitivity: string[];
+    integrations: string[];
+    data_sources: string[];
+    university_systems: string[];
+    output_types: string[];
+    complexity_match: boolean;
+    userbase_match: boolean;
+    auth_match: boolean;
+  };
+}
 
 // ============================================
 // Types
@@ -657,14 +678,95 @@ function ContactInfoStep({
   );
 }
 
+// ── Similar Matches Callout ──────────────────────────────────
+//
+// Renders the live similarity matches from /api/similarity/preview.
+// Shown both on the review step (with a "consider talking to..." nudge)
+// and on the results page (as a "related work" section).
+
+function SimilarMatchesCallout({
+  matches,
+  loading,
+  context,
+}: {
+  matches: SimilarMatch[];
+  loading: boolean;
+  context: "review" | "results";
+}) {
+  if (loading || matches.length === 0) return null;
+
+  const headline =
+    context === "review"
+      ? "Similar projects already in the portfolio"
+      : "Related work in the portfolio";
+  const sub =
+    context === "review"
+      ? "These projects share data sources, integrations, or scope with your idea. Worth a quick conversation before submitting — the portfolio owner may already be solving your problem."
+      : "These projects share dimensions with what you described. Submitter and IIDS reviewer will both see them.";
+
+  return (
+    <div className="rounded-xl border border-blue-200 bg-blue-50/60 p-5">
+      <p className="text-sm font-semibold text-blue-900">{headline}</p>
+      <p className="mt-1 text-xs text-blue-900/80 leading-relaxed">{sub}</p>
+      <ul className="mt-3 space-y-2">
+        {matches.map((m) => {
+          const overlapBits: string[] = [];
+          if (m.overlap_details.data_sources.length > 0)
+            overlapBits.push(
+              `${m.overlap_details.data_sources.length} data source${m.overlap_details.data_sources.length > 1 ? "s" : ""}`
+            );
+          if (m.overlap_details.university_systems.length > 0)
+            overlapBits.push(
+              `${m.overlap_details.university_systems.length} UI system${m.overlap_details.university_systems.length > 1 ? "s" : ""}`
+            );
+          if (m.overlap_details.integrations.length > 0)
+            overlapBits.push(
+              `${m.overlap_details.integrations.length} integration${m.overlap_details.integrations.length > 1 ? "s" : ""}`
+            );
+          if (m.overlap_details.sensitivity.length > 0)
+            overlapBits.push(`shared sensitivity class`);
+          return (
+            <li
+              key={m.application_id}
+              className="rounded-lg border border-blue-100 bg-white px-4 py-3"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-sm font-semibold text-ui-charcoal">
+                  {m.application_name}
+                </p>
+                <span className="text-xs text-blue-900/70">
+                  {Math.round(m.score * 100)}% match
+                </span>
+              </div>
+              <p className="mt-0.5 text-xs text-gray-600">
+                {m.application_department ?? "Unassigned home unit"} ·{" "}
+                {m.application_status}
+              </p>
+              {overlapBits.length > 0 && (
+                <p className="mt-1 text-xs text-blue-900/80">
+                  Overlap: {overlapBits.join(" · ")}
+                </p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 // ── Results View ─────────────────────────────────────────────
 
 function ResultsView({
   answers,
   onStartOver,
+  submissionId,
+  similarMatches,
 }: {
   answers: Answers;
   onStartOver: () => void;
+  submissionId: string | null;
+  similarMatches: SimilarMatch[];
 }) {
   const score = calculateScore(answers);
   const tier = getTierForScore(score);
@@ -677,6 +779,9 @@ function ResultsView({
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const owner = intakeConfig.intakeOwner;
+  const statusUrl = submissionId ? statusUrlFor(submissionId) : null;
+
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -687,6 +792,47 @@ function ResultsView({
         </div>
         <p className="mt-4 max-w-xl mx-auto text-sm text-gray-600">{tier.description}</p>
       </div>
+
+      {/* What happens next — named human + SLA + status link */}
+      <div className="rounded-xl border-l-4 border-ui-gold bg-ui-gold/5 p-5">
+        <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+          What happens next
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-ui-charcoal">
+          Your submission is in the IIDS intake queue.{" "}
+          <span className="font-semibold">{owner.name}</span> ({owner.title}) will
+          review the assessment and reach out within{" "}
+          <span className="font-semibold">
+            {intakeConfig.sla.businessDaysToFirstResponse} business days
+          </span>
+          .
+        </p>
+        {statusUrl && (
+          <div className="mt-3 rounded-lg border border-ui-gold/30 bg-white p-3 text-xs">
+            <p className="font-medium text-gray-700">
+              Bookmark this URL to track your submission:
+            </p>
+            <Link
+              href={statusUrl}
+              className="mt-1 block break-all font-mono text-ui-gold-dark hover:underline"
+            >
+              {statusUrl}
+            </Link>
+          </div>
+        )}
+        {!statusUrl && (
+          <p className="mt-3 text-xs italic text-gray-500">
+            Status link will appear shortly. Your submission is being recorded.
+          </p>
+        )}
+      </div>
+
+      {/* Related work in the portfolio */}
+      <SimilarMatchesCallout
+        matches={similarMatches}
+        loading={false}
+        context="results"
+      />
 
       {/* Project Idea */}
       {answers.idea && (
@@ -839,7 +985,52 @@ export default function BuilderGuidePage() {
   const [analyzing, setAnalyzing] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
 
+  // Submission ID — captured from POST /api/submissions response so the
+  // ResultsView can hand the submitter their tokenized status URL.
+  const [submissionId, setSubmissionId] = useState<string | null>(null);
+
+  // Live similarity matches — fetched once on entering the review step,
+  // surfaced both there (to give the user a chance to coordinate before
+  // submitting) and in the ResultsView.
+  const [liveMatches, setLiveMatches] = useState<SimilarMatch[]>([]);
+  const [liveMatchesLoading, setLiveMatchesLoading] = useState(false);
+
   const step = quizSteps[currentStep];
+
+  // Fetch similarity preview when the user reaches the review step. Cancels
+  // on unmount or step change so a fast Back doesn't race a stale request.
+  useEffect(() => {
+    if (currentStep !== REVIEW_STEP) return;
+    let cancelled = false;
+    setLiveMatchesLoading(true);
+    fetch("/api/similarity/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sensitivity: answers.sensitivity ?? [],
+        complexity: answers.complexity ?? null,
+        userbase: answers.userbase ?? null,
+        auth: answers.auth ?? null,
+        integrations: answers.integrations ?? [],
+        dataSources: answers.dataSources ?? [],
+        universitySystems: answers.universitySystems ?? [],
+        outputTypes: answers.outputTypes ?? [],
+      }),
+    })
+      .then((r) => (r.ok ? r.json() : { matches: [] }))
+      .then((data: { matches?: SimilarMatch[] }) => {
+        if (!cancelled) setLiveMatches(data.matches ?? []);
+      })
+      .catch(() => {
+        // Silent: similarity is a hint, not load-bearing.
+      })
+      .finally(() => {
+        if (!cancelled) setLiveMatchesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentStep, answers]);
 
   const updateAnswer = (value: string | string[]) => {
     setAnswers((prev) => ({ ...prev, [step.id]: value }));
@@ -949,7 +1140,7 @@ export default function BuilderGuidePage() {
     try {
       const score = calculateScore(answers);
       const tier = getTierForScore(score);
-      await fetch("/api/submissions", {
+      const res = await fetch("/api/submissions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -962,6 +1153,8 @@ export default function BuilderGuidePage() {
           department: contact.department,
         }),
       });
+      const data = await res.json().catch(() => ({}));
+      if (data?.id) setSubmissionId(data.id as string);
     } catch (err) {
       console.error("Failed to save submission:", err);
     }
@@ -996,6 +1189,8 @@ export default function BuilderGuidePage() {
     setShowResults(false);
     setAnalysis(null);
     setAnalysisError(null);
+    setSubmissionId(null);
+    setLiveMatches([]);
     submittedRef.current = false;
   };
 
@@ -1012,7 +1207,12 @@ export default function BuilderGuidePage() {
             Your personalized assessment and recommendations.
           </p>
         </div>
-        <ResultsView answers={answers} onStartOver={handleStartOver} />
+        <ResultsView
+          answers={answers}
+          onStartOver={handleStartOver}
+          submissionId={submissionId}
+          similarMatches={liveMatches}
+        />
       </div>
     );
   }
@@ -1063,6 +1263,11 @@ export default function BuilderGuidePage() {
                 Click any section to go back and change your answer.
               </p>
             </div>
+            <SimilarMatchesCallout
+              matches={liveMatches}
+              loading={liveMatchesLoading}
+              context="review"
+            />
             <div className="space-y-3">
               {quizSteps.map((s, i) => {
                 const answer = answers[s.id];

--- a/app/intake/[token]/page.tsx
+++ b/app/intake/[token]/page.tsx
@@ -1,0 +1,205 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { queryOne } from "@/lib/db";
+import { intakeConfig, submissionStatusLabels } from "@/lib/intake-config";
+
+export const dynamic = "force-dynamic";
+
+interface SubmissionRow {
+  id: string;
+  idea_text: string;
+  tier: number;
+  status: string;
+  submitter_name: string | null;
+  submitter_email: string | null;
+  department: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const tierLabels: Record<number, string> = {
+  1: "Tier 1 — Simple Static App",
+  2: "Tier 2 — Standard Web App",
+  3: "Tier 3 — Managed Service App",
+  4: "Tier 4 — Enterprise / Regulated App",
+};
+
+const toneStyles = {
+  neutral: "border-gray-200 bg-gray-50 text-gray-800",
+  active: "border-amber-200 bg-amber-50 text-amber-900",
+  done: "border-green-200 bg-green-50 text-green-900",
+} as const;
+
+function formatDate(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+// UUID format: 8-4-4-4-12 hex digits
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  return {
+    title: `Submission ${token.slice(0, 8)} · UI AI Project Intake`,
+    description: "Track the status of your submitted AI project idea.",
+  };
+}
+
+export default async function IntakeStatusPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  if (!UUID_RE.test(token)) notFound();
+
+  const submission = await queryOne<SubmissionRow>(
+    `SELECT id, idea_text, tier, status,
+            submitter_name, submitter_email, department,
+            created_at, updated_at
+     FROM submissions
+     WHERE id = $1`,
+    [token]
+  );
+
+  if (!submission) notFound();
+
+  const statusInfo =
+    submissionStatusLabels[submission.status] ?? {
+      label: submission.status,
+      description: "Status unknown.",
+      tone: "neutral" as const,
+    };
+  const owner = intakeConfig.intakeOwner;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-10">
+      {/* Header */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          UI AI Project Intake
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+          Submission status
+        </h1>
+        <p className="mt-3 text-sm text-gray-500">
+          Submitted {formatDate(submission.created_at)}
+          {submission.submitter_name ? ` by ${submission.submitter_name}` : ""}
+          {submission.department ? ` · ${submission.department}` : ""}
+        </p>
+      </div>
+
+      {/* Status panel */}
+      <section
+        className={`rounded-xl border p-6 ${toneStyles[statusInfo.tone]}`}
+      >
+        <div className="flex flex-wrap items-baseline justify-between gap-3">
+          <h2 className="text-lg font-semibold">{statusInfo.label}</h2>
+          <span className="text-xs">
+            Last updated {formatDate(submission.updated_at)}
+          </span>
+        </div>
+        <p className="mt-2 text-sm leading-relaxed">
+          {statusInfo.description}
+        </p>
+      </section>
+
+      {/* Assigned human + SLA */}
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+          Assigned to
+        </p>
+        <p className="mt-2 text-base font-semibold text-ui-charcoal">
+          {owner.name}
+          <span className="ml-2 text-sm font-normal text-gray-500">
+            ({owner.title})
+          </span>
+        </p>
+        {owner.email && (
+          <p className="mt-1 text-sm text-gray-600">
+            <a
+              href={`mailto:${owner.email}`}
+              className="text-ui-gold-dark hover:underline"
+            >
+              {owner.email}
+            </a>
+          </p>
+        )}
+        <p className="mt-3 text-sm leading-relaxed text-gray-700">
+          {intakeConfig.sla.text}
+        </p>
+      </section>
+
+      {/* Submission summary */}
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+          What you submitted
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-gray-700">
+          {submission.idea_text}
+        </p>
+        <p className="mt-4 text-sm font-medium text-ui-gold-dark">
+          {tierLabels[submission.tier] ?? `Tier ${submission.tier}`}
+        </p>
+      </section>
+
+      {/* What happens next */}
+      <section className="rounded-xl bg-ui-charcoal p-6 text-white">
+        <h2 className="text-base font-semibold text-ui-gold">
+          What happens next
+        </h2>
+        <ol className="mt-4 space-y-3 text-sm">
+          <li className="flex gap-3">
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-gold/20 text-xs font-bold text-ui-gold">
+              1
+            </span>
+            <span className="leading-relaxed text-white/90">
+              {owner.name} reviews the assessment and reaches out within{" "}
+              {intakeConfig.sla.businessDaysToFirstResponse} business days.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-gold/20 text-xs font-bold text-ui-gold">
+              2
+            </span>
+            <span className="leading-relaxed text-white/90">
+              IIDS scopes the project, checks for related work, and either
+              accepts it into the portfolio or refers you to the right
+              partner unit.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-gold/20 text-xs font-bold text-ui-gold">
+              3
+            </span>
+            <span className="leading-relaxed text-white/90">
+              Accepted projects appear on{" "}
+              <Link
+                href="/portfolio"
+                className="text-ui-gold hover:underline"
+              >
+                /portfolio
+              </Link>{" "}
+              with named operational ownership.
+            </span>
+          </li>
+        </ol>
+      </section>
+
+      <p className="text-center text-xs text-gray-400">
+        Bookmark this page to check back. The link is unique to your
+        submission.
+      </p>
+    </div>
+  );
+}

--- a/lib/intake-config.ts
+++ b/lib/intake-config.ts
@@ -1,0 +1,73 @@
+// lib/intake-config.ts
+//
+// Named-SLA configuration for the Submit-a-Project flow. Single source of
+// truth for who the named human is, what the SLA reads, and how status
+// values map to user-facing language. Edit here when staffing or copy
+// changes; do not embed strings in the wizard or status page directly.
+
+export const intakeConfig = {
+  /** The IIDS staff member named on the post-submit confirmation. */
+  intakeOwner: {
+    name: "Colin Armitage",
+    title: "IIDS",
+    email: "carmitage@uidaho.edu",
+  },
+  /** Service-level commitment shown to submitters at confirmation time. */
+  sla: {
+    /** Plain-English version. */
+    text: "Colin will follow up within 2 business days.",
+    /** Numeric form for any future automation. */
+    businessDaysToFirstResponse: 2,
+  },
+  /**
+   * Threshold for surfacing similar projects during the assessment.
+   * Lower than the post-submit threshold (0.3) — at intake time we'd
+   * rather over-notify and let the submitter decide than miss a real
+   * overlap.
+   */
+  liveSimilarityThreshold: 0.2,
+} as const;
+
+/**
+ * User-facing label and short description for each submissions.status
+ * value. Status states are defined in db/migrations/001_initial.sql:
+ *   new | reviewed | in-progress | archived
+ */
+export const submissionStatusLabels: Record<
+  string,
+  { label: string; description: string; tone: "neutral" | "active" | "done" }
+> = {
+  new: {
+    label: "Received",
+    description:
+      "Your submission has been logged and is in the IIDS intake queue.",
+    tone: "neutral",
+  },
+  reviewed: {
+    label: "Reviewed",
+    description:
+      "An IIDS reviewer has looked at the assessment and is preparing next steps.",
+    tone: "active",
+  },
+  "in-progress": {
+    label: "In progress",
+    description:
+      "Your project has been accepted and work has started or scoping is underway.",
+    tone: "active",
+  },
+  archived: {
+    label: "Closed",
+    description:
+      "This submission has been closed. Reach out to IIDS if you have questions about the outcome.",
+    tone: "done",
+  },
+};
+
+/**
+ * The submission UUID is used directly as the status-page token. UUIDs
+ * carry ~122 bits of entropy, enough to function as an unguessable
+ * capability for a single submission.
+ */
+export function statusUrlFor(submissionId: string): string {
+  return `/intake/${submissionId}`;
+}

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -39,6 +39,188 @@ const pool = new Pool({ connectionString: databaseUrl });
 // ClickUp wiring or by editing the rows in the DB directly.
 const PLACEHOLDER_BLOCKER_SINCE = "2026-03-01";
 
+// ────────────────────────────────────────────────────────────────────
+// Wizard-shape enrichment
+// ────────────────────────────────────────────────────────────────────
+//
+// lib/portfolio.ts doesn't carry the wizard's classification dimensions
+// (sensitivity, data_sources, integrations, university_systems,
+// output_types, complexity, userbase, auth_level). The applications
+// table needs them populated for the similarity engine to find matches
+// when a Submit-a-Project assessment runs.
+//
+// This is a best-guess heuristic mapping per slug, using exactly the
+// label vocabulary from lib/builder-guide-data.ts. Refine the mapping
+// here when an entry is misclassified, or hand-edit the row in the DB.
+// Sprint 3+ ClickUp wiring becomes the canonical source.
+
+interface WizardShape {
+  sensitivity: string[];
+  complexity: string | null;
+  userbase: string | null;
+  auth_level: string | null;
+  integrations: string[];
+  data_sources: string[];
+  university_systems: string[];
+  output_types: string[];
+}
+
+const wizardShapeBySlug: Record<string, WizardShape> = {
+  stratplan: {
+    sensitivity: ["No sensitive data"],
+    complexity: "Multiple data sources",
+    userbase: "University-wide",
+    auth_level: "Role-based access",
+    integrations: ["University APIs", "AI / LLM integration"],
+    data_sources: ["Custom / internal APIs", "Flat files / spreadsheets"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Read-only reporting"],
+  },
+  "audit-dashboard": {
+    sensitivity: ["PII", "Financial data"],
+    complexity: "Multiple data sources",
+    userbase: "My department",
+    auth_level: "Role-based access",
+    integrations: ["AI / LLM integration", "File storage"],
+    data_sources: ["Flat files / spreadsheets", "Custom / internal APIs"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Creates / modifies records", "Generates documents"],
+  },
+  "ucm-daily-register": {
+    sensitivity: ["No sensitive data"],
+    complexity: "Multiple data sources",
+    userbase: "University-wide",
+    auth_level: "University SSO",
+    integrations: ["External SaaS APIs", "AI / LLM integration", "Email / notifications"],
+    data_sources: ["Custom / internal APIs", "Flat files / spreadsheets"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Generates documents", "Sends notifications"],
+  },
+  "embargoed-osp": {
+    sensitivity: ["Research / IRB", "PII"],
+    complexity: "Complex pipelines",
+    userbase: "My department",
+    auth_level: "Role-based access",
+    integrations: ["External SaaS APIs", "University APIs"],
+    data_sources: ["Custom / internal APIs"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Creates / modifies records"],
+  },
+  vandalizer: {
+    sensitivity: ["No sensitive data"],
+    complexity: "Simple CRUD",
+    userbase: "University-wide",
+    auth_level: "University SSO",
+    integrations: ["AI / LLM integration"],
+    data_sources: ["Flat files / spreadsheets"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Generates documents"],
+  },
+  processmapping: {
+    sensitivity: ["No sensitive data"],
+    complexity: "Multiple data sources",
+    userbase: "University-wide",
+    auth_level: "University SSO",
+    integrations: ["University APIs", "AI / LLM integration"],
+    data_sources: ["Custom / internal APIs"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Creates / modifies records", "Read-only reporting"],
+  },
+  execord: {
+    sensitivity: ["PII"],
+    complexity: "Multiple data sources",
+    userbase: "My department",
+    auth_level: "Role-based access",
+    integrations: ["AI / LLM integration", "Email / notifications"],
+    data_sources: ["Custom / internal APIs", "Flat files / spreadsheets"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Creates / modifies records", "Triggers workflows"],
+  },
+  "sem-experiential": {
+    sensitivity: ["FERPA", "PII"],
+    complexity: "Simple CRUD",
+    userbase: "College-wide",
+    auth_level: "Role-based access",
+    integrations: ["University APIs"],
+    data_sources: ["Banner / SIS", "Custom / internal APIs"],
+    university_systems: ["Banner Student", "CAS / SSO"],
+    output_types: ["Creates / modifies records", "Read-only reporting"],
+  },
+  "rfd-career": {
+    sensitivity: ["FERPA", "PII"],
+    complexity: "Multiple data sources",
+    userbase: "My department",
+    auth_level: "Role-based access",
+    integrations: ["University APIs"],
+    data_sources: ["Banner / SIS", "Custom / internal APIs"],
+    university_systems: ["Banner Student", "CAS / SSO"],
+    output_types: ["Read-only reporting", "Generates documents"],
+  },
+  mindrouter: {
+    sensitivity: ["No sensitive data"],
+    complexity: "Real-time / streaming",
+    userbase: "University-wide",
+    auth_level: "Role-based access",
+    integrations: ["AI / LLM integration"],
+    data_sources: ["Custom / internal APIs"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Exposes an API"],
+  },
+  "dgx-stack": {
+    sensitivity: ["No sensitive data"],
+    complexity: "Real-time / streaming",
+    userbase: "University-wide",
+    auth_level: "Role-based access",
+    integrations: ["AI / LLM integration"],
+    data_sources: ["None / generates its own data"],
+    university_systems: ["CAS / SSO"],
+    output_types: ["Exposes an API"],
+  },
+  "template-app": {
+    sensitivity: ["No sensitive data"],
+    complexity: "Static content",
+    userbase: "Just me / my team",
+    auth_level: "University SSO",
+    integrations: ["None / standalone"],
+    data_sources: ["None / generates its own data"],
+    university_systems: [],
+    output_types: ["Read-only reporting"],
+  },
+  "oit-data-modernization": {
+    sensitivity: ["FERPA", "PII", "Financial data"],
+    complexity: "Complex pipelines",
+    userbase: "University-wide",
+    auth_level: "Role-based access",
+    integrations: ["University APIs"],
+    data_sources: ["Banner / SIS", "Custom / internal APIs"],
+    university_systems: ["Banner Student", "Banner Finance", "Banner HR"],
+    output_types: ["Read-only reporting"],
+  },
+  nexus: {
+    sensitivity: ["FERPA", "PII"],
+    complexity: "Multiple data sources",
+    userbase: "University-wide",
+    auth_level: "Role-based access",
+    integrations: ["University APIs", "AI / LLM integration"],
+    data_sources: ["Banner / SIS", "Custom / internal APIs"],
+    university_systems: ["Banner Student", "VandalWeb", "CAS / SSO"],
+    output_types: ["Read-only reporting", "Creates / modifies records"],
+  },
+};
+
+// Default for slugs not in the map — leaves wizard fields empty so
+// similarity simply returns no match for them.
+const EMPTY_SHAPE: WizardShape = {
+  sensitivity: [],
+  complexity: null,
+  userbase: null,
+  auth_level: null,
+  integrations: [],
+  data_sources: [],
+  university_systems: [],
+  output_types: [],
+};
+
 function visibilityTier(v: Visibility): "public" | "embargoed" | "internal" {
   switch (v) {
     case "Public":
@@ -100,10 +282,10 @@ function deriveBlockers(i: Intervention): BlockerSeed[] {
 
 async function seedIntervention(i: Intervention): Promise<{ id: string; blockers: number }> {
   const tier = inferTier(i);
-  const tierStr = String(tier);
   const visibility_tier = visibilityTier(i.visibility);
   const home_unit_primary = i.homeUnits[0] ?? null;
   const owner_primary = i.operationalOwners[0] ?? null;
+  const wizard = wizardShapeBySlug[i.slug] ?? EMPTY_SHAPE;
 
   const insert = await pool.query<{ id: string }>(
     `INSERT INTO applications (
@@ -117,7 +299,9 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        funding,
        operational_function, operational_excellence_outcome,
        features, tech,
-       tracking_only, related_slugs
+       tracking_only, related_slugs,
+       sensitivity, complexity, userbase, auth_level,
+       integrations, data_sources, university_systems, output_types
      )
      VALUES (
        $1, $2, $3, $4,
@@ -130,7 +314,9 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        $22,
        $23, $24,
        $25, $26,
-       $27, $28
+       $27, $28,
+       $29, $30, $31, $32,
+       $33, $34, $35, $36
      )
      RETURNING id`,
     [
@@ -162,11 +348,18 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
       i.tech ?? [],
       i.trackingOnly ?? false,
       i.relatedSlugs ?? [],
+      wizard.sensitivity,
+      wizard.complexity,
+      wizard.userbase,
+      wizard.auth_level,
+      wizard.integrations,
+      wizard.data_sources,
+      wizard.university_systems,
+      wizard.output_types,
     ]
   );
 
   const applicationId = insert.rows[0]!.id;
-  void tierStr;
 
   const blockers = deriveBlockers(i);
   for (const b of blockers) {


### PR DESCRIPTION
## Summary

The customer-facing half of Sprint 3 — Submit-a-Project delivery improvements that ship ahead of Colin's ClickUp wiring (which is now Sprint 3b). Three things go live, and they make the intake portal materially better than TDX in *delivery*, not just in the assessment quiz.

### What's new

- **`lib/intake-config.ts`** — single source of truth for the named human (Colin Armitage, IIDS), the SLA wording (2 business days), the user-facing status-state labels (Received / Reviewed / In progress / Closed), and a `statusUrlFor(id)` helper. Edit here when staffing or copy changes; do not embed strings in the wizard or status page directly.

- **`POST /api/similarity/preview`** — stateless similarity endpoint. Takes a partial assessment profile (the shape the wizard's `answers` object produces), returns the top 5 matches against the applications registry without persisting anything. Threshold 0.2 (vs the post-submit 0.3) — over-notify rather than miss at intake time.

- **`/intake/[token]`** — public, capability-based status page. Token is the submission UUID (~122 bits of entropy, unguessable enough). Renders current state, the named human + SLA, the original idea + tier, and a 3-step "what happens next." Bookmark-friendly URL the submitter can revisit.

### Builder-guide updates

- Captures submission ID from `POST /api/submissions` (was fire-and-forget) so the results page can hand the submitter their tokenized status URL.
- Fetches live similarity on entering the review step. Cancels on step change so a fast Back doesn't race a stale request.
- New `SimilarMatchesCallout` component renders matches in two contexts:
  - **Review step**: above the answers list, with a "consider talking to..." nudge — last chance to coordinate before submit.
  - **Results page**: as a "related work" section.
  Each match shows name, home unit, status, overall score, and per-category overlap counts (data sources, UI systems, integrations, sensitivity).
- New **"What happens next"** callout on the results page: named human, SLA, and the bookmarkable status URL.

### Seed enrichment

The similarity engine compares wizard-shape fields (sensitivity, complexity, userbase, auth_level, integrations, data_sources, university_systems, output_types) between submissions and applications. `lib/portfolio.ts` doesn't carry those dimensions natively — without enrichment, the engine returns empty matches.

`scripts/seed-portfolio.ts` now maps each portfolio slug to wizard-shape values using the exact label vocabulary from `lib/builder-guide-data.ts`. The mapping is heuristic; refine in the seed or via `/admin/registry` when an entry is misclassified. Sprint 3b's ClickUp wiring eventually becomes the canonical source.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm run seed:portfolio` populates 14 interventions with wizard-shape data
- [x] `POST /api/similarity/preview` with a Banner-FERPA-flavored profile returns 4 matches at 0.49-0.62 (SEM Experiential, RFD CAREER, Nexus, OIT Data Modernization)
- [x] Inserted test submission via `POST /api/submissions`, visited `/intake/[uuid]`, all four sections rendered (state panel, assigned human + SLA, submission summary, what happens next)
- [ ] Walk the wizard end-to-end in browser: idea → multi-selects → review (similarity callout shows) → contact → submit → results (status URL displayed) → click status URL → status page renders
- [ ] Spot-check the wizard-shape heuristic in `scripts/seed-portfolio.ts` for any glaringly wrong mappings (the labels need to match `lib/builder-guide-data.ts` exactly to participate in similarity)
- [ ] Decide whether the named human stays as Colin or rotates per-tier / per-domain in the future

## What's still deferred

- **Sprint 3b — ClickUp wiring** (Colin's). When that lands, status updates flow from ClickUp → `submissions.status` instead of being hand-edited, and `/admin/submissions` retires.
- **Acknowledgment email** — the original Sprint 3 plan included an email with the named human + SLA. Skipped for v1; the in-page confirmation + status URL covers the same surface area without standing up SMTP. Easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)