### PR TITLE
Polish pass: 9 minors from /critique deep-dive (closes #78)

### DIFF
--- a/app/standards/data-model/page.tsx
+++ b/app/standards/data-model/page.tsx
@@ -24,8 +24,7 @@ function ProjectCard({ project }: { project: (typeof projects)[number] }) {
       <p className="mt-3 text-sm text-ink-muted">
         <span className="font-semibold text-brand-black">{project.tableCount} tables</span>
         {" — "}
-        {project.canonicalUdmCount} canonical, {project.projectExtensionCount}{" "}
-        project-specific.
+        {project.canonicalUdmCount}&nbsp;canonical, {project.projectExtensionCount}&nbsp;project-specific.
       </p>
       {project.runtimeModes && project.runtimeModes.length > 0 && (
         <p className="mt-2 text-xs text-ink-subtle">

--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -7,6 +7,8 @@ import {
 } from "@/lib/governance/catalog";
 import { getProjectFraming } from "@/lib/governance/project-framing";
 import GlossaryTerm from "@/components/GlossaryTerm";
+import ExpandAllSchemas from "@/components/ExpandAllSchemas";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import type { Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -88,9 +90,18 @@ function ColumnRow({
   );
 }
 
-function TableCard({ table }: { table: Table }) {
+function TableCard({
+  table,
+  defaultOpen = false,
+}: {
+  table: Table;
+  defaultOpen?: boolean;
+}) {
   return (
-    <article className="rounded-lg border border-gray-200 bg-white p-5">
+    <article
+      data-table-card
+      className="rounded-lg border border-gray-200 bg-white p-5"
+    >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
@@ -126,9 +137,9 @@ function TableCard({ table }: { table: Table }) {
         </div>
       </header>
 
-      <details className="mt-4 group">
+      <details className="mt-4 group" open={defaultOpen}>
         <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-ui-charcoal">
-          Show columns
+          {defaultOpen ? "Hide columns" : "Show columns"}
         </summary>
         <div className="mt-3 overflow-x-auto">
           <table className="w-full min-w-full text-left">
@@ -169,14 +180,22 @@ export default async function ProjectDetailPage({
     (t) => t.classification === "project-extension",
   );
 
+  // For projects with a small enough catalog, default-open the column lists
+  // so engineers don't have to click through every Show columns disclosure.
+  // Above 10 tables (e.g., OpenERA at 32), keep them collapsed by default.
+  const defaultOpenColumns = allTables.length <= 10;
+
   const framing = getProjectFraming(project.slug);
 
   return (
     <div className="space-y-10">
       <header>
-        <p className="text-xs">
-          <Link href="/standards/data-model">← Data Model</Link>
-        </p>
+        <Breadcrumbs
+          items={[
+            { label: "Data Model", href: "/standards/data-model" },
+            { label: project.application },
+          ]}
+        />
         <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {project.domain}
         </p>
@@ -273,6 +292,12 @@ export default async function ProjectDetailPage({
         )}
       </header>
 
+      {!defaultOpenColumns && allTables.length > 0 && (
+        <div className="-mb-4 flex justify-end">
+          <ExpandAllSchemas />
+        </div>
+      )}
+
       {canonical.length > 0 && (
         <section className="space-y-4">
           <div>
@@ -286,7 +311,11 @@ export default async function ProjectDetailPage({
           </div>
           <div className="space-y-3">
             {canonical.map((t) => (
-              <TableCard key={`${t.kind}-${t.name}`} table={t} />
+              <TableCard
+                key={`${t.kind}-${t.name}`}
+                table={t}
+                defaultOpen={defaultOpenColumns}
+              />
             ))}
           </div>
         </section>
@@ -305,7 +334,11 @@ export default async function ProjectDetailPage({
           </div>
           <div className="space-y-3">
             {extension.map((t) => (
-              <TableCard key={`${t.kind}-${t.name}`} table={t} />
+              <TableCard
+                key={`${t.kind}-${t.name}`}
+                table={t}
+                defaultOpen={defaultOpenColumns}
+              />
             ))}
           </div>
         </section>

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { resolveVocabularyGroupForColumn } from "@/lib/governance/vocabulary-usage";
 import { getProjectFraming } from "@/lib/governance/project-framing";
 import GlossaryTerm from "@/components/GlossaryTerm";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import type { Column, Table, TableKind } from "@/lib/governance/types";
 
 export function generateStaticParams() {
@@ -81,7 +82,7 @@ function VocabPill({
   return (
     <Link
       href={`/standards/data-model/vocabularies/${encodeURIComponent(domain)}/${encodeURIComponent(group)}`}
-      className="unstyled ml-2 inline-block rounded bg-brand-huckleberry/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-huckleberry hover:bg-brand-huckleberry/20"
+      className="unstyled ml-2 inline-block rounded bg-brand-lupine/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-lupine hover:bg-brand-lupine/20"
       title={`Vocabulary group: ${domain}/${group}`}
     >
       Vocab
@@ -166,16 +167,22 @@ export default async function TableDetailPage({
   return (
     <div className="space-y-10">
       <header>
-        <p className="text-xs">
-          <Link href={`/standards/data-model/projects/${project.slug}`}>
-            ← {project.application}
-          </Link>
-        </p>
+        <Breadcrumbs
+          items={[
+            { label: "Data Model", href: "/standards/data-model" },
+            { label: "Tables", href: "/standards/data-model/tables" },
+            {
+              label: project.application,
+              href: `/standards/data-model/projects/${project.slug}`,
+            },
+            { label: table.name },
+          ]}
+        />
         <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {project.domain}
         </p>
         <div className="mt-1 flex flex-wrap items-center gap-3">
-          <h1 className="font-mono text-3xl font-black tracking-tight text-brand-black">
+          <h1 className="text-3xl font-black tracking-tight text-brand-black">
             {table.name}
           </h1>
           <ClassificationBadge classification={table.classification} />
@@ -271,7 +278,7 @@ export default async function TableDetailPage({
               <>
                 {" "}
                 ·{" "}
-                <span className="font-bold text-brand-huckleberry">
+                <span className="font-bold text-brand-lupine">
                   {vocabColumnCount}
                 </span>{" "}
                 vocabulary

--- a/app/standards/data-model/tables/page.tsx
+++ b/app/standards/data-model/tables/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import DataModelHeader from "@/components/DataModelHeader";
 import TablesExplorer, {
   type ProjectMeta,
@@ -46,7 +47,9 @@ export default function TablesIndexPage() {
           </p>
         </div>
 
-        <TablesExplorer rows={rows} projectsList={projectsList} />
+        <Suspense fallback={null}>
+          <TablesExplorer rows={rows} projectsList={projectsList} />
+        </Suspense>
       </section>
 
       <p className="text-xs text-ink-subtle">

--- a/app/standards/data-model/tables/page.tsx
+++ b/app/standards/data-model/tables/page.tsx
@@ -37,7 +37,7 @@ export default function TablesIndexPage() {
       <section className="space-y-4">
         <div>
           <h2 className="text-xl font-bold text-ui-charcoal">
-            Every table, every project
+            All tables across the portfolio
           </h2>
           <p className="mt-1 max-w-3xl text-sm text-gray-600">
             Sortable, filterable index spanning all five governed

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -4,6 +4,7 @@ import { vocabularyGroups } from "@/lib/governance/vocabularies";
 import { getProject } from "@/lib/governance/catalog";
 import { getVocabularyDomainFraming } from "@/lib/governance/project-framing";
 import GlossaryTerm from "@/components/GlossaryTerm";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import {
   getProjectsUsingGroup,
   type MatchReason,
@@ -100,14 +101,19 @@ export default async function VocabularyDetailPage({
   return (
     <div className="space-y-10">
       <header>
-        <p className="text-xs">
-          <Link href="/standards/data-model/vocabularies">← Vocabularies</Link>
-        </p>
+        <Breadcrumbs
+          items={[
+            { label: "Data Model", href: "/standards/data-model" },
+            { label: "Vocabularies", href: "/standards/data-model/vocabularies" },
+            { label: vg.domain },
+            { label: vg.group },
+          ]}
+        />
         <p className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
           {vg.domain}
         </p>
         <div className="mt-1 flex flex-wrap items-center gap-3">
-          <h1 className="font-mono text-3xl font-black tracking-tight text-brand-black">
+          <h1 className="text-3xl font-black tracking-tight text-brand-black">
             {vg.group}
           </h1>
           {vg.application && (

--- a/app/standards/data-model/vocabularies/page.tsx
+++ b/app/standards/data-model/vocabularies/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import DataModelHeader from "@/components/DataModelHeader";
 import VocabulariesExplorer, {
   type VocabularyRow,
@@ -43,11 +44,13 @@ export default function VocabulariesIndexPage() {
           </p>
         </div>
 
-        <VocabulariesExplorer
-          rows={rows}
-          domains={domains}
-          applications={applications}
-        />
+        <Suspense fallback={null}>
+          <VocabulariesExplorer
+            rows={rows}
+            domains={domains}
+            applications={applications}
+          />
+        </Suspense>
       </section>
 
       <p className="text-xs text-ink-subtle">

--- a/app/standards/data-model/vocabularies/page.tsx
+++ b/app/standards/data-model/vocabularies/page.tsx
@@ -33,7 +33,7 @@ export default function VocabulariesIndexPage() {
       <section className="space-y-4">
         <div>
           <h2 className="text-xl font-bold text-ui-charcoal">
-            Every controlled vocabulary, every domain
+            All controlled vocabularies
           </h2>
           <p className="mt-1 max-w-3xl text-sm text-gray-600">
             Sortable, filterable index spanning every allowed-value group in

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export default function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="text-xs">
+      <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={i} className="flex items-center gap-x-1.5">
+              {item.href && !isLast ? (
+                <Link href={item.href}>{item.label}</Link>
+              ) : (
+                <span
+                  className={isLast ? "text-ink-muted" : ""}
+                  aria-current={isLast ? "page" : undefined}
+                >
+                  {item.label}
+                </span>
+              )}
+              {!isLast && (
+                <span className="text-ink-subtle" aria-hidden>
+                  /
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/components/DataModelHeader.tsx
+++ b/components/DataModelHeader.tsx
@@ -69,6 +69,7 @@ function TabBar({ active }: { active: DataModelTab }) {
 export default function DataModelHeader({ active }: { active: DataModelTab }) {
   const totalTables = projects.reduce((sum, p) => sum + p.tableCount, 0);
   const totalVocab = vocabularyGroups.length;
+  const isIndex = active === "projects";
 
   return (
     <header className="space-y-6">
@@ -76,25 +77,29 @@ export default function DataModelHeader({ active }: { active: DataModelTab }) {
         <h1 className="text-3xl font-black tracking-tight text-brand-black">
           Data Model
         </h1>
-        <p className="mt-3 max-w-3xl text-base leading-relaxed text-ink-muted">
-          The AI4RA Unified Data Model and the per-project extensions
-          installed across the IIDS portfolio. Engineers can use this to
-          connect to our data; stakeholders can use it to understand the
-          definitions and business rules. Source of truth:{" "}
-          <a
-            href="https://github.com/ui-insight/data-governance"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ui-insight/data-governance
-          </a>
-          .
-        </p>
-        <p className="mt-3 max-w-3xl text-base leading-relaxed text-brand-black">
-          <span className="font-bold">{projects.length} projects</span> governed,{" "}
-          <span className="font-bold">{totalTables} tables</span> across the portfolio,{" "}
-          <span className="font-bold">{totalVocab} controlled-vocabulary groups</span>.
-        </p>
+        {isIndex && (
+          <>
+            <p className="mt-3 max-w-3xl text-base leading-relaxed text-ink-muted">
+              The AI4RA Unified Data Model and the per-project extensions
+              installed across the IIDS portfolio. Engineers can use this to
+              connect to our data; stakeholders can use it to understand the
+              definitions and business rules. Source of truth:{" "}
+              <a
+                href="https://github.com/ui-insight/data-governance"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ui-insight/data-governance
+              </a>
+              .
+            </p>
+            <p className="mt-3 max-w-3xl text-base leading-relaxed text-brand-black">
+              <span className="font-bold">{projects.length} projects</span> governed,{" "}
+              <span className="font-bold">{totalTables} tables</span> across the portfolio,{" "}
+              <span className="font-bold">{totalVocab} controlled-vocabulary groups</span>.
+            </p>
+          </>
+        )}
       </div>
 
       <TabBar active={active} />

--- a/components/ExpandAllSchemas.tsx
+++ b/components/ExpandAllSchemas.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+// Toggles all <details> elements within the given selector. Used on
+// project-detail pages with >10 tables, where defaulting all column lists
+// open would create an excessively long page but engineers still want a
+// one-click way to expand the whole catalog.
+
+export default function ExpandAllSchemas({
+  selector = "[data-table-card] details",
+}: {
+  selector?: string;
+}) {
+  const [allOpen, setAllOpen] = useState(false);
+
+  const toggle = () => {
+    const els = document.querySelectorAll<HTMLDetailsElement>(selector);
+    const next = !allOpen;
+    els.forEach((d) => {
+      d.open = next;
+    });
+    setAllOpen(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="text-xs font-medium text-ink-muted hover:text-brand-black"
+    >
+      {allOpen ? "Collapse all schemas" : "Expand all schemas"}
+    </button>
+  );
+}

--- a/components/TablesExplorer.tsx
+++ b/components/TablesExplorer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import type { Table, TableKind } from "@/lib/governance/types";
 
 const KIND_LABEL: Record<TableKind, string> = {
@@ -102,10 +103,27 @@ export default function TablesExplorer({
   rows: TableRow[];
   projectsList: ProjectMeta[];
 }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
   const [sortKey, setSortKey] = useState<SortKey>("project");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
-  const [projectFilter, setProjectFilter] = useState<string>("all");
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [projectFilter, setProjectFilter] = useState<string>(
+    searchParams.get("project") ?? "all",
+  );
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>(
+    (searchParams.get("type") as TypeFilter) ?? "all",
+  );
+
+  // Reflect filter state into the URL so views are bookmarkable.
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (projectFilter !== "all") params.set("project", projectFilter);
+    if (typeFilter !== "all") params.set("type", typeFilter);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [projectFilter, typeFilter, pathname, router]);
 
   const handleSort = (k: SortKey) => {
     if (k === sortKey) {
@@ -178,35 +196,22 @@ export default function TablesExplorer({
         </div>
 
         <div className="flex items-center gap-2">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+          <label
+            htmlFor="type-filter"
+            className="text-[11px] font-semibold uppercase tracking-wider text-gray-500"
+          >
             Type
-          </span>
-          <div className="flex overflow-hidden rounded border border-gray-300 text-xs">
-            {(
-              [
-                { v: "all", label: "All" },
-                { v: "canonical-udm", label: "Canonical" },
-                { v: "project-extension", label: "Extension" },
-              ] as { v: TypeFilter; label: string }[]
-            ).map((opt) => {
-              const active = typeFilter === opt.v;
-              return (
-                <button
-                  key={opt.v}
-                  type="button"
-                  onClick={() => setTypeFilter(opt.v)}
-                  aria-pressed={active}
-                  className={`unstyled px-3 py-1 transition-colors ${
-                    active
-                      ? "bg-ui-charcoal text-white"
-                      : "bg-white text-gray-600 hover:text-ui-charcoal"
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              );
-            })}
-          </div>
+          </label>
+          <select
+            id="type-filter"
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as TypeFilter)}
+            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-ui-charcoal focus:border-brand-clearwater focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="canonical-udm">Canonical UDM</option>
+            <option value="project-extension">Project extension</option>
+          </select>
         </div>
 
         <p className="ml-auto text-xs text-gray-500">

--- a/components/VocabulariesExplorer.tsx
+++ b/components/VocabulariesExplorer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 
 type SortKey =
   | "group"
@@ -75,11 +76,31 @@ export default function VocabulariesExplorer({
   domains: string[];
   applications: string[];
 }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
   const [sortKey, setSortKey] = useState<SortKey>("domain");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
-  const [domainFilter, setDomainFilter] = useState<Set<string>>(new Set());
-  const [applicationFilter, setApplicationFilter] = useState<string>("all");
-  const [minValues, setMinValues] = useState<number>(0);
+  const [domainFilter, setDomainFilter] = useState<string>(
+    searchParams.get("domain") ?? "all",
+  );
+  const [applicationFilter, setApplicationFilter] = useState<string>(
+    searchParams.get("application") ?? "all",
+  );
+  const [minValues, setMinValues] = useState<number>(
+    Number(searchParams.get("min")) || 0,
+  );
+
+  // Reflect filter state into the URL so views are bookmarkable.
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (domainFilter !== "all") params.set("domain", domainFilter);
+    if (applicationFilter !== "all") params.set("application", applicationFilter);
+    if (minValues > 0) params.set("min", String(minValues));
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [domainFilter, applicationFilter, minValues, pathname, router]);
 
   const handleSort = (k: SortKey) => {
     if (k === sortKey) {
@@ -91,18 +112,9 @@ export default function VocabulariesExplorer({
     }
   };
 
-  const toggleDomain = (d: string) => {
-    setDomainFilter((prev) => {
-      const next = new Set(prev);
-      if (next.has(d)) next.delete(d);
-      else next.add(d);
-      return next;
-    });
-  };
-
   const filteredSorted = useMemo(() => {
     const filtered = rows.filter((r) => {
-      if (domainFilter.size > 0 && !domainFilter.has(r.domain)) return false;
+      if (domainFilter !== "all" && r.domain !== domainFilter) return false;
       if (
         applicationFilter !== "all" &&
         (r.application ?? "shared") !== applicationFilter
@@ -147,38 +159,25 @@ export default function VocabulariesExplorer({
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
         <div className="flex items-center gap-2">
-          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+          <label
+            htmlFor="domain-filter"
+            className="text-[11px] font-semibold uppercase tracking-wider text-gray-500"
+          >
             Domain
-          </span>
-          <div className="flex flex-wrap overflow-hidden rounded border border-gray-300 text-xs">
-            {domains.map((d) => {
-              const active = domainFilter.has(d);
-              return (
-                <button
-                  key={d}
-                  type="button"
-                  onClick={() => toggleDomain(d)}
-                  aria-pressed={active}
-                  className={`unstyled border-l border-gray-300 px-3 py-1 first:border-l-0 transition-colors ${
-                    active
-                      ? "bg-ui-charcoal text-white"
-                      : "bg-white text-gray-600 hover:text-ui-charcoal"
-                  }`}
-                >
-                  {d}
-                </button>
-              );
-            })}
-          </div>
-          {domainFilter.size > 0 && (
-            <button
-              type="button"
-              onClick={() => setDomainFilter(new Set())}
-              className="unstyled text-[11px] text-gray-500 hover:text-ui-charcoal"
-            >
-              clear
-            </button>
-          )}
+          </label>
+          <select
+            id="domain-filter"
+            value={domainFilter}
+            onChange={(e) => setDomainFilter(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-ui-charcoal focus:border-brand-clearwater focus:outline-none"
+          >
+            <option value="all">All domains</option>
+            {domains.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Closes #78. Bundles all 9 minor observations from the [#61](https://github.com/ui-insight/AISPEG/issues/61) data-model deep dive into one PR. Each is small on its own; together they remove residual rough edges that the prior 5 polish PRs (#80, #81, #82, #83, #84) didn't touch.

## What changed

| # | Item | Implementation |
|---|---|---|
| 1 | **Wrap bug** on `/standards/data-model` ("11 project-specific" wrapping as "11project-specific") | Non-breaking spaces between each count and its noun |
| 2 | **Twee section headings** ("Every table, every project") | Reworded to "All tables across the portfolio" / "All controlled vocabularies" |
| 3 | **Vocab pill color overload** | Vocab pill now uses `brand-lupine`; Application chip keeps `brand-huckleberry`. Two unrelated concepts now have distinct colors |
| 4 | **Typographic clash on detail-page H1s** (font-mono vs sans) | H1s now Public Sans 900 like the rest; mono treatment stays at body level |
| 5 | **`<details>` Show columns** closed by default | Projects ≤10 tables default-open all; >10 tables get a new `<ExpandAllSchemas>` client toggle ("Expand all schemas" / "Collapse all schemas") |
| 6 | **Filter UI inconsistency** (segmented buttons vs selects in same toolbar) | All four filters across TablesExplorer + VocabulariesExplorer now `<select>`. Domain filter dropped multi-select in favor of single-select (simpler; multi was rarely used) |
| 7 | **DataModelHeader count duplication** across tabs | "5 projects governed, 71 tables, 49 vocabulary groups" now renders only on Projects (index) tab |
| 8 | **Sub-page back-nav inconsistency** (3 different patterns) | New `<Breadcrumbs>` component applied to all 3 detail pages — `Data Model / OpenERA` (project), `Data Model / Tables / OpenERA / Organization` (table), `Data Model / Vocabularies / audit / DocumentType` (vocabulary) |
| 9 | **No URL state on filters** | TablesExplorer + VocabulariesExplorer now sync filter state to URL search params. `/tables?project=openera&type=canonical-udm` is bookmarkable and shareable. Reads from URL on mount; updates URL via `router.replace({ scroll: false })` |

## New components

- [components/Breadcrumbs.tsx](https://github.com/ui-insight/AISPEG/blob/feat/issue-78-polish-minors/components/Breadcrumbs.tsx) — server component, renders `<nav aria-label="Breadcrumb">` with proper `aria-current="page"` on the leaf
- [components/ExpandAllSchemas.tsx](https://github.com/ui-insight/AISPEG/blob/feat/issue-78-polish-minors/components/ExpandAllSchemas.tsx) — client component, toggles all `[data-table-card] details` on the page

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `/tables?project=openera&type=canonical-udm` — both selects pre-populated from URL
- [x] Changing a filter — URL updates without scroll jump
- [x] Breadcrumbs render on all 3 detail-page types
- [x] Tables/Vocabularies tabs no longer show count paragraph; only Projects tab does
- [x] Vocab pill renders in lupine; Application chip in huckleberry — distinct
- [x] Project detail H1 + table detail H1 use Public Sans 900 (no mono)
- [ ] CI Production Build job

## Closes [#61](https://github.com/ui-insight/AISPEG/issues/61) almost-completely

After this lands: **7 of 8 children** of #61 done. Only #75 (Tables tab IA reframe — canonical-vs-extension as primary cut) remains. That's the bigger move; my recommendation is `/shape` first since the IA decision needs alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)