### PR TITLE
Drop meeting-agenda framing from /standards UI

### DIFF
--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -160,7 +160,7 @@ export default function StandardsWatchPage() {
       <section className="space-y-4">
         <div>
           <h2 className="text-xl font-bold text-ui-charcoal">
-            Agenda Item I — Software Development Standards
+            Software Development Standards
           </h2>
           <p className="mt-1 text-sm text-gray-600">
             Requested deliverables governing how applications are architected,
@@ -178,7 +178,7 @@ export default function StandardsWatchPage() {
       <section className="space-y-4">
         <div>
           <h2 className="text-xl font-bold text-ui-charcoal">
-            Agenda Item II — User Experience Standards
+            User Experience Standards
           </h2>
           <p className="mt-1 text-sm text-gray-600">
             Requested deliverables governing how University of Idaho

--- a/components/StandardsSubNav.tsx
+++ b/components/StandardsSubNav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const subNavItems = [
-  { href: "/standards", label: "Standards Watch" },
+  { href: "/standards", label: "Standards" },
   { href: "/standards/data-model", label: "Data Model" },
 ];
 


### PR DESCRIPTION
## Summary

Two cosmetic copy edits requested in review.

| Where | Was | Now |
|---|---|---|
| `components/StandardsSubNav.tsx` | "Standards Watch" tab label | "Standards" |
| `app/standards/page.tsx` H2 | "Agenda Item I — Software Development Standards" | "Software Development Standards" |
| `app/standards/page.tsx` H2 | "Agenda Item II — User Experience Standards" | "User Experience Standards" |

The meeting-agenda framing was an artifact of pasting the original requirements list in from an agenda doc. The ledger entries themselves carry the substance now.

Internal file naming (`lib/standards-watch.ts`, the `standardsWatch` export, REFACTOR.md sprint history) is unchanged — those names don't appear in the UI and bulk-renaming would churn imports across the route for no user-visible payoff.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Reviewer: visit `/standards` on dev — verify the tab reads "Standards" (not "Standards Watch") and the two H2 section headings are now bare titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)