### PR TITLE
Cross-project FK detection helper (closes #59)

### DIFF
--- a/lib/governance/cross-project-fk.ts
+++ b/lib/governance/cross-project-fk.ts
@@ -1,0 +1,210 @@
+// Cross-project foreign-key / relationship detection across the governance
+// catalog. A "cross-project reference" is an FK or declared Relationship on
+// table A in project P whose target table name resolves only to project(s)
+// other than P.
+//
+// As of slice #59 the upstream catalog convention does not yet encode
+// cross-project lineage explicitly: every FK string and Relationship.target
+// is a bare table name, and each project's catalog is parsed in isolation.
+// In practice this means `getCrossProjectReferences()` returns an empty
+// array today — see the audit findings in PR #59 / issue
+// `ui-insight/data-governance#<TBD>` for the proposed catalog convention.
+//
+// The helper still ships so consumers (the Table detail page, the Tables
+// tab) can render lineage automatically once the upstream representation
+// lands. Treat the empty case as a useful negative result, not an absence.
+//
+// Detection mechanics:
+//   1. Build a map: tableName -> Set<project> (which projects host a table
+//      by this name). Names are matched case-sensitively because the
+//      catalog is case-sensitive throughout.
+//   2. For each (sourceProject, sourceTable) pair, scan:
+//      a. Every column.foreignKey of the form "<TargetTable>.<col>".
+//         Resolve <TargetTable> against the map. If hosted in another
+//         project AND not in the source project, it's a cross-project FK.
+//      b. Every relationships[].target. Same logic, reason
+//         "declared-relationship".
+//   3. The same target table may live in several other projects (e.g.
+//      a hypothetical institutional `Personnel` shared by both
+//      `audit-dashboard` and `openera`). The helper emits one
+//      CrossProjectRef per resolved (sourceProject, sourceTable, sourceColumn,
+//      targetProject, targetTable) tuple — i.e. it fans out across all
+//      hosting projects so renderers can link to each destination. If
+//      multiple reasons fire on the same column→target pair (FK + a
+//      declared relationship to the same target), the FK wins; renderers
+//      should not show duplicates.
+
+import { tables } from "./catalog";
+import type { Table } from "./types";
+
+export type CrossProjectReason = "foreign-key" | "declared-relationship";
+
+export interface CrossProjectRef {
+  sourceProject: string;
+  sourceTable: string;
+  /** Column name when the reason is "foreign-key"; null for relationships. */
+  sourceColumn: string | null;
+  targetProject: string;
+  targetTable: string;
+  reason: CrossProjectReason;
+}
+
+/** Build the project-hosting map once per call. Cheap (O(tables)); the
+ * catalog is small and the helper is invoked from server components.
+ */
+function buildTableHostMap(): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const t of tables) {
+    let set = map.get(t.name);
+    if (!set) {
+      set = new Set<string>();
+      map.set(t.name, set);
+    }
+    set.add(t.project);
+  }
+  return map;
+}
+
+function parseForeignKeyTargetTable(fk: string): string | null {
+  // Catalog convention: "<TableName>.<column>" — single dot. We tolerate
+  // longer forms ("<TableName>.<column>.<sub>") by taking the head segment.
+  const idx = fk.indexOf(".");
+  if (idx <= 0) return null;
+  return fk.slice(0, idx);
+}
+
+function refKey(r: CrossProjectRef): string {
+  return [
+    r.sourceProject,
+    r.sourceTable,
+    r.sourceColumn ?? "",
+    r.targetProject,
+    r.targetTable,
+    r.reason,
+  ].join("");
+}
+
+function sortRefs(refs: CrossProjectRef[]): CrossProjectRef[] {
+  // Deterministic ordering for stable rendering: source first, then target,
+  // then column, with FK reason ahead of declared-relationship when ties
+  // remain.
+  return refs.sort((a, b) => {
+    const cmp =
+      a.sourceProject.localeCompare(b.sourceProject) ||
+      a.sourceTable.localeCompare(b.sourceTable) ||
+      a.targetProject.localeCompare(b.targetProject) ||
+      a.targetTable.localeCompare(b.targetTable) ||
+      (a.sourceColumn ?? "").localeCompare(b.sourceColumn ?? "");
+    if (cmp !== 0) return cmp;
+    if (a.reason === b.reason) return 0;
+    return a.reason === "foreign-key" ? -1 : 1;
+  });
+}
+
+function collectForTable(
+  source: Table,
+  hostMap: Map<string, Set<string>>,
+): CrossProjectRef[] {
+  const out: CrossProjectRef[] = [];
+  const seen = new Set<string>();
+
+  // Foreign-key columns.
+  for (const c of source.columns) {
+    if (!c.foreignKey) continue;
+    const targetTable = parseForeignKeyTargetTable(c.foreignKey);
+    if (!targetTable) continue;
+    const hosts = hostMap.get(targetTable);
+    if (!hosts) continue;
+    if (hosts.has(source.project)) continue; // resolves locally — not cross-project
+    for (const targetProject of hosts) {
+      const ref: CrossProjectRef = {
+        sourceProject: source.project,
+        sourceTable: source.name,
+        sourceColumn: c.name,
+        targetProject,
+        targetTable,
+        reason: "foreign-key",
+      };
+      const k = refKey(ref);
+      if (!seen.has(k)) {
+        seen.add(k);
+        out.push(ref);
+      }
+    }
+  }
+
+  // Declared relationships.
+  for (const r of source.relationships) {
+    const hosts = hostMap.get(r.target);
+    if (!hosts) continue;
+    if (hosts.has(source.project)) continue;
+    for (const targetProject of hosts) {
+      const ref: CrossProjectRef = {
+        sourceProject: source.project,
+        sourceTable: source.name,
+        sourceColumn: null,
+        targetProject,
+        targetTable: r.target,
+        reason: "declared-relationship",
+      };
+      const k = refKey(ref);
+      // If an FK already covered the same source→target pair on a column,
+      // prefer the FK record and drop the relationship duplicate. We do
+      // this by checking for any existing FK ref on the same source table
+      // pointing at the same target.
+      const fkAlreadyCovers = out.some(
+        (existing) =>
+          existing.reason === "foreign-key" &&
+          existing.sourceProject === ref.sourceProject &&
+          existing.sourceTable === ref.sourceTable &&
+          existing.targetProject === ref.targetProject &&
+          existing.targetTable === ref.targetTable,
+      );
+      if (fkAlreadyCovers) continue;
+      if (!seen.has(k)) {
+        seen.add(k);
+        out.push(ref);
+      }
+    }
+  }
+
+  return out;
+}
+
+/** Every cross-project reference detected in the catalog. */
+export function getCrossProjectReferences(): CrossProjectRef[] {
+  const hostMap = buildTableHostMap();
+  const out: CrossProjectRef[] = [];
+  for (const t of tables) {
+    out.push(...collectForTable(t, hostMap));
+  }
+  return sortRefs(out);
+}
+
+/**
+ * References that point INTO (project, table) — i.e. external tables that
+ * declare an FK or relationship targeting this table. Use on a Table
+ * detail page to render an "Also referenced by" section.
+ */
+export function getInboundReferencesForTable(
+  project: string,
+  table: string,
+): CrossProjectRef[] {
+  return getCrossProjectReferences().filter(
+    (r) => r.targetProject === project && r.targetTable === table,
+  );
+}
+
+/**
+ * References that point OUT FROM (project, table) — i.e. FKs or
+ * relationships on this table whose target lives only in another project.
+ * Use on a Table detail page to render a "References tables in" section.
+ */
+export function getOutboundReferencesForTable(
+  project: string,
+  table: string,
+): CrossProjectRef[] {
+  return getCrossProjectReferences().filter(
+    (r) => r.sourceProject === project && r.sourceTable === table,
+  );
+}


### PR DESCRIPTION
Slice #59 of the Data Governance Explorer epic (#53) — the HITL slice whose deliverable forks on what the audit reveals.

## Phase 1 — Audit findings

Walked all five vendored catalogs (`vendor/data-governance/catalog/*.json`):

| Metric | Value |
|---|---|
| Total tables | 71 |
| Distinct table names | 67 |
| Tables that share a name across projects | 4 |
| FK strings whose target table exists *only* in another project | **0** |
| Relationships whose `target` exists *only* in another project | **0** |
| Orphan FKs (target nowhere in catalog) | 0 |

Detection ran against `Column.foreignKey` (parsing the head segment before the first `.`) and `Table.relationships[].target`, comparing the resolved target table name to a `tableName -> Set<project>` host map. A reference is cross-project iff the target table exists in projects *other than* the source's project AND not in the source's project.

The four name-shared tables — `AllowedValues`, `ActivityLog`, `Document`, `users` — are pattern-shared (each project owns its own copy). They are not encoded as pointers between projects.

Spot-checks of FK targets used inside catalogs (representative, all resolve locally):

- `audit-dashboard.AuditReport.Source_Document_ID` -> `audit-dashboard.Document.Document_ID`
- `audit-dashboard.Observation.Audit_Report_ID` -> `audit-dashboard.AuditReport.Audit_Report_ID`
- `openera.Project.Project_Type_Value_ID` -> `openera.AllowedValues.Allowed_Value_ID`
- `openera.ConflictOfInterest.Personnel_ID` -> `openera.Personnel.Personnel_ID`
- `ucm-daily-register.newsletter_sections.Id` cluster — all resolve to other `ucm-daily-register` tables

The implied institutional dependencies (e.g. \"every project that references Personnel ought to point at the canonical OpenERA `Personnel`\") are not captured anywhere in the catalog.

## Phase 2 — Fork taken: **not-found**

Per slice #59's contract, the deliverable is:

1. Ship the detection helper anyway (the empty case is a useful negative result, and the function will return data once upstream adds it).
2. Document the gap. Open a follow-up against `ui-insight/data-governance` proposing a catalog convention for cross-project lineage. Open a follow-up AISPEG issue noting the rendering is paused on the upstream convention.

### What ships in this PR

`lib/governance/cross-project-fk.ts` exporting:

- `getCrossProjectReferences(): CrossProjectRef[]`
- `getInboundReferencesForTable(project, table)` — for the future \"Also referenced by\" section
- `getOutboundReferencesForTable(project, table)` — for the future \"References tables in\" section

`reason: \"foreign-key\" | \"declared-relationship\"`. Returns sorted, deduplicated refs. When both an FK column and a declared relationship target the same (sourceTable → targetTable) pair, the FK record wins (one row per link, never two).

### What does NOT ship

- No \"Also referenced by\" section on the Table detail page (no data to render)
- No \"Externally referenced\" column on the Tables tab (would always be `no`)

These are not faked — once the upstream convention lands, the helper starts returning data and the rendering work is small.

## Follow-ups opened

- `ui-insight/data-governance#12` — Catalog convention: encode cross-project lineage. Proposes two representations (project-prefixed FK strings or a top-level `cross_project_references` array) and recommends the latter as canonical.
- `ui-insight/AISPEG#67` — Render cross-project lineage on Table detail + Tables tab (paused on upstream convention).

## Anything surprising

- The catalog is more locally-scoped than expected. Even within a single project, declared `relationships[]` are sometimes absent on tables that have FK columns — the table-detail page already falls back to inferred FK relationships in that case.
- `users` tables appear in two projects (`audit-dashboard` and `openera`), strongly hinting at an institutional auth identity. If these were ever federated, lineage would explode in size — worth designing for from day one.

## Acceptance criteria

- [x] Phase 1 audit run; findings documented
- [x] Phase 2 path chosen and executed; \"not-found\" fork
- [x] Helper module shipped (works against today's empty case, lights up automatically when upstream lands)
- [x] `ui-insight/data-governance` upstream issue opened (#12)
- [x] AISPEG follow-up rendering issue opened (#67)
- [x] `npm run lint` clean
- [x] `npm run build` clean (75 routes prerendered, including all `/standards/data-model/tables/[project]/[table]` pages)

## Test plan

- [ ] CI green on the PR
- [ ] Spot-check `getCrossProjectReferences()` returns `[]` against today's catalog (run from a repl or temp script — the helper is pure data).
- [ ] When `data-governance#12` lands and a single cross-project FK is added, the Table detail page automatically grows an \"Also referenced by\" section without further code changes (this is the ship-time follow-up tracked in #67).

Closes #59.