### PR TITLE
Mobile responsive: collapse data-model tables to card lists below sm (closes #76)

### DIFF
--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -275,7 +275,47 @@ export default async function TableDetailPage({
           </p>
         </div>
 
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        {/* Mobile: card list (< sm) */}
+        <ul className="space-y-2 sm:hidden">
+          {table.columns.map((c, i) => {
+            const vocabKey = vocabKeys[i] ?? null;
+            const meta = [
+              c.type,
+              c.nullable === true
+                ? "nullable"
+                : c.nullable === false
+                  ? "required"
+                  : null,
+              c.foreignKey ? `FK → ${c.foreignKey}` : null,
+            ].filter(Boolean);
+            return (
+              <li
+                key={c.name}
+                className="rounded-lg border border-gray-200 bg-white p-3"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="break-all font-mono text-sm font-semibold text-ui-charcoal">
+                    {c.name}
+                  </span>
+                  {c.primaryKey && (
+                    <span className="rounded bg-ui-gold/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+                      PK
+                    </span>
+                  )}
+                  {vocabKey && (
+                    <VocabPill domain={vocabKey.domain} group={vocabKey.group} />
+                  )}
+                </div>
+                <p className="mt-1.5 break-words font-mono text-xs text-gray-600">
+                  {meta.join(" · ")}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Tablet+: schema table (≥ sm) */}
+        <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
           <table className="w-full min-w-[720px] text-left">
             <thead className="border-b border-gray-200 bg-gray-50">
               <tr className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -164,7 +164,33 @@ export default async function VocabularyDetailPage({
           </p>
         </div>
 
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        {/* Mobile: card list (< sm) */}
+        <ul className="space-y-2 sm:hidden">
+          {sortedValues.map((v) => (
+            <li
+              key={v.code}
+              className="rounded-lg border border-gray-200 bg-white p-3"
+            >
+              <div className="flex flex-wrap items-baseline gap-2">
+                <span className="break-all font-mono text-sm font-semibold text-ui-charcoal">
+                  {v.code}
+                </span>
+                <span className="text-sm text-ui-charcoal">{v.label}</span>
+                {typeof v.displayOrder === "number" && (
+                  <span className="font-mono text-[11px] text-gray-500">
+                    #{v.displayOrder}
+                  </span>
+                )}
+              </div>
+              {v.description && (
+                <p className="mt-1.5 text-xs text-gray-600">{v.description}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {/* Tablet+: values table (≥ sm) */}
+        <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
           <table className="w-full min-w-[640px] text-left">
             <thead className="border-b border-gray-200 bg-gray-50">
               <tr className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">

--- a/components/TablesExplorer.tsx
+++ b/components/TablesExplorer.tsx
@@ -214,8 +214,56 @@ export default function TablesExplorer({
         </p>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+      {/* Mobile: card list (< sm) */}
+      <div className="space-y-2 sm:hidden">
+        {filteredSorted.map((r) => (
+          <article
+            key={`${r.project}/${r.name}/${r.kind}`}
+            className="rounded-lg border border-gray-200 bg-white p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <Link
+                  href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
+                    r.name,
+                  )}`}
+                  className="unstyled break-all font-mono text-sm font-semibold text-ui-charcoal hover:text-brand-clearwater"
+                >
+                  {r.name}
+                </Link>
+                <Link
+                  href={`/standards/data-model/projects/${r.project}`}
+                  className="unstyled mt-1 block text-xs text-gray-600 hover:text-brand-clearwater"
+                >
+                  {r.projectApplication}
+                </Link>
+              </div>
+              <ClassificationPill classification={r.classification} />
+            </div>
+            <p className="mt-3 text-xs text-gray-500">
+              <span className="font-medium uppercase tracking-wider">
+                {KIND_LABEL[r.kind]}
+              </span>
+              <span className="mx-1.5">·</span>
+              <span className="font-mono tabular-nums text-ui-charcoal">
+                {r.columnCount} {r.columnCount === 1 ? "col" : "cols"}
+              </span>
+              <span className="mx-1.5">·</span>
+              <span className="font-mono tabular-nums text-ui-charcoal">
+                {r.relationshipCount} {r.relationshipCount === 1 ? "rel" : "rels"}
+              </span>
+            </p>
+          </article>
+        ))}
+        {filteredSorted.length === 0 && (
+          <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-xs text-gray-500">
+            No tables match the current filters.
+          </p>
+        )}
+      </div>
+
+      {/* Tablet+: sortable table (≥ sm) */}
+      <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
         <table className="w-full min-w-[760px] text-left">
           <thead className="border-b border-gray-200 bg-gray-50">
             <tr>

--- a/components/VocabulariesExplorer.tsx
+++ b/components/VocabulariesExplorer.tsx
@@ -227,8 +227,51 @@ export default function VocabulariesExplorer({
         </p>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+      {/* Mobile: card list (< sm) */}
+      <div className="space-y-2 sm:hidden">
+        {filteredSorted.map((r) => (
+          <article
+            key={`${r.domain}/${r.group}`}
+            className="rounded-lg border border-gray-200 bg-white p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <Link
+                  href={`/standards/data-model/vocabularies/${encodeURIComponent(
+                    r.domain,
+                  )}/${encodeURIComponent(r.group)}`}
+                  className="unstyled break-all font-mono text-sm font-semibold text-ui-charcoal hover:text-brand-clearwater"
+                >
+                  {r.group}
+                </Link>
+                <p className="mt-1 text-xs text-gray-600">
+                  {r.application ?? (
+                    <span className="italic text-gray-400">shared</span>
+                  )}
+                </p>
+              </div>
+              <DomainBadge domain={r.domain} />
+            </div>
+            <p className="mt-3 text-xs text-gray-500">
+              <span className="font-mono tabular-nums text-ui-charcoal">
+                {r.valueCount} {r.valueCount === 1 ? "value" : "values"}
+              </span>
+              <span className="mx-1.5">·</span>
+              <span className="font-mono tabular-nums text-ui-charcoal">
+                {r.projectsUsing} {r.projectsUsing === 1 ? "project" : "projects"}
+              </span>
+            </p>
+          </article>
+        ))}
+        {filteredSorted.length === 0 && (
+          <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-xs text-gray-500">
+            No vocabulary groups match the current filters.
+          </p>
+        )}
+      </div>
+
+      {/* Tablet+: sortable table (≥ sm) */}
+      <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
         <table className="w-full min-w-[760px] text-left">
           <thead className="border-b border-gray-200 bg-gray-50">
             <tr>


### PR DESCRIPTION
## Summary

Closes #76. Below the `sm` breakpoint (< 640px), all four heavy tables in the Data Governance Explorer collapse to vertical card lists. Above `sm`, the sortable tables render exactly as before.

A Dean checking on mobile previously saw only the table-name column and a sliver of the project column; the canonical/extension classification — the most institutionally meaningful column — was invisible past the right edge of the viewport.

## What changed

| Surface | Mobile | Desktop |
|---|---|---|
| `/tables` (TablesExplorer) | Card per row: name + project + classification pill + kind · cols · rels | Sortable table (unchanged) |
| `/vocabularies` (VocabulariesExplorer) | Card per row: group + domain badge + application + values · projects | Sortable table (unchanged) |
| `/tables/[project]/[table]` (column list) | Card per column: name + PK/Vocab badges + type · nullability · FK target | Schema table (unchanged) |
| `/vocabularies/[domain]/[group]` (allowed values) | Card per value: code + label + #order + description | Values table (unchanged) |

Singular/plural handling on counts ("1 col" vs "2 cols", "1 project" vs "2 projects") matches PR #81's prose-summary work.

## Implementation

Pure Tailwind responsive classes — no JS resize listeners, no hydration cost:

```jsx
{/* Mobile: card list (< sm) */}
<ul className="space-y-2 sm:hidden">...</ul>

{/* Tablet+: sortable table (≥ sm) */}
<div className="hidden ... sm:block">...</div>
```

Both blocks consume the same filtered/sorted data, so filter and sort UI continues to work in both modes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `/tables` at 375px (mobile preset) — cards render, filter chips wrap, no horizontal scroll
- [x] `/vocabularies` at 375px — cards render, domain filter chips wrap correctly
- [x] `/tables/openera/Organization` at 375px — column cards render, FK targets wrap correctly
- [x] `/vocabularies/audit/DocumentType` at 375px — allowed-value cards render
- [x] All four pages at 1280px — sortable tables render unchanged
- [ ] CI Production Build job

## Related

- Stacks on PR #81 (now merged) which removed the stat-grids that would otherwise also need mobile treatment
- Children of #61 progress: 4 of 8 once this lands (#72, #73, #74, #76)
- Next up: #77 (consolidate v1-heuristic footnote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)