### PR TITLE
Data Model: Tables tab + table detail (closes #56)

### DIFF
--- a/app/standards/data-model/page.tsx
+++ b/app/standards/data-model/page.tsx
@@ -1,43 +1,12 @@
 import Link from "next/link";
+import DataModelHeader from "@/components/DataModelHeader";
 import { projects } from "@/lib/governance/catalog";
-import { vocabularyGroups } from "@/lib/governance/vocabularies";
 
 export const metadata = {
   title: "Data Model — Standards",
   description:
     "Interactive explorer for the AI4RA Unified Data Model and per-project extensions across the IIDS portfolio.",
 };
-
-const TAB_ITEMS = [
-  { id: "projects" as const, label: "Projects" },
-  { id: "tables" as const, label: "Tables" },
-  { id: "vocabularies" as const, label: "Vocabularies" },
-];
-
-function TabBar({ active }: { active: "projects" | "tables" | "vocabularies" }) {
-  return (
-    <div className="flex gap-6 border-b border-gray-200">
-      {TAB_ITEMS.map((t) => (
-        <span
-          key={t.id}
-          aria-current={t.id === active ? "page" : undefined}
-          className={`-mb-px border-b-2 pb-2 text-xs font-semibold uppercase tracking-wider ${
-            t.id === active
-              ? "border-brand-clearwater text-ui-charcoal"
-              : "border-transparent text-gray-400"
-          }`}
-        >
-          {t.label}
-          {t.id !== active && (
-            <span className="ml-1.5 text-[10px] font-normal normal-case tracking-normal text-gray-400">
-              (next)
-            </span>
-          )}
-        </span>
-      ))}
-    </div>
-  );
-}
 
 function ProjectCard({ project }: { project: (typeof projects)[number] }) {
   return (
@@ -87,58 +56,9 @@ function ProjectCard({ project }: { project: (typeof projects)[number] }) {
 }
 
 export default function DataModelIndexPage() {
-  const totalTables = projects.reduce((sum, p) => sum + p.tableCount, 0);
-  const totalVocab = vocabularyGroups.length;
-
   return (
     <div className="space-y-10">
-      <header>
-        <h1 className="text-3xl font-black tracking-tight text-ui-charcoal">
-          Data Model
-        </h1>
-        <p className="mt-3 max-w-3xl text-base leading-relaxed text-gray-700">
-          The AI4RA Unified Data Model and the per-project extensions
-          installed across the IIDS portfolio. Engineers can use this to
-          connect to our data; stakeholders can use it to understand the
-          definitions and business rules. Source of truth:{" "}
-          <a
-            href="https://github.com/ui-insight/data-governance"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ui-insight/data-governance
-          </a>
-          .
-        </p>
-        <dl className="mt-6 grid grid-cols-3 gap-6 text-sm">
-          <div>
-            <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
-              Projects governed
-            </dt>
-            <dd className="mt-1 text-2xl font-black text-ui-charcoal">
-              {projects.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
-              Tables across portfolio
-            </dt>
-            <dd className="mt-1 text-2xl font-black text-ui-charcoal">
-              {totalTables}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
-              Vocabulary groups
-            </dt>
-            <dd className="mt-1 text-2xl font-black text-ui-charcoal">
-              {totalVocab}
-            </dd>
-          </div>
-        </dl>
-      </header>
-
-      <TabBar active="projects" />
+      <DataModelHeader active="projects" />
 
       <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {projects.map((p) => (

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -1,0 +1,452 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import {
+  getProject,
+  getTablesForProject,
+  projects,
+  tables,
+} from "@/lib/governance/catalog";
+import { vocabularyGroups } from "@/lib/governance/vocabularies";
+import type { Column, Table, TableKind } from "@/lib/governance/types";
+
+export function generateStaticParams() {
+  return tables.map((t) => ({
+    project: t.project,
+    table: t.name,
+  }));
+}
+
+const KIND_LABEL: Record<TableKind, string> = {
+  table: "Table",
+  entity: "Entity",
+  projection_table: "Projection table",
+};
+
+function findTable(projectSlug: string, tableName: string): Table | undefined {
+  return getTablesForProject(projectSlug).find((t) => t.name === tableName);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ project: string; table: string }>;
+}) {
+  const { project: projectSlug, table: tableNameRaw } = await params;
+  const tableName = decodeURIComponent(tableNameRaw);
+  const project = getProject(projectSlug);
+  const table = project ? findTable(projectSlug, tableName) : undefined;
+
+  return {
+    title:
+      project && table
+        ? `${table.name} — ${project.application} — Data Model`
+        : "Table — Data Model",
+    description:
+      table?.description ??
+      (project
+        ? `Schema for ${tableName} in ${project.application}.`
+        : undefined),
+  };
+}
+
+function ClassificationBadge({
+  classification,
+}: {
+  classification: Table["classification"];
+}) {
+  const label =
+    classification === "canonical-udm" ? "Canonical UDM" : "Project extension";
+  const styles =
+    classification === "canonical-udm"
+      ? "bg-brand-clearwater/10 text-brand-clearwater"
+      : "bg-gray-100 text-gray-700";
+  return (
+    <span
+      className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${styles}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Build the set of vocabulary-group names that may apply to a given project.
+ * Match by both `application` (e.g. "OpenERA") and `domain` (e.g. "openera"),
+ * using case-insensitive comparison so the loose tagging in upstream JSON
+ * still matches our project slugs/applications.
+ */
+function vocabularyGroupNamesForProject(
+  projectSlug: string,
+  projectApplication: string,
+): Set<string> {
+  const slugLower = projectSlug.toLowerCase();
+  const appLower = projectApplication.toLowerCase();
+  const names = new Set<string>();
+  for (const g of vocabularyGroups) {
+    const domainLower = (g.domain ?? "").toLowerCase();
+    const appField = (g.application ?? "").toLowerCase();
+    if (
+      domainLower === slugLower ||
+      domainLower === appLower ||
+      appField === appLower ||
+      appField === slugLower
+    ) {
+      names.add(g.group.toLowerCase());
+    }
+  }
+  return names;
+}
+
+/**
+ * Heuristic: is this column a controlled-vocabulary column?
+ * 1. Foreign key targets the AllowedValues table.
+ * 2. Column name (normalized) matches a known vocabulary group name in this project.
+ */
+function isVocabularyColumn(
+  column: Column,
+  vocabNamesLower: Set<string>,
+): boolean {
+  const fk = column.foreignKey ?? "";
+  if (fk.startsWith("AllowedValues.")) return true;
+
+  const normalize = (s: string) =>
+    s.replace(/[_\s-]+/g, "").replace(/id$/i, "").toLowerCase();
+  const normalized = normalize(column.name);
+  if (!normalized) return false;
+  for (const g of vocabNamesLower) {
+    if (normalize(g) === normalized) return true;
+  }
+  return false;
+}
+
+function ColumnRow({
+  column,
+  isVocab,
+}: {
+  column: Column;
+  isVocab: boolean;
+}) {
+  return (
+    <tr className="border-t border-gray-100 align-top">
+      <td className="py-2 pr-4 font-mono text-xs text-ui-charcoal">
+        <span>{column.name}</span>
+        {column.primaryKey && (
+          <span className="ml-2 rounded bg-ui-gold/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+            PK
+          </span>
+        )}
+        {isVocab && (
+          <span
+            className="ml-2 rounded bg-brand-huckleberry/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-huckleberry"
+            title="Values controlled by a vocabulary group"
+          >
+            Vocab
+          </span>
+        )}
+      </td>
+      <td className="py-2 pr-4 font-mono text-xs text-gray-600">
+        {column.type}
+      </td>
+      <td className="py-2 pr-4 text-xs text-gray-600">
+        {column.nullable === true
+          ? "nullable"
+          : column.nullable === false
+            ? "required"
+            : ""}
+      </td>
+      <td className="py-2 pr-4 font-mono text-xs text-gray-600">
+        {column.foreignKey ?? ""}
+      </td>
+    </tr>
+  );
+}
+
+export default async function TableDetailPage({
+  params,
+}: {
+  params: Promise<{ project: string; table: string }>;
+}) {
+  const { project: projectSlug, table: tableNameRaw } = await params;
+  const tableName = decodeURIComponent(tableNameRaw);
+  const project = getProject(projectSlug);
+  if (!project) notFound();
+  const table = findTable(projectSlug, tableName);
+  if (!table) notFound();
+
+  const vocabNamesLower = vocabularyGroupNamesForProject(
+    project.slug,
+    project.application,
+  );
+
+  const vocabFlags = table.columns.map((c) =>
+    isVocabularyColumn(c, vocabNamesLower),
+  );
+  const vocabColumnCount = vocabFlags.filter(Boolean).length;
+
+  // Group declared relationships by target.
+  const relationshipsByTarget = new Map<string, typeof table.relationships>();
+  for (const rel of table.relationships) {
+    const arr = relationshipsByTarget.get(rel.target) ?? [];
+    arr.push(rel);
+    relationshipsByTarget.set(rel.target, arr);
+  }
+
+  // Inferred FK relationships fallback.
+  const inferredFks = table.columns
+    .filter((c) => c.foreignKey)
+    .map((c) => ({ column: c.name, target: c.foreignKey as string }));
+
+  const classificationCopy =
+    table.classification === "canonical-udm"
+      ? "Adopted from the AI4RA Unified Data Model — naming and shape follow the institutional standard."
+      : "Specific to this project — workflow, tooling, or domain-specific entities not part of the canonical UDM.";
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <p className="text-xs">
+          <Link href={`/standards/data-model/projects/${project.slug}`}>
+            ← {project.application}
+          </Link>
+        </p>
+        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+          {project.domain}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-3">
+          <h1 className="font-mono text-3xl font-black tracking-tight text-ui-charcoal">
+            {table.name}
+          </h1>
+          <ClassificationBadge classification={table.classification} />
+          <span className="text-[10px] font-medium uppercase tracking-wider text-gray-500">
+            {KIND_LABEL[table.kind]}
+          </span>
+        </div>
+
+        <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-4">
+          <div>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
+              Columns
+            </dt>
+            <dd className="mt-1 font-bold text-ui-charcoal">
+              {table.columns.length}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
+              Relationships
+            </dt>
+            <dd className="mt-1 font-bold text-ui-charcoal">
+              {table.relationships.length}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
+              Vocab columns
+            </dt>
+            <dd className="mt-1 font-bold text-ui-charcoal">
+              {vocabColumnCount}
+            </dd>
+          </div>
+          {table.modelClass && (
+            <div>
+              <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
+                Model class
+              </dt>
+              <dd className="mt-1 font-mono text-xs font-bold text-ui-charcoal">
+                {table.modelClass}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </header>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-5">
+        {table.description && (
+          <p className="text-sm leading-relaxed text-gray-700">
+            {table.description}
+          </p>
+        )}
+        <p
+          className={`${
+            table.description ? "mt-3 border-t border-gray-100 pt-3" : ""
+          } text-xs text-gray-600`}
+        >
+          {classificationCopy}
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-ui-charcoal">Columns</h2>
+            <p className="mt-1 text-sm text-gray-600">
+              Full column list. PK marks primary keys; Vocab marks columns
+              whose values come from a controlled vocabulary group.
+            </p>
+          </div>
+          <p className="text-xs text-gray-500">
+            <span className="font-bold text-ui-charcoal">
+              {table.columns.length}
+            </span>{" "}
+            columns
+            {vocabColumnCount > 0 && (
+              <>
+                {" "}
+                ·{" "}
+                <span className="font-bold text-brand-huckleberry">
+                  {vocabColumnCount}
+                </span>{" "}
+                vocabulary
+              </>
+            )}
+          </p>
+        </div>
+
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="w-full min-w-[720px] text-left">
+            <thead className="border-b border-gray-200 bg-gray-50">
+              <tr className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+                <th scope="col" className="px-3 py-2">
+                  Name
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Type
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Nullability
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Foreign key
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {table.columns.map((c, i) => (
+                <ColumnRow
+                  key={c.name}
+                  column={c}
+                  isVocab={vocabFlags[i] ?? false}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {table.uniqueConstraints.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-ui-charcoal">
+            Unique constraints
+          </h2>
+          <ul className="space-y-1 text-xs">
+            {table.uniqueConstraints.map((cols, idx) => (
+              <li
+                key={idx}
+                className="rounded border border-gray-200 bg-white px-3 py-1.5 font-mono text-ui-charcoal"
+              >
+                ({cols.join(", ")})
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {table.relationships.length > 0 ? (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-xl font-bold text-ui-charcoal">
+              Relationships
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">
+              Declared associations grouped by target table.
+            </p>
+          </div>
+          <ul className="space-y-2">
+            {Array.from(relationshipsByTarget.entries()).map(([target, rels]) => (
+              <li
+                key={target}
+                className="rounded-lg border border-gray-200 bg-white px-4 py-3"
+              >
+                <p className="font-mono text-sm font-bold text-ui-charcoal">
+                  {target}
+                </p>
+                <ul className="mt-1 space-y-0.5 text-xs text-gray-600">
+                  {rels.map((r) => (
+                    <li key={`${r.name}-${r.type}`}>
+                      <span className="font-mono text-ui-charcoal">
+                        {r.name}
+                      </span>{" "}
+                      <span className="text-[10px] uppercase tracking-wider text-gray-500">
+                        {r.type}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : inferredFks.length > 0 ? (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-xl font-bold text-ui-charcoal">
+              Inferred relationships
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">
+              No relationships are declared in the catalog for this table.
+              The following are inferred from foreign-key columns.
+            </p>
+          </div>
+          <ul className="space-y-2">
+            {inferredFks.map((fk) => (
+              <li
+                key={fk.column}
+                className="rounded-lg border border-gray-200 bg-white px-4 py-3"
+              >
+                <p className="font-mono text-sm font-bold text-ui-charcoal">
+                  {fk.target}
+                </p>
+                <p className="mt-0.5 text-xs text-gray-600">
+                  via{" "}
+                  <span className="font-mono text-ui-charcoal">
+                    {fk.column}
+                  </span>
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
+        Canonical / extension tagging and vocabulary-column detection are
+        v1 heuristics. PII flags and column-level classification are not
+        yet captured upstream and are tracked at{" "}
+        <a
+          href="https://github.com/ui-insight/data-governance/issues/9"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ui-insight/data-governance#9
+        </a>
+        ; vocabulary hyperlinking arrives with{" "}
+        <a
+          href="https://github.com/ui-insight/AISPEG/issues/57"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          #57
+        </a>
+        . See{" "}
+        <a
+          href="https://github.com/ui-insight/AISPEG/issues/53"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          #53
+        </a>{" "}
+        for the full epic and follow-up tracking.
+      </footer>
+    </div>
+  );
+}

--- a/app/standards/data-model/tables/page.tsx
+++ b/app/standards/data-model/tables/page.tsx
@@ -1,0 +1,75 @@
+import DataModelHeader from "@/components/DataModelHeader";
+import TablesExplorer, {
+  type ProjectMeta,
+  type TableRow,
+} from "@/components/TablesExplorer";
+import { projects, tables } from "@/lib/governance/catalog";
+
+export const metadata = {
+  title: "Tables — Data Model",
+  description:
+    "Cross-project index of every table in the IIDS data-governance catalog: canonical UDM tables and per-project extensions.",
+};
+
+export default function TablesIndexPage() {
+  const projectsBySlug = new Map(projects.map((p) => [p.slug, p]));
+
+  const rows: TableRow[] = tables.map((t) => ({
+    project: t.project,
+    projectApplication: projectsBySlug.get(t.project)?.application ?? t.project,
+    name: t.name,
+    kind: t.kind,
+    classification: t.classification,
+    columnCount: t.columns.length,
+    relationshipCount: t.relationships.length,
+  }));
+
+  const projectsList: ProjectMeta[] = projects.map((p) => ({
+    slug: p.slug,
+    application: p.application,
+  }));
+
+  return (
+    <div className="space-y-10">
+      <DataModelHeader active="tables" />
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-bold text-ui-charcoal">
+            Every table, every project
+          </h2>
+          <p className="mt-1 max-w-3xl text-sm text-gray-600">
+            Sortable, filterable index spanning all five governed
+            applications. Click a table name to see columns, relationships,
+            and controlled-vocabulary detection.
+          </p>
+        </div>
+
+        <TablesExplorer rows={rows} projectsList={projectsList} />
+      </section>
+
+      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
+        Canonical / extension tagging is a v1 heuristic against a
+        hand-curated list of research-admin UDM tables. PII flags and
+        column-level data classification are not yet captured upstream and
+        are tracked at{" "}
+        <a
+          href="https://github.com/ui-insight/data-governance/issues/9"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ui-insight/data-governance#9
+        </a>
+        ; see{" "}
+        <a
+          href="https://github.com/ui-insight/AISPEG/issues/53"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          #53
+        </a>{" "}
+        for the full epic.
+      </footer>
+    </div>
+  );
+}

--- a/components/DataModelHeader.tsx
+++ b/components/DataModelHeader.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import { projects } from "@/lib/governance/catalog";
+import { vocabularyGroups } from "@/lib/governance/vocabularies";
+
+const TAB_ITEMS = [
+  { id: "projects" as const, label: "Projects", href: "/standards/data-model" },
+  {
+    id: "tables" as const,
+    label: "Tables",
+    href: "/standards/data-model/tables",
+  },
+  {
+    id: "vocabularies" as const,
+    label: "Vocabularies",
+    href: "/standards/data-model/vocabularies",
+    stub: true,
+  },
+];
+
+export type DataModelTab = "projects" | "tables" | "vocabularies";
+
+function TabBar({ active }: { active: DataModelTab }) {
+  return (
+    <div className="flex gap-6 border-b border-gray-200">
+      {TAB_ITEMS.map((t) => {
+        const isActive = t.id === active;
+        const baseClasses =
+          "-mb-px border-b-2 pb-2 text-xs font-semibold uppercase tracking-wider";
+        const stateClasses = isActive
+          ? "border-brand-clearwater text-ui-charcoal"
+          : "border-transparent text-gray-400 hover:text-ui-charcoal";
+
+        if (t.stub) {
+          return (
+            <span
+              key={t.id}
+              aria-current={isActive ? "page" : undefined}
+              className={`${baseClasses} ${stateClasses} cursor-default`}
+            >
+              {t.label}
+              <span className="ml-1.5 text-[10px] font-normal normal-case tracking-normal text-gray-400">
+                (next)
+              </span>
+            </span>
+          );
+        }
+
+        return (
+          <Link
+            key={t.id}
+            href={t.href}
+            aria-current={isActive ? "page" : undefined}
+            className={`unstyled ${baseClasses} ${stateClasses}`}
+          >
+            {t.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function DataModelHeader({ active }: { active: DataModelTab }) {
+  const totalTables = projects.reduce((sum, p) => sum + p.tableCount, 0);
+  const totalVocab = vocabularyGroups.length;
+
+  return (
+    <header className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-black tracking-tight text-ui-charcoal">
+          Data Model
+        </h1>
+        <p className="mt-3 max-w-3xl text-base leading-relaxed text-gray-700">
+          The AI4RA Unified Data Model and the per-project extensions
+          installed across the IIDS portfolio. Engineers can use this to
+          connect to our data; stakeholders can use it to understand the
+          definitions and business rules. Source of truth:{" "}
+          <a
+            href="https://github.com/ui-insight/data-governance"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ui-insight/data-governance
+          </a>
+          .
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-3 gap-6 text-sm">
+        <div>
+          <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Projects governed
+          </dt>
+          <dd className="mt-1 text-2xl font-black text-ui-charcoal">
+            {projects.length}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Tables across portfolio
+          </dt>
+          <dd className="mt-1 text-2xl font-black text-ui-charcoal">
+            {totalTables}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Vocabulary groups
+          </dt>
+          <dd className="mt-1 text-2xl font-black text-ui-charcoal">
+            {totalVocab}
+          </dd>
+        </div>
+      </dl>
+
+      <TabBar active={active} />
+    </header>
+  );
+}

--- a/components/TablesExplorer.tsx
+++ b/components/TablesExplorer.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { Table, TableKind } from "@/lib/governance/types";
+
+const KIND_LABEL: Record<TableKind, string> = {
+  table: "Table",
+  entity: "Entity",
+  projection_table: "Projection",
+};
+
+type SortKey =
+  | "name"
+  | "project"
+  | "classification"
+  | "kind"
+  | "columns"
+  | "relationships";
+
+type SortDir = "asc" | "desc";
+
+type TypeFilter = "all" | "canonical-udm" | "project-extension";
+
+export interface ProjectMeta {
+  slug: string;
+  application: string;
+}
+
+export interface TableRow {
+  project: string; // slug
+  projectApplication: string;
+  name: string;
+  kind: TableKind;
+  classification: Table["classification"];
+  columnCount: number;
+  relationshipCount: number;
+}
+
+function ClassificationPill({
+  classification,
+}: {
+  classification: Table["classification"];
+}) {
+  const label =
+    classification === "canonical-udm" ? "Canonical UDM" : "Extension";
+  const styles =
+    classification === "canonical-udm"
+      ? "bg-brand-clearwater/10 text-brand-clearwater"
+      : "bg-gray-100 text-gray-700";
+  return (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${styles}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  activeDir,
+  onSort,
+  align = "left",
+  numeric = false,
+}: {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  activeDir: SortDir;
+  onSort: (k: SortKey) => void;
+  align?: "left" | "right";
+  numeric?: boolean;
+}) {
+  const isActive = activeKey === sortKey;
+  const indicator = isActive ? (activeDir === "asc" ? "↑" : "↓") : "";
+  return (
+    <th
+      scope="col"
+      className={`pb-2 ${numeric ? "pl-4" : "pr-4"} text-${align}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={`unstyled inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider transition-colors ${
+          isActive ? "text-ui-charcoal" : "text-gray-500 hover:text-ui-charcoal"
+        }`}
+      >
+        <span>{label}</span>
+        <span className="w-3 text-brand-clearwater">{indicator}</span>
+      </button>
+    </th>
+  );
+}
+
+export default function TablesExplorer({
+  rows,
+  projectsList,
+}: {
+  rows: TableRow[];
+  projectsList: ProjectMeta[];
+}) {
+  const [sortKey, setSortKey] = useState<SortKey>("project");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [projectFilter, setProjectFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+
+  const handleSort = (k: SortKey) => {
+    if (k === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(k);
+      // Default direction: numeric columns desc-first, strings asc-first.
+      setSortDir(k === "columns" || k === "relationships" ? "desc" : "asc");
+    }
+  };
+
+  const filteredSorted = useMemo(() => {
+    const filtered = rows.filter((r) => {
+      if (projectFilter !== "all" && r.project !== projectFilter) return false;
+      if (typeFilter !== "all" && r.classification !== typeFilter) return false;
+      return true;
+    });
+
+    const dirMul = sortDir === "asc" ? 1 : -1;
+    const sorted = [...filtered].sort((a, b) => {
+      switch (sortKey) {
+        case "name":
+          return a.name.localeCompare(b.name) * dirMul;
+        case "project":
+          return (
+            a.projectApplication.localeCompare(b.projectApplication) * dirMul ||
+            a.name.localeCompare(b.name)
+          );
+        case "classification":
+          return a.classification.localeCompare(b.classification) * dirMul;
+        case "kind":
+          return a.kind.localeCompare(b.kind) * dirMul;
+        case "columns":
+          return (a.columnCount - b.columnCount) * dirMul;
+        case "relationships":
+          return (a.relationshipCount - b.relationshipCount) * dirMul;
+        default:
+          return 0;
+      }
+    });
+    return sorted;
+  }, [rows, projectFilter, typeFilter, sortKey, sortDir]);
+
+  const visibleCount = filteredSorted.length;
+
+  return (
+    <div className="space-y-5">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor="project-filter"
+            className="text-[11px] font-semibold uppercase tracking-wider text-gray-500"
+          >
+            Project
+          </label>
+          <select
+            id="project-filter"
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-ui-charcoal focus:border-brand-clearwater focus:outline-none"
+          >
+            <option value="all">All projects</option>
+            {projectsList.map((p) => (
+              <option key={p.slug} value={p.slug}>
+                {p.application}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+            Type
+          </span>
+          <div className="flex overflow-hidden rounded border border-gray-300 text-xs">
+            {(
+              [
+                { v: "all", label: "All" },
+                { v: "canonical-udm", label: "Canonical" },
+                { v: "project-extension", label: "Extension" },
+              ] as { v: TypeFilter; label: string }[]
+            ).map((opt) => {
+              const active = typeFilter === opt.v;
+              return (
+                <button
+                  key={opt.v}
+                  type="button"
+                  onClick={() => setTypeFilter(opt.v)}
+                  aria-pressed={active}
+                  className={`unstyled px-3 py-1 transition-colors ${
+                    active
+                      ? "bg-ui-charcoal text-white"
+                      : "bg-white text-gray-600 hover:text-ui-charcoal"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <p className="ml-auto text-xs text-gray-500">
+          Showing <span className="font-bold text-ui-charcoal">{visibleCount}</span> of {rows.length} tables
+        </p>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        <table className="w-full min-w-[760px] text-left">
+          <thead className="border-b border-gray-200 bg-gray-50">
+            <tr>
+              <SortHeader
+                label="Table"
+                sortKey="name"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortHeader
+                label="Project"
+                sortKey="project"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortHeader
+                label="Type"
+                sortKey="classification"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortHeader
+                label="Kind"
+                sortKey="kind"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortHeader
+                label="Cols"
+                sortKey="columns"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+                numeric
+                align="right"
+              />
+              <SortHeader
+                label="Rels"
+                sortKey="relationships"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={handleSort}
+                numeric
+                align="right"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {filteredSorted.map((r) => (
+              <tr
+                key={`${r.project}/${r.name}/${r.kind}`}
+                className="border-t border-gray-100 transition-colors hover:bg-gray-50"
+              >
+                <td className="py-2 pl-3 pr-4">
+                  <Link
+                    href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
+                      r.name,
+                    )}`}
+                    className="unstyled font-mono text-xs font-semibold text-ui-charcoal hover:text-brand-clearwater"
+                  >
+                    {r.name}
+                  </Link>
+                </td>
+                <td className="py-2 pr-4 text-xs text-gray-700">
+                  <Link
+                    href={`/standards/data-model/projects/${r.project}`}
+                    className="unstyled hover:text-brand-clearwater"
+                  >
+                    {r.projectApplication}
+                  </Link>
+                </td>
+                <td className="py-2 pr-4">
+                  <ClassificationPill classification={r.classification} />
+                </td>
+                <td className="py-2 pr-4 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+                  {KIND_LABEL[r.kind]}
+                </td>
+                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
+                  {r.columnCount}
+                </td>
+                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
+                  {r.relationshipCount}
+                </td>
+              </tr>
+            ))}
+            {filteredSorted.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center text-xs text-gray-500"
+                >
+                  No tables match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Builds on #55 (the data-governance tracer) to make the **Tables** tab live in the Data Model explorer, plus a per-table detail page for every table across every governed project (~71 SSG pages).

- **Tables tab** at `/standards/data-model/tables` — sortable, filterable cross-project index. Sortable by Table, Project, Type, Kind, column count, relationship count. Filterable by project (dropdown) and by Canonical / Extension (segmented control).
- **Table detail** at `/standards/data-model/tables/[project]/[table]` — header (breadcrumb back to project, classification badge, kind label), summary card (description + classification footnote), full column list with PK and Vocab pills, relationships grouped by target (or inferred from FKs when no `relationships` are declared), unique constraints, footer note linking to #53 / #57 / `ui-insight/data-governance#9`.
- Tables tab is no longer marked `(next)`; only Vocabularies remains stubbed.

### Implementation choices

- **Route-split over query-string** (`/standards/data-model/tables` rather than `?tab=tables`). Why: it parallels the existing `/projects/[slug]` detail route, keeps URLs bookmarkable without hydration, and lets each tab page own its own metadata. Each tab page renders the shared `DataModelHeader` (H1, stats, tab bar) so the visual frame stays identical across tabs.
- **Server load, client interactivity.** `app/standards/data-model/tables/page.tsx` is a server component that prebuilds typed `TableRow` props from the typed catalog; `components/TablesExplorer.tsx` is the only client component and owns sort/filter state.
- **Vocabulary-column heuristic (v1).** A column is flagged as a controlled-vocabulary column if its `foreignKey` targets `AllowedValues.*` OR its normalized name matches a known `vocabularyGroups[].group` in the same project's domain/application (case-insensitive, with separator stripping and a trailing `Id` suffix removed). Pill uses `bg-brand-huckleberry/10 text-brand-huckleberry`. **Hyperlinking is deferred to #57** per the brief.

### PII deferral (substitution called out)

The original #56 acceptance criteria asked for **PII column count** as the last numeric column in the cross-project table. PII metadata is not yet in the upstream catalog and is tracked at [`ui-insight/data-governance#9`](https://github.com/ui-insight/data-governance/issues/9). **Substituted with Relationships count.** The Tables footer and the Table-detail footer both link the deferral so reviewers and stakeholders can trace it.

## Acceptance criteria

- [x] Tables tab renders cross-project list from typed catalog data
- [x] Sortable by Table, Project, Type, Column count, Relationships count (also Kind)
- [x] Filterable by project and by Canonical / Extension type
- [x] `/standards/data-model/tables/[project]/[table]` works for every table in every project's catalog (71 pages, all SSG via `generateStaticParams` — confirmed in build output)
- [x] Intra-project FK relationships rendered (grouped list, falls back to inferred FKs)
- [x] Allowed-value-group columns visually distinct (Vocab pill in `brand-huckleberry`; hyperlinking deferred to #57)
- [x] PII / classification badges deferred — explicitly documented above and at `ui-insight/data-governance#9`
- [x] Server-rendered (interactive table is the only client component); brand tokens only; no raw hex
- [x] `npm run build` clean; `npm run lint` clean

## Test plan

- [ ] Visit `/standards/data-model` → Projects tab active; Tables tab is a real link, Vocabularies still stubbed `(next)`
- [ ] Click Tables tab → cross-project index renders with 71 rows, "Showing 71 of 71"
- [ ] Click a column header → sort indicator (`↑`/`↓`) appears; click again to flip; click another header to switch
- [ ] Project filter → dropdown narrows the list; counter updates
- [ ] Type filter → "Canonical" / "Extension" segmented control filters correctly
- [ ] Click a table row → table detail page renders with breadcrumb back to project
- [ ] On a canonical UDM table (e.g. `openera/Personnel`), the classification badge is teal and Vocab pills appear on `Allowed_Value_Group`-style columns
- [ ] On a project-extension table (e.g. `audit-dashboard/AuditReport`), the classification badge is gray and Relationships section shows declared associations
- [ ] On a table with no declared `relationships` but FK columns, the page falls back to "Inferred relationships"
- [ ] Direct-link to `/standards/data-model/tables/openera/Personnel` works (SSG, 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)