### PR TITLE
Subdivide /standards with sub-nav scaffolding (closes #54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ _archive/                  # Routes/files archived in May 2026 refactor
 |---|---|---|
 | An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. |
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
+| A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |
 | A presentation/deck | `lib/artifacts.ts` (entry with `kind: "deck"`) plus `content/presentations/<slug>.md` if rendered via reveal.js | The artifact appears in the /reports timeline; the markdown drives the deck itself. |
 | A report | `app/reports/page.tsx` and (if needed) a route under `app/reports/<slug>` | Time-stamped, reverse-chron. |
 

--- a/app/standards/data-model/page.tsx
+++ b/app/standards/data-model/page.tsx
@@ -1,0 +1,34 @@
+export const metadata = {
+  title: "Data Model — Standards",
+  description:
+    "Interactive explorer for the AI4RA Unified Data Model and per-project extensions across the IIDS portfolio.",
+};
+
+export default function DataModelPlaceholderPage() {
+  return (
+    <div className="max-w-3xl">
+      <h1 className="text-3xl font-black tracking-tight text-ui-charcoal">
+        Data Model
+      </h1>
+      <p className="mt-4 text-base leading-relaxed text-gray-700">
+        An interactive explorer for the AI4RA Unified Data Model and the
+        per-project extensions installed across the IIDS portfolio. The
+        explorer surfaces tables, columns, controlled vocabularies, and
+        cross-project usage so engineers can connect to our data and
+        stakeholders can understand the definitions and business rules.
+      </p>
+      <p className="mt-6 rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+        Tracking issue:{" "}
+        <a
+          href="https://github.com/ui-insight/AISPEG/issues/53"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold text-ui-charcoal underline decoration-brand-clearwater decoration-[1.5px] underline-offset-4"
+        >
+          [Epic] Data Governance Explorer (#53)
+        </a>
+        . The first interactive view ships in #55.
+      </p>
+    </div>
+  );
+}

--- a/app/standards/layout.tsx
+++ b/app/standards/layout.tsx
@@ -1,0 +1,21 @@
+import StandardsSubNav from "@/components/StandardsSubNav";
+
+export default function StandardsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <header className="mb-10 border-b border-gray-200">
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          Institutional Standards
+        </p>
+        <div className="mt-4">
+          <StandardsSubNav />
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -110,10 +110,7 @@ export default function StandardsWatchPage() {
     <div className="space-y-10">
       {/* Header */}
       <header>
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
-          Institutional Standards
-        </p>
-        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+        <h1 className="text-3xl font-black tracking-tight text-ui-charcoal">
           Software-development and user-experience standards
         </h1>
         <p className="mt-3 max-w-3xl text-base leading-relaxed text-gray-700">

--- a/components/StandardsSubNav.tsx
+++ b/components/StandardsSubNav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const subNavItems = [
+  { href: "/standards", label: "Standards Watch" },
+  { href: "/standards/data-model", label: "Data Model" },
+];
+
+export default function StandardsSubNav() {
+  const pathname = usePathname();
+  return (
+    <nav
+      aria-label="Standards sections"
+      className="-mb-px flex gap-8 overflow-x-auto"
+    >
+      {subNavItems.map((item) => {
+        const active =
+          item.href === "/standards"
+            ? pathname === "/standards"
+            : pathname === item.href || pathname.startsWith(item.href + "/");
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? "page" : undefined}
+            className={`unstyled whitespace-nowrap border-b-2 pb-3 text-sm font-semibold tracking-tight transition-colors ${
+              active
+                ? "border-brand-clearwater text-ui-charcoal"
+                : "border-transparent text-gray-600 hover:text-ui-charcoal"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Promote the existing "INSTITUTIONAL STANDARDS" eyebrow into a new `app/standards/layout.tsx` so it persists across sub-sections; render a sub-nav under it; each sub-page owns its own H1.
- New `components/StandardsSubNav.tsx` (`"use client"`) with a tiny `subNavItems` config — adding a new sub-section means one new row + one new `app/standards/<sub>/page.tsx`. **No sidebar edit, ever.**
- Active-tab treatment: 2px clearwater-teal underline (`brand-clearwater` → `#008080`), matching the institutional link convention in `.impeccable.md`. Pride Gold avoided here per `.impeccable.md`'s "Pride Gold is rare" rule — persistent UI on every page is the wrong place for it.
- Placeholder `/standards/data-model` page so the sub-nav has two items and the visual pattern is demoable on its own. Replaced by [#55](https://github.com/ui-insight/AISPEG/issues/55).
- CLAUDE.md "Adding content" table updated with the sub-section pattern.

## HITL design decisions locked

| Decision | Choice |
|---|---|
| Sub-nav pattern | Underlined tabs across the top (rejected: left-rail competes with main sidebar; inline-link loses hierarchy) |
| Active highlight | Clearwater teal underline (rejected: Pride Gold — would violate "rare" rule) |
| Heading composition | Persistent parent eyebrow → sub-nav → per-sub-section H1 (rejected: single H1 with no parent context) |

## Acceptance criteria (from #54)

- [x] `/standards` still renders the existing standards-watch ledger as default
- [x] Sub-nav renders on every `/standards/*` route
- [x] Adding a new route file under `app/standards/<sub>/page.tsx` is enough to add a sub-section (no parallel sidebar edit)
- [x] Sidebar continues to show one entry for Standards
- [x] Pattern documented in CLAUDE.md
- [x] Brand tokens only; clearwater teal active state (no raw hex)
- [x] `npm run build` clean; `npm run lint` clean

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean; both `/standards` and `/standards/data-model` prerendered as static
- [x] Browser preview: visited both routes, verified active-state border color is `rgb(0, 128, 128)` (clearwater teal), text-decoration is `none` on sub-nav links (`unstyled` class added to escape the global `main a[href]` underline rule at `globals.css:57`)
- [x] Sidebar still shows a single "Standards" entry; remains active on both sub-routes via the existing `pathname.startsWith` logic
- [x] No console errors on either route
- [ ] Reviewer: confirm sub-nav reads correctly on mobile (`overflow-x-auto` is set; if you'd like stacking instead, flag it)

## Unblocks

- [#55](https://github.com/ui-insight/AISPEG/issues/55) — Tracer slice (vendor catalog, build pipeline, Projects index, one project detail)

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)