### PR TITLE
Distill stat-grids on table + vocabulary detail pages (closes #73, #74)

### DIFF
--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -195,42 +195,42 @@ export default async function TableDetailPage({
           </p>
         )}
 
-        <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-4">
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Columns
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {table.columns.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Relationships
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {table.relationships.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Vocab columns
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {vocabColumnCount}
-            </dd>
-          </div>
-          {table.modelClass && (
-            <div>
-              <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-                Model class
-              </dt>
-              <dd className="mt-1 font-mono text-xs font-bold text-ui-charcoal">
-                {table.modelClass}
-              </dd>
-            </div>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-brand-black">
+          <span className="font-bold">{table.columns.length}</span>{" "}
+          {table.columns.length === 1 ? "column" : "columns"}
+          {vocabColumnCount > 0 && (
+            <>
+              ,{" "}
+              <span className="font-bold">{vocabColumnCount}</span>{" "}
+              {vocabColumnCount === 1
+                ? "drawn from a controlled vocabulary"
+                : "drawn from controlled vocabularies"}
+            </>
           )}
-        </dl>
+          {table.relationships.length > 0 ? (
+            <>
+              ,{" "}
+              <span className="font-bold">{table.relationships.length}</span>{" "}
+              {table.relationships.length === 1
+                ? "declared relationship"
+                : "declared relationships"}
+              .
+            </>
+          ) : inferredFks.length > 0 ? (
+            <>. No relationships declared; {inferredFks.length} inferred from foreign keys.</>
+          ) : (
+            <>. No relationships declared in the catalog.</>
+          )}
+        </p>
+
+        {table.modelClass && (
+          <p className="mt-1 max-w-3xl text-xs text-ink-muted">
+            <span className="font-semibold text-brand-black">Model class:</span>{" "}
+            <code className="rounded bg-surface-alt px-1 py-0.5 font-mono text-brand-black">
+              {table.modelClass}
+            </code>
+          </p>
+        )}
       </header>
 
       <section className="rounded-lg border border-gray-200 bg-white p-5">

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -128,32 +128,22 @@ export default async function VocabularyDetailPage({
           </p>
         )}
 
-        <dl className="mt-6 grid grid-cols-2 gap-x-8 gap-y-3 text-sm md:grid-cols-3">
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Allowed values
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {vg.values.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Projects using
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {usages.length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[11px] font-medium uppercase tracking-wider text-gray-500">
-              Column references
-            </dt>
-            <dd className="mt-1 font-bold text-ui-charcoal">
-              {totalColumnHits}
-            </dd>
-          </div>
-        </dl>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-brand-black">
+          <span className="font-bold">{vg.values.length}</span>{" "}
+          {vg.values.length === 1 ? "allowed value" : "allowed values"}
+          {usages.length === 0 ? (
+            <>. Not yet referenced by any catalog table.</>
+          ) : (
+            <>
+              , used by{" "}
+              <span className="font-bold">{usages.length}</span>{" "}
+              {usages.length === 1 ? "project" : "projects"} across{" "}
+              <span className="font-bold">{totalColumnHits}</span>{" "}
+              {totalColumnHits === 1 ? "column reference" : "column references"}
+              .
+            </>
+          )}
+        </p>
       </header>
 
       {vg.description && (


### PR DESCRIPTION
## Summary

Closes #73 and #74. Removes the 4-cell and 3-cell `<dl>` stat blocks at the top of the table-detail and vocabulary-detail pages, replacing each with a single prose sentence that handles zero-state naturally.

The stat-grid pattern was the surface's main remaining slop tell after PR #71's index sweep — the same SaaS-dashboard silhouette in lighter clothing. After this PR, the data-model surface no longer renders a hero-metric template anywhere.

## What changed

### `/standards/data-model/tables/[project]/[table]`

**Before**: 4-cell dl (Columns / Relationships / Vocab columns / Model class) above the description.

**After**: one prose line that handles singular/plural and 0/N+ for columns, vocab columns, declared relationships, and inferred FKs. Model class moved to a small follow-up line, only rendered when set.

Examples:
- `5 columns. No relationships declared in the catalog.`
- `5 columns, 1 declared relationship.`
- `17 columns, 2 drawn from controlled vocabularies, 3 declared relationships.`

### `/standards/data-model/vocabularies/[domain]/[group]`

**Before**: 3-cell dl (Allowed values / Projects using / Column references) — and on unused groups (e.g. `ActionItemStatus`), three bold "0" cards under one heading. Textbook AI-dashboard-without-data anti-pattern.

**After**: one prose line that branches on usage:

- `4 allowed values, used by 1 project across 1 column reference.`
- `5 allowed values. Not yet referenced by any catalog table.`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Visual check: `/tables/openera/AllowedValues` (0 relationships) — prose reads correctly, no stat grid
- [x] Visual check: `/tables/openera/Organization` (1 relationship, singular) — singular/plural handling correct
- [x] Visual check: `/vocabularies/audit/DocumentType` (used) — usage prose renders
- [x] Visual check: `/vocabularies/audit/ActionItemStatus` (zero usage) — collapses to single explanatory sentence
- [ ] CI Production Build job

## Related

- Stacks on PR #80 (now merged) which handled the project-detail page's stat-grid as part of the stakeholder-framing work
- Both issues are children of #61 (stakeholder polish epic)
- Next up logically: #76 (mobile responsive — same files), #75 (Tables tab IA reframe — bigger move, may want /shape session first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)