### PR TITLE
Consolidate v1-heuristic footnotes into a single disclosure (closes #77)

### DIFF
--- a/app/standards/data-model/page.tsx
+++ b/app/standards/data-model/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import DataModelHeader from "@/components/DataModelHeader";
+import TaggingMethod from "@/components/TaggingMethod";
 import { projects } from "@/lib/governance/catalog";
 
 export const metadata = {
@@ -45,6 +46,8 @@ export default function DataModelIndexPage() {
           <ProjectCard key={p.slug} project={p} />
         ))}
       </section>
+
+      <TaggingMethod />
     </div>
   );
 }

--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -310,19 +310,11 @@ export default async function ProjectDetailPage({
         </section>
       )}
 
-      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
-        Canonical / extension tagging is a v1 heuristic against a
-        hand-curated list of research-admin UDM tables; PII and
-        classification metadata are not yet captured upstream. See{" "}
-        <a
-          href="https://github.com/ui-insight/AISPEG/issues/53"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #53
-        </a>{" "}
-        for the full epic and follow-up tracking.
-      </footer>
+      <p className="text-xs text-ink-subtle">
+        <Link href="/standards/data-model#tagging-method">
+          Tagging method &rarr;
+        </Link>
+      </p>
     </div>
   );
 }

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -431,29 +431,13 @@ export default async function TableDetailPage({
         </section>
       ) : null}
 
-      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
-        Canonical / extension tagging and vocabulary-column detection are
-        v1 heuristics. PII flags and column-level classification are not
-        yet captured upstream and are tracked at{" "}
-        <a
-          href="https://github.com/ui-insight/data-governance/issues/9"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ui-insight/data-governance#9
-        </a>
-        . Vocab pills link to the vocabulary detail page when the resolver
-        can pick a single destination; ambiguous matches stay unlinked.
-        See{" "}
-        <a
-          href="https://github.com/ui-insight/AISPEG/issues/53"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #53
-        </a>{" "}
-        for the full epic.
-      </footer>
+      <p className="text-xs text-ink-subtle">
+        Vocab pills link to the vocabulary detail page when the resolver
+        can pick a single destination; ambiguous matches stay unlinked.{" "}
+        <Link href="/standards/data-model#tagging-method">
+          Tagging method &rarr;
+        </Link>
+      </p>
     </div>
   );
 }

--- a/app/standards/data-model/tables/page.tsx
+++ b/app/standards/data-model/tables/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import DataModelHeader from "@/components/DataModelHeader";
 import TablesExplorer, {
   type ProjectMeta,
@@ -48,28 +49,11 @@ export default function TablesIndexPage() {
         <TablesExplorer rows={rows} projectsList={projectsList} />
       </section>
 
-      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
-        Canonical / extension tagging is a v1 heuristic against a
-        hand-curated list of research-admin UDM tables. PII flags and
-        column-level data classification are not yet captured upstream and
-        are tracked at{" "}
-        <a
-          href="https://github.com/ui-insight/data-governance/issues/9"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ui-insight/data-governance#9
-        </a>
-        ; see{" "}
-        <a
-          href="https://github.com/ui-insight/AISPEG/issues/53"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #53
-        </a>{" "}
-        for the full epic.
-      </footer>
+      <p className="text-xs text-ink-subtle">
+        <Link href="/standards/data-model#tagging-method">
+          Tagging method &rarr;
+        </Link>
+      </p>
     </div>
   );
 }

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -296,27 +296,11 @@ export default async function VocabularyDetailPage({
         )}
       </section>
 
-      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
-        Cross-walk is a v1 heuristic — see{" "}
-        <span className="font-mono">lib/governance/vocabulary-usage.ts</span>{" "}
-        for the matching logic and tie-breaking rules. Source of truth:{" "}
-        <a
-          href="https://github.com/ui-insight/data-governance"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ui-insight/data-governance
-        </a>
-        ; see{" "}
-        <a
-          href="https://github.com/ui-insight/AISPEG/issues/53"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #53
-        </a>{" "}
-        for the full epic.
-      </footer>
+      <p className="text-xs text-ink-subtle">
+        <Link href="/standards/data-model#tagging-method">
+          Tagging method &rarr;
+        </Link>
+      </p>
     </div>
   );
 }

--- a/app/standards/data-model/vocabularies/page.tsx
+++ b/app/standards/data-model/vocabularies/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import DataModelHeader from "@/components/DataModelHeader";
 import VocabulariesExplorer, {
   type VocabularyRow,
@@ -49,29 +50,11 @@ export default function VocabulariesIndexPage() {
         />
       </section>
 
-      <footer className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
-        &ldquo;Projects using&rdquo; is a v1 cross-walk: a project counts as a
-        user when one of its tables has either an{" "}
-        <span className="font-mono">AllowedValues.&lt;group&gt;</span>{" "}
-        foreign key OR a column whose name matches the group name (PascalCase
-        / snake_case / camelCase normalized). Source of truth:{" "}
-        <a
-          href="https://github.com/ui-insight/data-governance"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ui-insight/data-governance
-        </a>
-        ; see{" "}
-        <a
-          href="https://github.com/ui-insight/AISPEG/issues/53"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          #53
-        </a>{" "}
-        for the full epic.
-      </footer>
+      <p className="text-xs text-ink-subtle">
+        <Link href="/standards/data-model#tagging-method">
+          Tagging method &rarr;
+        </Link>
+      </p>
     </div>
   );
 }

--- a/components/TaggingMethod.tsx
+++ b/components/TaggingMethod.tsx
@@ -1,0 +1,90 @@
+// Single canonical explanation of the v1 heuristics that drive the Data
+// Governance Explorer. Rendered once on the data-model index. Detail pages
+// link to it via /standards/data-model#tagging-method instead of repeating
+// the prose. When the upstream catalog adopts canonical/extension and
+// classification fields, both the heuristics and this disclosure retire.
+
+export default function TaggingMethod() {
+  return (
+    <details
+      id="tagging-method"
+      className="rounded-lg border border-hairline bg-surface-alt p-5 scroll-mt-6"
+    >
+      <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.14em] text-brand-clearwater hover:text-brand-black">
+        Tagging method &mdash; how canonical / extension tags and vocabulary cross-walks are computed
+      </summary>
+
+      <div className="mt-4 space-y-3 border-t border-hairline pt-4 text-sm leading-relaxed text-ink-muted">
+        <p>
+          <span className="font-semibold text-brand-black">
+            Canonical UDM tables
+          </span>{" "}
+          are adopted from the AI4RA Unified Data Model. Their names and shapes
+          follow the institutional standard for research-administration data.{" "}
+          <span className="font-semibold text-brand-black">
+            Project extensions
+          </span>{" "}
+          are tables specific to one or more projects in the IIDS portfolio,
+          not (yet) part of the institutional standard.
+        </p>
+        <p>
+          The canonical / extension distinction is currently a v1 heuristic
+          against a hand-curated list in{" "}
+          <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-brand-black">
+            lib/governance/canonical-udm-tables.ts
+          </code>
+          . When the upstream{" "}
+          <a
+            href="https://github.com/ui-insight/data-governance"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ui-insight/data-governance
+          </a>{" "}
+          catalog adopts the classification field, this overlay retires.
+        </p>
+        <p>
+          <span className="font-semibold text-brand-black">
+            Vocabulary cross-walks
+          </span>{" "}
+          &mdash; the &ldquo;Vocab&rdquo; pill on a column and the
+          &ldquo;Projects using&rdquo; count on a vocabulary group &mdash; are
+          also v1 heuristics. A column counts as using a vocabulary group when
+          it has an{" "}
+          <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-brand-black">
+            AllowedValues.&lt;group&gt;
+          </code>{" "}
+          foreign key, or when its name matches the group name normalized
+          across PascalCase, snake_case, and camelCase. Logic lives in{" "}
+          <code className="rounded bg-white px-1 py-0.5 font-mono text-xs text-brand-black">
+            lib/governance/vocabulary-usage.ts
+          </code>
+          .
+        </p>
+        <p>
+          PII flags and column-level data classification are{" "}
+          <span className="font-semibold text-brand-black">
+            not yet captured
+          </span>{" "}
+          upstream. Tracking at{" "}
+          <a
+            href="https://github.com/ui-insight/data-governance/issues/9"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ui-insight/data-governance#9
+          </a>
+          ; full epic at{" "}
+          <a
+            href="https://github.com/ui-insight/AISPEG/issues/53"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            AISPEG #53
+          </a>
+          .
+        </p>
+      </div>
+    </details>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #77. Removes the 5 duplicated v1-heuristic footnotes that appeared at the bottom of every data-model surface, replaces them with a single `<details>` disclosure on the index page, and adds a small inline "Tagging method →" link from each detail/tab page.

To a Provost, the repeated footnotes read as repeated "in progress" signals across the page set. Now there's one canonical explanation, and the rest of the surface stays focused on the actual content.

## What changed

**New: [components/TaggingMethod.tsx](https://github.com/ui-insight/AISPEG/blob/feat/issue-77-v1-heuristic-consolidation/components/TaggingMethod.tsx)** — single `<details id="tagging-method">` disclosure covering:

- Canonical-UDM tables vs project extensions in stakeholder terms
- How v1 tagging works (hand-curated list in `lib/governance/canonical-udm-tables.ts`, retiring when upstream catalog adopts the field)
- How vocabulary cross-walks are computed (FK + name-normalized match)
- What's *not* yet captured (PII flags, classification levels)
- Source-of-truth + epic links

**Rendered once** on `/standards/data-model` with `id="tagging-method"`, `scroll-mt-6` for anchor positioning.

**5 footnotes removed** from:
- [app/standards/data-model/tables/page.tsx](https://github.com/ui-insight/AISPEG/blob/main/app/standards/data-model/tables/page.tsx)
- [app/standards/data-model/vocabularies/page.tsx](https://github.com/ui-insight/AISPEG/blob/main/app/standards/data-model/vocabularies/page.tsx)
- [app/standards/data-model/projects/[slug]/page.tsx](https://github.com/ui-insight/AISPEG/blob/main/app/standards/data-model/projects/%5Bslug%5D/page.tsx)
- [app/standards/data-model/tables/[project]/[table]/page.tsx](https://github.com/ui-insight/AISPEG/blob/main/app/standards/data-model/tables/%5Bproject%5D/%5Btable%5D/page.tsx)
- [app/standards/data-model/vocabularies/[domain]/[group]/page.tsx](https://github.com/ui-insight/AISPEG/blob/main/app/standards/data-model/vocabularies/%5Bdomain%5D/%5Bgroup%5D/page.tsx)

Each replaced with a small `<p class="text-xs text-ink-subtle"><Link href="/standards/data-model#tagging-method">Tagging method →</Link></p>`.

The table-detail page keeps one extra sentence about the Vocab-pill linking behavior (specific to that surface) before the link — the rest is gone.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Confirmed via DOM: disclosure renders on `/standards/data-model`, opens to 258px of body content
- [x] Confirmed via DOM: each detail page renders `<a href="/standards/data-model#tagging-method">Tagging method →</a>`
- [x] No remaining "v1 heuristic" prose anywhere except in the canonical component
- [ ] CI Production Build job
- [ ] Reviewer to click through and confirm the disclosure copy reads well

## Related

- Stacks on PR #82 (now merged)
- Children of #61 progress: 5 of 8 once this lands (#72, #73, #74, #76, #77)
- Next: #79 (glossary tooltips) — picks up where this one leaves off, drilling into the inline jargon

🤖 Generated with [Claude Code](https://claude.com/claude-code)