### PR TITLE
Glossary tooltips on UDM jargon (closes #79)

### DIFF
--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   projects,
 } from "@/lib/governance/catalog";
 import { getProjectFraming } from "@/lib/governance/project-framing";
+import GlossaryTerm from "@/components/GlossaryTerm";
 import type { Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -276,7 +277,7 @@ export default async function ProjectDetailPage({
         <section className="space-y-4">
           <div>
             <h2 className="text-xl font-bold text-ui-charcoal">
-              Canonical UDM tables
+              <GlossaryTerm term="Canonical UDM">Canonical UDM</GlossaryTerm> tables
             </h2>
             <p className="mt-1 text-sm text-gray-600">
               Adopted from the AI4RA Unified Data Model. Naming and shape
@@ -295,7 +296,7 @@ export default async function ProjectDetailPage({
         <section className="space-y-4">
           <div>
             <h2 className="text-xl font-bold text-ui-charcoal">
-              Project extensions
+              <GlossaryTerm term="Project extension">Project extensions</GlossaryTerm>
             </h2>
             <p className="mt-1 text-sm text-gray-600">
               Tables specific to this project — workflow, tooling, or

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/governance/catalog";
 import { resolveVocabularyGroupForColumn } from "@/lib/governance/vocabulary-usage";
 import { getProjectFraming } from "@/lib/governance/project-framing";
+import GlossaryTerm from "@/components/GlossaryTerm";
 import type { Column, Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -253,8 +254,12 @@ export default async function TableDetailPage({
           <div>
             <h2 className="text-xl font-bold text-ui-charcoal">Columns</h2>
             <p className="mt-1 text-sm text-gray-600">
-              Full column list. PK marks primary keys; Vocab marks columns
-              whose values come from a controlled vocabulary group.
+              Full column list.{" "}
+              <GlossaryTerm term="PK">PK</GlossaryTerm> marks primary keys;{" "}
+              <GlossaryTerm term="Vocab">Vocab</GlossaryTerm> marks columns
+              whose values come from a controlled vocabulary group.{" "}
+              <GlossaryTerm term="FK">Foreign keys</GlossaryTerm> reference rows in
+              another table.
             </p>
           </div>
           <p className="text-xs text-gray-500">

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { vocabularyGroups } from "@/lib/governance/vocabularies";
 import { getProject } from "@/lib/governance/catalog";
 import { getVocabularyDomainFraming } from "@/lib/governance/project-framing";
+import GlossaryTerm from "@/components/GlossaryTerm";
 import {
   getProjectsUsingGroup,
   type MatchReason,
@@ -156,7 +157,9 @@ export default async function VocabularyDetailPage({
 
       <section className="space-y-3">
         <div>
-          <h2 className="text-xl font-bold text-ui-charcoal">Allowed values</h2>
+          <h2 className="text-xl font-bold text-ui-charcoal">
+            <GlossaryTerm term="Allowed values">Allowed values</GlossaryTerm>
+          </h2>
           <p className="mt-1 text-sm text-gray-600">
             Codes are the persisted form; labels are the human-readable
             display. Display Order, when set, is the suggested sort order

--- a/components/GlossaryTerm.tsx
+++ b/components/GlossaryTerm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useId, useState, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
+import { glossary, type GlossaryKey } from "@/lib/governance/glossary";
+
+interface GlossaryTermProps {
+  term: GlossaryKey;
+  children?: ReactNode;
+  /** Where to position the tooltip relative to the trigger. */
+  placement?: "below" | "above";
+}
+
+export default function GlossaryTerm({
+  term,
+  children,
+  placement = "below",
+}: GlossaryTermProps) {
+  const def = glossary[term];
+  const id = useId();
+  const [tapOpen, setTapOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!tapOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setTapOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [tapOpen]);
+
+  if (!def) return <>{children ?? term}</>;
+
+  const positionClass =
+    placement === "above"
+      ? "bottom-full mb-1.5"
+      : "top-full mt-1.5";
+
+  return (
+    <span ref={wrapperRef} className="group relative inline-block">
+      <span
+        tabIndex={0}
+        role="button"
+        aria-describedby={id}
+        onClick={() => setTapOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") setTapOpen(false);
+        }}
+        className="cursor-help border-b border-dotted border-current outline-none focus-visible:rounded-sm focus-visible:bg-brand-clearwater/15"
+      >
+        {children ?? term}
+      </span>
+      <span
+        id={id}
+        role="tooltip"
+        className={`pointer-events-none absolute left-0 z-50 w-64 max-w-[80vw] rounded-md border border-hairline bg-white p-3 text-xs font-normal normal-case leading-relaxed tracking-normal text-ink-muted shadow-md transition-opacity ${positionClass} ${
+          tapOpen ? "visible opacity-100" : "invisible opacity-0"
+        } group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100`}
+      >
+        {def}
+      </span>
+    </span>
+  );
+}

--- a/lib/governance/glossary.ts
+++ b/lib/governance/glossary.ts
@@ -1,0 +1,24 @@
+// Plain-language definitions for engineer-shorthand terms used across the
+// Data Governance Explorer. Wrapped via <GlossaryTerm term="..."> to render
+// a dotted-underline trigger with a tooltip on hover, focus, or tap.
+//
+// The TaggingMethod disclosure on /standards/data-model is the deeper
+// explanation; these are quick reminders for skimmers.
+
+export const glossary = {
+  PK: "Primary key — the unique identifier for a row in this table.",
+  FK: "Foreign key — a reference to a row in another table, named in the form Target_Table.Target_Column.",
+  Vocab: "Indicates this column draws values from a controlled vocabulary group — a defined list of allowed codes, not free-text.",
+  "Canonical UDM":
+    "A table whose name and shape are adopted from the AI4RA Unified Data Model — the institutional standard for research-administration data.",
+  "Project extension":
+    "A table specific to one or more projects in the IIDS portfolio, not (yet) part of the institutional standard.",
+  "Allowed values":
+    "Values drawn from a controlled vocabulary group. The field is enumerated, not free-text — every value has a code, a human-readable label, and an optional sort order.",
+  "Projection table":
+    "A view-like table whose data is derived from other source-of-truth tables. Read-only by convention; not the place to write new records.",
+  Entity:
+    "A table representing a real-world thing — a person, a grant, a device — rather than an event or a relationship between things.",
+} as const;
+
+export type GlossaryKey = keyof typeof glossary;


### PR DESCRIPTION
## Summary

Closes #79. Adds inline plain-language tooltips on engineer-shorthand terms across the data-model surface, picking up where #77's TaggingMethod disclosure left off — the disclosure is the deeper explanation, tooltips are the quick-reminder layer for skimmers.

The /critique deep-dive scored heuristic 2 ("Match real world") at 1/4 because the surface used engineer-shorthand throughout. This PR wraps the most impactful terms with hover/focus/tap tooltips so a Dean can skim without losing meaning.

## What changed

### New: [lib/governance/glossary.ts](https://github.com/ui-insight/AISPEG/blob/feat/issue-79-glossary-tooltips/lib/governance/glossary.ts)

Single TS module of 8 hand-written definitions: PK, FK, Vocab, Canonical UDM, Project extension, Allowed values, Projection table, Entity. Tone is institutional-stakeholder, not engineer.

### New: [components/GlossaryTerm.tsx](https://github.com/ui-insight/AISPEG/blob/feat/issue-79-glossary-tooltips/components/GlossaryTerm.tsx)

Client component (`useId` for stable IDs, tap-to-toggle state, click-outside-to-dismiss). Renders a dotted-underline trigger with `role="button"` and `aria-describedby` linked to a `role="tooltip"` panel.

Behavior:
- **Hover** (mouse): tooltip on `:hover`
- **Focus** (keyboard): tooltip on `:focus-within`
- **Tap** (touch): tooltip toggles on click; `Escape` or click-outside dismisses
- **Screen readers**: definition is announced via `aria-describedby` (verified via DOM textContent — the heading reads "Canonical UDM<definition> tables")

### 6 strategic placements

One per term per page — no row-level repetition (the issue body explicitly warned against littering markup):

| Page | Wrapped terms |
|---|---|
| `/standards/data-model/projects/[slug]` | "Canonical UDM" (in H2) + "Project extension" (in H2) |
| `/standards/data-model/tables/[project]/[table]` | "PK", "Vocab", "Foreign keys" (in column-list legend sentence) |
| `/standards/data-model/vocabularies/[domain]/[group]` | "Allowed values" (in H2) |

The legend sentence on table-detail was extended to mention foreign keys explicitly so the FK tooltip has a natural anchor.

## Notes

- **Projection table** and **Entity** are defined in the glossary but not yet wired to call sites. Those terms appear in the Tables tab `Kind` column where row-level wrapping would litter — reserved for a follow-up if #75 (Tables tab IA reframe) creates a better placement.
- **Classification level** wasn't included — the term doesn't appear inline anywhere on the surface (it's mentioned only in the TaggingMethod disclosure).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] DOM verification: 3 tooltips on table-detail, 2 on project-detail, 1 on vocabulary-detail
- [x] DOM verification: tooltip text accessible to screen readers (via `aria-describedby`)
- [x] Visual verification: dotted underlines render on each wrapped term
- [ ] Reviewer to hover/focus each term and confirm tooltip copy reads well
- [ ] CI Production Build job

## Related

- Stacks on PR #83 (now merged) — the TaggingMethod disclosure is the deeper explanation; this PR adds the inline shorthand layer
- Children of #61 progress: 6 of 8 once this lands (#72, #73, #74, #76, #77, #79)
- Remaining: #78 (polish minors), #75 (Tables tab IA reframe — `/shape` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)