### PR TITLE
Stakeholder framing on Data Model detail pages (closes #72)

### DIFF
--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   getTablesForProject,
   projects,
 } from "@/lib/governance/catalog";
+import { getProjectFraming } from "@/lib/governance/project-framing";
 import type { Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -167,64 +168,93 @@ export default async function ProjectDetailPage({
     (t) => t.classification === "project-extension",
   );
 
+  const framing = getProjectFraming(project.slug);
+
   return (
     <div className="space-y-10">
       <header>
         <p className="text-xs">
           <Link href="/standards/data-model">← Data Model</Link>
         </p>
-        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {project.domain}
         </p>
-        <h1 className="mt-1 text-3xl font-black tracking-tight text-ui-charcoal">
+        <h1 className="mt-1 text-3xl font-black tracking-tight text-brand-black">
           {project.application}
         </h1>
-        <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-4">
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Tables
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {project.tableCount}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Canonical UDM
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {project.canonicalUdmCount}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Project extensions
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {project.projectExtensionCount}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Repository
-            </dt>
-            <dd className="mt-1">
-              <a
-                href={project.repository}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs"
-              >
-                {project.repository.replace("https://github.com/", "")}
-              </a>
-            </dd>
-          </div>
-        </dl>
+
+        {framing && (
+          <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+            {framing.lede}
+          </p>
+        )}
+
+        <div className="mt-6 grid gap-x-8 gap-y-4 md:grid-cols-[1.5fr_1fr]">
+          {/* Left: ownership */}
+          <dl className="space-y-3 text-sm">
+            {framing && (
+              <>
+                <div>
+                  <dt className="text-[11px] font-medium uppercase tracking-wider text-ink-subtle">
+                    Home unit
+                  </dt>
+                  <dd className="mt-0.5 text-brand-black">{framing.homeUnit}</dd>
+                </div>
+                <div>
+                  <dt className="text-[11px] font-medium uppercase tracking-wider text-ink-subtle">
+                    {framing.owners.length === 1 ? "Operational owner" : "Operational owners"}
+                  </dt>
+                  <dd className="mt-0.5 text-brand-black">
+                    {framing.owners.map((o, i) => (
+                      <span key={o.name}>
+                        {i > 0 && ", "}
+                        <span className="font-semibold">{o.name}</span>
+                        {o.title && (
+                          <span className="text-ink-muted"> · {o.title}</span>
+                        )}
+                      </span>
+                    ))}
+                  </dd>
+                </div>
+              </>
+            )}
+          </dl>
+
+          {/* Right: facts */}
+          <dl className="space-y-3 text-sm md:border-l md:border-hairline md:pl-8">
+            <div>
+              <dt className="text-[11px] font-medium uppercase tracking-wider text-ink-subtle">
+                Tables in catalog
+              </dt>
+              <dd className="mt-0.5 text-brand-black">
+                <span className="font-semibold">{project.tableCount}</span> total
+                {" — "}
+                {project.canonicalUdmCount} canonical, {project.projectExtensionCount} project-specific
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-medium uppercase tracking-wider text-ink-subtle">
+                Repository
+              </dt>
+              <dd className="mt-0.5">
+                <a
+                  href={project.repository}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs"
+                >
+                  {project.repository.replace("https://github.com/", "")}
+                </a>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
         {(project.techStack.backend ||
           project.techStack.frontend ||
           project.techStack.database) && (
-          <p className="mt-4 max-w-2xl text-xs text-gray-600">
-            <span className="font-semibold text-ui-charcoal">Stack:</span>{" "}
+          <p className="mt-6 max-w-2xl text-xs text-ink-muted">
+            <span className="font-semibold text-brand-black">Stack:</span>{" "}
             {[
               project.techStack.backend,
               project.techStack.frontend,
@@ -235,8 +265,8 @@ export default async function ProjectDetailPage({
           </p>
         )}
         {project.runtimeModes && project.runtimeModes.length > 0 && (
-          <p className="mt-1 max-w-2xl text-xs text-gray-600">
-            <span className="font-semibold text-ui-charcoal">Runtime:</span>{" "}
+          <p className="mt-1 max-w-2xl text-xs text-ink-muted">
+            <span className="font-semibold text-brand-black">Runtime:</span>{" "}
             {project.runtimeModes.join(" / ")}
           </p>
         )}

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -7,6 +7,7 @@ import {
   tables,
 } from "@/lib/governance/catalog";
 import { resolveVocabularyGroupForColumn } from "@/lib/governance/vocabulary-usage";
+import { getProjectFraming } from "@/lib/governance/project-framing";
 import type { Column, Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -159,6 +160,8 @@ export default async function TableDetailPage({
       ? "Adopted from the AI4RA Unified Data Model — naming and shape follow the institutional standard."
       : "Specific to this project — workflow, tooling, or domain-specific entities not part of the canonical UDM.";
 
+  const projectFraming = getProjectFraming(project.slug);
+
   return (
     <div className="space-y-10">
       <header>
@@ -167,18 +170,30 @@ export default async function TableDetailPage({
             ← {project.application}
           </Link>
         </p>
-        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {project.domain}
         </p>
         <div className="mt-1 flex flex-wrap items-center gap-3">
-          <h1 className="font-mono text-3xl font-black tracking-tight text-ui-charcoal">
+          <h1 className="font-mono text-3xl font-black tracking-tight text-brand-black">
             {table.name}
           </h1>
           <ClassificationBadge classification={table.classification} />
-          <span className="text-[10px] font-medium uppercase tracking-wider text-gray-500">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-ink-subtle">
             {KIND_LABEL[table.kind]}
           </span>
         </div>
+
+        {projectFraming && (
+          <p className="mt-3 text-sm text-ink-muted">
+            <span className="font-semibold text-brand-black">{project.application}</span>
+            {" "}is operated by{" "}
+            <span className="font-semibold text-brand-black">
+              {projectFraming.owners.map((o) => o.name).join(", ")}
+            </span>
+            {" · "}
+            {projectFraming.homeUnit}
+          </p>
+        )}
 
         <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-4">
           <div>

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { vocabularyGroups } from "@/lib/governance/vocabularies";
 import { getProject } from "@/lib/governance/catalog";
+import { getVocabularyDomainFraming } from "@/lib/governance/project-framing";
 import {
   getProjectsUsingGroup,
   type MatchReason,
@@ -93,17 +94,19 @@ export default async function VocabularyDetailPage({
     0,
   );
 
+  const domainFraming = getVocabularyDomainFraming(vg.domain);
+
   return (
     <div className="space-y-10">
       <header>
         <p className="text-xs">
           <Link href="/standards/data-model/vocabularies">← Vocabularies</Link>
         </p>
-        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {vg.domain}
         </p>
         <div className="mt-1 flex flex-wrap items-center gap-3">
-          <h1 className="font-mono text-3xl font-black tracking-tight text-ui-charcoal">
+          <h1 className="font-mono text-3xl font-black tracking-tight text-brand-black">
             {vg.group}
           </h1>
           {vg.application && (
@@ -112,6 +115,18 @@ export default async function VocabularyDetailPage({
             </span>
           )}
         </div>
+
+        {domainFraming && (
+          <p className="mt-3 text-sm text-ink-muted">
+            <span className="font-semibold text-brand-black">{vg.domain}</span>{" "}
+            vocabularies are stewarded by{" "}
+            <span className="font-semibold text-brand-black">
+              {domainFraming.owners.map((o) => o.name).join(", ")}
+            </span>
+            {" · "}
+            {domainFraming.homeUnit}
+          </p>
+        )}
 
         <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-3">
           <div>

--- a/lib/governance/project-framing.ts
+++ b/lib/governance/project-framing.ts
@@ -1,0 +1,111 @@
+// Stakeholder framing for the Data Governance Explorer detail pages.
+//
+// The governance catalog (lib/governance/catalog.ts) carries technical metadata —
+// table counts, repository URLs, runtime modes. It does not carry the
+// stakeholder-readable framing the .impeccable.md principle #1 requires
+// ("every claim names a human"). This module supplies that.
+//
+// Source-of-truth note: 4 of 5 governance projects (audit-dashboard, processmapping,
+// stratplan, ucm-daily-register) also exist in lib/portfolio.ts. The lede / owner
+// data here is hand-written for the data-model surface specifically; when a
+// fact diverges between this file and portfolio.ts, treat portfolio.ts as
+// canonical and update here. OpenERA is not yet a portfolio entry — see
+// `portfolioSlug: undefined` below.
+
+interface ProjectOwner {
+  name: string;
+  title?: string;
+}
+
+export interface ProjectFraming {
+  /** Matches `slug` in lib/governance/catalog.ts. */
+  slug: string;
+  /** 1–2 sentence stakeholder-readable framing of what the project does. */
+  lede: string;
+  /** UI home unit whose work depends on the project. */
+  homeUnit: string;
+  /** Operational owner(s) — the people accountable for the outcome, not the build. */
+  owners: ProjectOwner[];
+  /** Matches `slug` in lib/portfolio.ts where the project is also a portfolio entry. */
+  portfolioSlug?: string;
+}
+
+const FRAMINGS: ProjectFraming[] = [
+  {
+    slug: "audit-dashboard",
+    portfolioSlug: "audit-dashboard",
+    lede:
+      "AI-assisted audit-observation lifecycle tracking. Ingests audit-report PDFs via OCR + LLM extraction, then carries corrective action items through closure for the Division of Financial Affairs.",
+    homeUnit: "Division of Financial Affairs",
+    owners: [{ name: "Kim Salisbury" }],
+  },
+  {
+    slug: "openera",
+    // TODO: Add a portfolio entry for OpenERA in lib/portfolio.ts so this
+    // surface can join cleanly to the rest of /portfolio. Until then, the
+    // owner below is the ORED default — confirm with Sarah before public
+    // ramp-up.
+    lede:
+      "OpenERA is the institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration.",
+    homeUnit: "Office of Research and Economic Development",
+    owners: [{ name: "Sarah Martonick", title: "UI implementation owner" }],
+  },
+  {
+    slug: "processmapping",
+    portfolioSlug: "processmapping",
+    lede:
+      "Process intelligence platform for Research Administration. Documents who does what with which systems, surfaces process/tooling gaps, and feeds requirements for OpenERA and adjacent tools.",
+    homeUnit: "Office of Sponsored Programs (ORED)",
+    owners: [{ name: "Barrie Robison" }],
+  },
+  {
+    slug: "stratplan",
+    portfolioSlug: "stratplan",
+    lede:
+      "Executive visibility into 337 tactics aligned to the UI 2025–2030 Strategic Plan. Alignment, synergy, coverage, and investment-portfolio analytics for the Office of the President.",
+    homeUnit: "Office of the President",
+    owners: [{ name: "Michele Bartlett" }],
+  },
+  {
+    slug: "ucm-daily-register",
+    portfolioSlug: "ucm-daily-register",
+    lede:
+      "AI-assisted newsletter production pipeline for The Daily Register and My UI. Submission intake, AP+UI style enforcement, word-level diff review, and branded export for University Communications and Marketing.",
+    homeUnit: "University Communications and Marketing",
+    owners: [
+      { name: "Joy Bauer" },
+      { name: "Leigh Cooper" },
+      { name: "Jodi Walker" },
+    ],
+  },
+];
+
+export function getProjectFraming(slug: string): ProjectFraming | undefined {
+  return FRAMINGS.find((f) => f.slug === slug);
+}
+
+// Vocabulary-domain → governance-project slug that owns the domain.
+// Domains observed in lib/governance/vocabularies.ts: audit, communications,
+// processmapping, research-admin. research-admin is shared across multiple
+// projects (OpenERA, Vandalizer); we attribute to OpenERA as the canonical
+// UDM implementor for the domain.
+const VOCABULARY_DOMAIN_PROJECT: Record<string, string> = {
+  audit: "audit-dashboard",
+  communications: "ucm-daily-register",
+  processmapping: "processmapping",
+  "research-admin": "openera",
+};
+
+export function getVocabularyDomainFraming(domain: string): ProjectFraming | undefined {
+  const slug = VOCABULARY_DOMAIN_PROJECT[domain];
+  if (!slug) return undefined;
+  return getProjectFraming(slug);
+}
+
+/** Render owners as "Name, Name, Name +N" with optional title on the first. */
+export function formatOwners(owners: ProjectOwner[], maxVisible = 3): string {
+  if (owners.length === 0) return "";
+  const visible = owners.slice(0, maxVisible).map((o) => o.name);
+  const overflow = owners.length > maxVisible ? ` +${owners.length - maxVisible}` : "";
+  return visible.join(", ") + overflow;
+}


### PR DESCRIPTION
## Summary

Closes #72. Every detail page in the Data Governance Explorer now opens with a prose lede and names the human accountable for the work — satisfying [`.impeccable.md`](https://github.com/ui-insight/AISPEG/blob/main/.impeccable.md) principle #1 ("every claim names a human"). The /critique deep-dive ranked this the load-bearing item under #61.

## What changed

### New: [lib/governance/project-framing.ts](https://github.com/ui-insight/AISPEG/blob/feat/issue-72-stakeholder-framing/lib/governance/project-framing.ts)

A small overlay module that carries — for each of the 5 governance projects — a 1–2 sentence stakeholder-readable lede, a home unit, and operational-owner names. Plus a vocabulary-domain → project map so the vocabulary detail page can attribute domain stewardship.

Hand-written rather than joined from `lib/portfolio.ts` because:
- 4 of 5 governance projects (audit-dashboard, processmapping, stratplan, ucm-daily-register) exist in both — the data-model surface wants a tighter voice than the portfolio's longer descriptions
- OpenERA is **not yet a portfolio entry** — the overlay carries its data directly with a TODO comment. Owner is Sarah Martonick by inference from other ORED projects; **confirm before public ramp-up**.

### `/standards/data-model/projects/[slug]`

Before: 4-cell stat grid (Tables / Canonical UDM / Project Extensions / Repository) above the table list, no narrative, no owner.

After:
- Prose lede explaining what the project does institutionally
- 2-column layout: home unit + operational owner(s) on left, count metrics + repository on right (counts inlined to "32 total — 20 canonical, 12 project-specific")

### `/standards/data-model/tables/[project]/[table]`

Adds owner attribution sentence below the H1 + classification badge:

> *OpenERA is operated by **Sarah Martonick** · Office of Research and Economic Development*

Stat grid retained (collapsing it is #73's job).

### `/standards/data-model/vocabularies/[domain]/[group]`

Adds owner attribution sentence below the H1 + application chip:

> *audit vocabularies are stewarded by **Kim Salisbury** · Division of Financial Affairs*

Stat grid retained (collapsing it is #73's job).

## Acceptance criteria

- [x] Every project detail page opens with a prose lede, not a stat grid
- [x] At least one named human appears on every detail page in the Explorer
- [x] Slug join between `lib/governance/catalog.ts` and `lib/portfolio.ts` verified — surfaced the OpenERA gap
- [x] No regressions in `npm run build` or `npm run lint`

## Related followups

- **OpenERA portfolio gap**: this PR works around it via the overlay; the portfolio itself should add a proper entry (small standalone task, separate from this).
- **Stat-grid distill** (issue #73): collapses the remaining `<dl>` blocks on table-detail and vocabulary-detail. Coordinated with this PR but scoped separately.
- **Zero-state cells** (issue #74): same files. Bundle if scope permits.

## Test plan

- [x] Navigate `/standards/data-model/projects/openera` — prose lede, owner shown
- [x] Navigate `/standards/data-model/projects/processmapping` — confirms 4 of 5 governance projects render
- [x] Navigate `/standards/data-model/tables/openera/AllowedValues` — owner attribution rendered
- [x] Navigate `/standards/data-model/vocabularies/audit/DocumentType` — domain stewardship shown
- [x] `npx tsc --noEmit` clean
- [ ] CI Production Build job
- [ ] Reviewer to confirm OpenERA owner attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)