### PR TITLE
Tables tab: by-domain view as default + flat-list toggle (closes #75)

### DIFF
--- a/app/standards/data-model/tables/page.tsx
+++ b/app/standards/data-model/tables/page.tsx
@@ -16,19 +16,24 @@ export const metadata = {
 export default function TablesIndexPage() {
   const projectsBySlug = new Map(projects.map((p) => [p.slug, p]));
 
-  const rows: TableRow[] = tables.map((t) => ({
-    project: t.project,
-    projectApplication: projectsBySlug.get(t.project)?.application ?? t.project,
-    name: t.name,
-    kind: t.kind,
-    classification: t.classification,
-    columnCount: t.columns.length,
-    relationshipCount: t.relationships.length,
-  }));
+  const rows: TableRow[] = tables.map((t) => {
+    const proj = projectsBySlug.get(t.project);
+    return {
+      project: t.project,
+      projectApplication: proj?.application ?? t.project,
+      domain: proj?.domain ?? "Unassigned",
+      name: t.name,
+      kind: t.kind,
+      classification: t.classification,
+      columnCount: t.columns.length,
+      relationshipCount: t.relationships.length,
+    };
+  });
 
   const projectsList: ProjectMeta[] = projects.map((p) => ({
     slug: p.slug,
     application: p.application,
+    domain: p.domain,
   }));
 
   return (

--- a/components/TablesExplorer.tsx
+++ b/components/TablesExplorer.tsx
@@ -22,15 +22,18 @@ type SortKey =
 type SortDir = "asc" | "desc";
 
 type TypeFilter = "all" | "canonical-udm" | "project-extension";
+type ViewMode = "domain" | "flat";
 
 export interface ProjectMeta {
   slug: string;
   application: string;
+  domain: string;
 }
 
 export interface TableRow {
   project: string; // slug
   projectApplication: string;
+  domain: string; // project's domain (institutional axis)
   name: string;
   kind: TableKind;
   classification: Table["classification"];
@@ -96,6 +99,357 @@ function SortHeader({
   );
 }
 
+// ---- Mobile and desktop row renderers (shared by both views) -------------
+
+function TableRowCard({ r }: { r: TableRow }) {
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
+              r.name,
+            )}`}
+            className="unstyled break-all font-mono text-sm font-semibold text-ui-charcoal hover:text-brand-clearwater"
+          >
+            {r.name}
+          </Link>
+          <Link
+            href={`/standards/data-model/projects/${r.project}`}
+            className="unstyled mt-1 block text-xs text-gray-600 hover:text-brand-clearwater"
+          >
+            {r.projectApplication}
+          </Link>
+        </div>
+        <ClassificationPill classification={r.classification} />
+      </div>
+      <p className="mt-3 text-xs text-gray-500">
+        <span className="font-medium uppercase tracking-wider">
+          {KIND_LABEL[r.kind]}
+        </span>
+        <span className="mx-1.5">·</span>
+        <span className="font-mono tabular-nums text-ui-charcoal">
+          {r.columnCount} {r.columnCount === 1 ? "col" : "cols"}
+        </span>
+        <span className="mx-1.5">·</span>
+        <span className="font-mono tabular-nums text-ui-charcoal">
+          {r.relationshipCount} {r.relationshipCount === 1 ? "rel" : "rels"}
+        </span>
+      </p>
+    </article>
+  );
+}
+
+// ---- By-domain view ------------------------------------------------------
+
+interface DomainGroup {
+  domain: string;
+  rows: TableRow[];
+  canonicalCount: number;
+  extensionCount: number;
+  projects: { project: string; projectApplication: string; rows: TableRow[] }[];
+}
+
+function groupByDomain(rows: TableRow[]): DomainGroup[] {
+  const byDomain = new Map<string, TableRow[]>();
+  for (const r of rows) {
+    const arr = byDomain.get(r.domain) ?? [];
+    arr.push(r);
+    byDomain.set(r.domain, arr);
+  }
+  const groups: DomainGroup[] = [];
+  for (const [domain, dRows] of byDomain.entries()) {
+    const byProject = new Map<string, TableRow[]>();
+    for (const r of dRows) {
+      const arr = byProject.get(r.project) ?? [];
+      arr.push(r);
+      byProject.set(r.project, arr);
+    }
+    const projectsArr = Array.from(byProject.entries())
+      .map(([project, rows]) => ({
+        project,
+        projectApplication: rows[0]?.projectApplication ?? project,
+        rows: [...rows].sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+      .sort((a, b) =>
+        a.projectApplication.localeCompare(b.projectApplication),
+      );
+    groups.push({
+      domain,
+      rows: dRows,
+      canonicalCount: dRows.filter((r) => r.classification === "canonical-udm")
+        .length,
+      extensionCount: dRows.filter(
+        (r) => r.classification === "project-extension",
+      ).length,
+      projects: projectsArr,
+    });
+  }
+  return groups.sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+function DomainSummary({ group }: { group: DomainGroup }) {
+  const total = group.rows.length;
+  const { canonicalCount, extensionCount } = group;
+  const tableWord = total === 1 ? "table" : "tables";
+
+  if (canonicalCount > 0 && extensionCount > 0) {
+    return (
+      <p className="mt-1 text-sm text-ink-muted">
+        <span className="font-bold text-brand-black">
+          {total} {tableWord}
+        </span>{" "}
+        — {canonicalCount} canonical UDM, {extensionCount} project-specific
+      </p>
+    );
+  }
+  if (canonicalCount > 0) {
+    return (
+      <p className="mt-1 text-sm text-ink-muted">
+        <span className="font-bold text-brand-black">
+          {total} {tableWord}
+        </span>
+        , all canonical UDM
+      </p>
+    );
+  }
+  return (
+    <p className="mt-1 text-sm text-ink-muted">
+      <span className="font-bold text-brand-black">
+        {total} {tableWord}
+      </span>
+      , all project-specific
+    </p>
+  );
+}
+
+function DomainView({ groups }: { groups: DomainGroup[] }) {
+  if (groups.length === 0) {
+    return (
+      <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-xs text-gray-500">
+        No tables match the current filters.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      {groups.map((group) => (
+        <section key={group.domain} className="space-y-5">
+          <header>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-clearwater">
+              Domain
+            </p>
+            <h3 className="mt-1 text-xl font-black tracking-tight text-brand-black">
+              {group.domain}
+            </h3>
+            <DomainSummary group={group} />
+          </header>
+
+          <div className="space-y-6">
+            {group.projects.map((p) => (
+              <div key={p.project} className="space-y-3">
+                <h4 className="text-sm font-bold tracking-tight text-brand-black">
+                  <Link
+                    href={`/standards/data-model/projects/${p.project}`}
+                    className="unstyled hover:text-brand-clearwater"
+                  >
+                    {p.projectApplication}
+                  </Link>{" "}
+                  <span className="text-xs font-medium text-ink-subtle">
+                    · {p.rows.length}{" "}
+                    {p.rows.length === 1 ? "table" : "tables"}
+                  </span>
+                </h4>
+
+                {/* Mobile: card list */}
+                <div className="space-y-2 sm:hidden">
+                  {p.rows.map((r) => (
+                    <TableRowCard key={`${r.kind}-${r.name}`} r={r} />
+                  ))}
+                </div>
+
+                {/* Tablet+: simple flat list */}
+                <ul className="hidden divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white sm:block">
+                  {p.rows.map((r) => (
+                    <li
+                      key={`${r.kind}-${r.name}`}
+                      className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2 transition-colors hover:bg-gray-50"
+                    >
+                      <Link
+                        href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(r.name)}`}
+                        className="unstyled font-mono text-xs font-semibold text-ui-charcoal hover:text-brand-clearwater"
+                      >
+                        {r.name}
+                      </Link>
+                      <ClassificationPill classification={r.classification} />
+                      <span className="text-[10px] font-medium uppercase tracking-wider text-gray-500">
+                        {KIND_LABEL[r.kind]}
+                      </span>
+                      <span className="ml-auto text-xs text-gray-500">
+                        <span className="font-mono tabular-nums text-ui-charcoal">
+                          {r.columnCount}
+                        </span>{" "}
+                        {r.columnCount === 1 ? "col" : "cols"}
+                        {r.relationshipCount > 0 && (
+                          <>
+                            <span className="mx-1.5">·</span>
+                            <span className="font-mono tabular-nums text-ui-charcoal">
+                              {r.relationshipCount}
+                            </span>{" "}
+                            {r.relationshipCount === 1 ? "rel" : "rels"}
+                          </>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+// ---- Flat sortable view (the engineer's lens) ---------------------------
+
+function FlatView({
+  rows,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  rows: TableRow[];
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (k: SortKey) => void;
+}) {
+  return (
+    <>
+      {/* Mobile: card list (< sm) */}
+      <div className="space-y-2 sm:hidden">
+        {rows.map((r) => (
+          <TableRowCard key={`${r.project}/${r.name}/${r.kind}`} r={r} />
+        ))}
+        {rows.length === 0 && (
+          <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-xs text-gray-500">
+            No tables match the current filters.
+          </p>
+        )}
+      </div>
+
+      {/* Tablet+: sortable table (≥ sm) */}
+      <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
+        <table className="w-full min-w-[760px] text-left">
+          <thead className="border-b border-gray-200 bg-gray-50">
+            <tr>
+              <SortHeader
+                label="Table"
+                sortKey="name"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+              />
+              <SortHeader
+                label="Project"
+                sortKey="project"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+              />
+              <SortHeader
+                label="Type"
+                sortKey="classification"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+              />
+              <SortHeader
+                label="Kind"
+                sortKey="kind"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+              />
+              <SortHeader
+                label="Cols"
+                sortKey="columns"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+                numeric
+                align="right"
+              />
+              <SortHeader
+                label="Rels"
+                sortKey="relationships"
+                activeKey={sortKey}
+                activeDir={sortDir}
+                onSort={onSort}
+                numeric
+                align="right"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={`${r.project}/${r.name}/${r.kind}`}
+                className="border-t border-gray-100 transition-colors hover:bg-gray-50"
+              >
+                <td className="py-2 pl-3 pr-4">
+                  <Link
+                    href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
+                      r.name,
+                    )}`}
+                    className="unstyled font-mono text-xs font-semibold text-ui-charcoal hover:text-brand-clearwater"
+                  >
+                    {r.name}
+                  </Link>
+                </td>
+                <td className="py-2 pr-4 text-xs text-gray-700">
+                  <Link
+                    href={`/standards/data-model/projects/${r.project}`}
+                    className="unstyled hover:text-brand-clearwater"
+                  >
+                    {r.projectApplication}
+                  </Link>
+                </td>
+                <td className="py-2 pr-4">
+                  <ClassificationPill classification={r.classification} />
+                </td>
+                <td className="py-2 pr-4 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+                  {KIND_LABEL[r.kind]}
+                </td>
+                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
+                  {r.columnCount}
+                </td>
+                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
+                  {r.relationshipCount}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center text-xs text-gray-500"
+                >
+                  No tables match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+// ---- Shell: filters, view toggle, URL state ------------------------------
+
 export default function TablesExplorer({
   rows,
   projectsList,
@@ -115,15 +469,19 @@ export default function TablesExplorer({
   const [typeFilter, setTypeFilter] = useState<TypeFilter>(
     (searchParams.get("type") as TypeFilter) ?? "all",
   );
+  const [view, setView] = useState<ViewMode>(
+    searchParams.get("view") === "flat" ? "flat" : "domain",
+  );
 
-  // Reflect filter state into the URL so views are bookmarkable.
+  // Reflect filter and view state into the URL so views are bookmarkable.
   useEffect(() => {
     const params = new URLSearchParams();
     if (projectFilter !== "all") params.set("project", projectFilter);
     if (typeFilter !== "all") params.set("type", typeFilter);
+    if (view !== "domain") params.set("view", view);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [projectFilter, typeFilter, pathname, router]);
+  }, [projectFilter, typeFilter, view, pathname, router]);
 
   const handleSort = (k: SortKey) => {
     if (k === sortKey) {
@@ -135,15 +493,18 @@ export default function TablesExplorer({
     }
   };
 
-  const filteredSorted = useMemo(() => {
-    const filtered = rows.filter((r) => {
+  const filtered = useMemo(() => {
+    return rows.filter((r) => {
       if (projectFilter !== "all" && r.project !== projectFilter) return false;
       if (typeFilter !== "all" && r.classification !== typeFilter) return false;
       return true;
     });
+  }, [rows, projectFilter, typeFilter]);
 
+  const flatSorted = useMemo(() => {
+    if (view !== "flat") return filtered;
     const dirMul = sortDir === "asc" ? 1 : -1;
-    const sorted = [...filtered].sort((a, b) => {
+    return [...filtered].sort((a, b) => {
       switch (sortKey) {
         case "name":
           return a.name.localeCompare(b.name) * dirMul;
@@ -164,14 +525,16 @@ export default function TablesExplorer({
           return 0;
       }
     });
-    return sorted;
-  }, [rows, projectFilter, typeFilter, sortKey, sortDir]);
+  }, [filtered, view, sortKey, sortDir]);
 
-  const visibleCount = filteredSorted.length;
+  const domainGroups = useMemo(
+    () => (view === "domain" ? groupByDomain(filtered) : []),
+    [filtered, view],
+  );
 
   return (
-    <div className="space-y-5">
-      {/* Filters */}
+    <div className="space-y-6">
+      {/* Toolbar: filters + view toggle */}
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
         <div className="flex items-center gap-2">
           <label
@@ -214,163 +577,54 @@ export default function TablesExplorer({
           </select>
         </div>
 
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+            View
+          </span>
+          <div className="flex overflow-hidden rounded border border-gray-300 text-xs">
+            {(
+              [
+                { v: "domain", label: "By domain" },
+                { v: "flat", label: "Flat list" },
+              ] as { v: ViewMode; label: string }[]
+            ).map((opt) => {
+              const active = view === opt.v;
+              return (
+                <button
+                  key={opt.v}
+                  type="button"
+                  onClick={() => setView(opt.v)}
+                  aria-pressed={active}
+                  className={`unstyled border-l border-gray-300 px-3 py-1 first:border-l-0 transition-colors ${
+                    active
+                      ? "bg-ui-charcoal text-white"
+                      : "bg-white text-gray-600 hover:text-ui-charcoal"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <p className="ml-auto text-xs text-gray-500">
-          Showing <span className="font-bold text-ui-charcoal">{visibleCount}</span> of {rows.length} tables
+          Showing{" "}
+          <span className="font-bold text-ui-charcoal">{filtered.length}</span>{" "}
+          of {rows.length} tables
         </p>
       </div>
 
-      {/* Mobile: card list (< sm) */}
-      <div className="space-y-2 sm:hidden">
-        {filteredSorted.map((r) => (
-          <article
-            key={`${r.project}/${r.name}/${r.kind}`}
-            className="rounded-lg border border-gray-200 bg-white p-4"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <Link
-                  href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
-                    r.name,
-                  )}`}
-                  className="unstyled break-all font-mono text-sm font-semibold text-ui-charcoal hover:text-brand-clearwater"
-                >
-                  {r.name}
-                </Link>
-                <Link
-                  href={`/standards/data-model/projects/${r.project}`}
-                  className="unstyled mt-1 block text-xs text-gray-600 hover:text-brand-clearwater"
-                >
-                  {r.projectApplication}
-                </Link>
-              </div>
-              <ClassificationPill classification={r.classification} />
-            </div>
-            <p className="mt-3 text-xs text-gray-500">
-              <span className="font-medium uppercase tracking-wider">
-                {KIND_LABEL[r.kind]}
-              </span>
-              <span className="mx-1.5">·</span>
-              <span className="font-mono tabular-nums text-ui-charcoal">
-                {r.columnCount} {r.columnCount === 1 ? "col" : "cols"}
-              </span>
-              <span className="mx-1.5">·</span>
-              <span className="font-mono tabular-nums text-ui-charcoal">
-                {r.relationshipCount} {r.relationshipCount === 1 ? "rel" : "rels"}
-              </span>
-            </p>
-          </article>
-        ))}
-        {filteredSorted.length === 0 && (
-          <p className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-xs text-gray-500">
-            No tables match the current filters.
-          </p>
-        )}
-      </div>
-
-      {/* Tablet+: sortable table (≥ sm) */}
-      <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white sm:block">
-        <table className="w-full min-w-[760px] text-left">
-          <thead className="border-b border-gray-200 bg-gray-50">
-            <tr>
-              <SortHeader
-                label="Table"
-                sortKey="name"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-              />
-              <SortHeader
-                label="Project"
-                sortKey="project"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-              />
-              <SortHeader
-                label="Type"
-                sortKey="classification"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-              />
-              <SortHeader
-                label="Kind"
-                sortKey="kind"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-              />
-              <SortHeader
-                label="Cols"
-                sortKey="columns"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-                numeric
-                align="right"
-              />
-              <SortHeader
-                label="Rels"
-                sortKey="relationships"
-                activeKey={sortKey}
-                activeDir={sortDir}
-                onSort={handleSort}
-                numeric
-                align="right"
-              />
-            </tr>
-          </thead>
-          <tbody>
-            {filteredSorted.map((r) => (
-              <tr
-                key={`${r.project}/${r.name}/${r.kind}`}
-                className="border-t border-gray-100 transition-colors hover:bg-gray-50"
-              >
-                <td className="py-2 pl-3 pr-4">
-                  <Link
-                    href={`/standards/data-model/tables/${r.project}/${encodeURIComponent(
-                      r.name,
-                    )}`}
-                    className="unstyled font-mono text-xs font-semibold text-ui-charcoal hover:text-brand-clearwater"
-                  >
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-2 pr-4 text-xs text-gray-700">
-                  <Link
-                    href={`/standards/data-model/projects/${r.project}`}
-                    className="unstyled hover:text-brand-clearwater"
-                  >
-                    {r.projectApplication}
-                  </Link>
-                </td>
-                <td className="py-2 pr-4">
-                  <ClassificationPill classification={r.classification} />
-                </td>
-                <td className="py-2 pr-4 text-[10px] font-medium uppercase tracking-wider text-gray-500">
-                  {KIND_LABEL[r.kind]}
-                </td>
-                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
-                  {r.columnCount}
-                </td>
-                <td className="py-2 pl-4 pr-3 text-right font-mono text-xs tabular-nums text-ui-charcoal">
-                  {r.relationshipCount}
-                </td>
-              </tr>
-            ))}
-            {filteredSorted.length === 0 && (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="px-4 py-8 text-center text-xs text-gray-500"
-                >
-                  No tables match the current filters.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+      {view === "flat" ? (
+        <FlatView
+          rows={flatSorted}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+        />
+      ) : (
+        <DomainView groups={domainGroups} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #75. **The last child of #61.** Reframes `/standards/data-model/tables` from a flat sortable list of 71 tables into a domain-grouped hierarchy that tells the institutional story (*"what does AI4RA UDM look like across the units we govern?"*) while preserving the engineer's quick-find behavior.

Confirmed via [`/shape`](https://github.com/ui-insight/AISPEG/issues/75#issuecomment-shape) — the /critique deep-dive raised by-domain vs canonical-vs-extension as an open IA question; we picked **by-domain primary cut**. Future-proofs for multi-project domains: when a second research-admin project lands, the structure absorbs it without redesign.

## What changed

### By-domain view (default)

- **5 stacked sections**, alphabetical by domain — Communications, Internal Audit, Process Intelligence, Research Administration, Strategic Planning
- Each section: clearwater eyebrow + Public Sans 900 heading + summary line with canonical/extension breakdown:

  > *Communications — **10 tables** — 1 canonical UDM, 9 project-specific*

- Within each domain: project sub-heading (links to project detail) + alphabetical table list
- **Mobile**: cards (matches PR #82 pattern). **Desktop**: borderless rows with classification pill, kind label, column/relationship counts inline

### Flat-list view (`?view=flat`)

- Existing sortable table **preserved verbatim**. Sort headers, multi-filter, URL state all intact.

### Toolbar

- **Project / Type filters** (existing from PR #85) + new **View toggle** (segmented control, "By domain" / "Flat list")
- View persists in URL as `?view=flat` (default "domain" omitted)
- All three pieces of state reflect into URL — `?project=openera&type=canonical-udm&view=flat` is bookmarkable

## Threading the audience needle

Per the /shape brief, the design serves both audiences without pandering:

- **Skeptical Dean / Provost**: opens to the 5 domain sections, scans their unit's slice, sees canonical/extension breakdown per domain
- **Practitioner / engineer**: flips to flat-list, sorts/filters, finds a specific table fast — the entire current Tables tab UX preserved

## Implementation

- `components/TablesExplorer.tsx` refactored: shell owns state + URL + toolbar; `<FlatView>` and `<DomainView>` are inner components consuming filtered rows
- `TableRow` + `ProjectMeta` gain a `domain` field, populated from the project's catalog domain in `tables/page.tsx`
- `TableRowCard` extracted as a shared mobile component used by both views
- Singular/plural counts handled in domain summary and project sub-heading copy. Empty-domain sections (when filtered out) don't render
- Static prerender preserved (`<Suspense>` wrapper from #85's fixup catches `useSearchParams`)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — `/standards/data-model/tables` still `○ Static`
- [x] By-domain view: all 5 domain sections render alphabetically, project sub-headings link to project detail, table rows link correctly
- [x] Flat-list view (`?view=flat`): sortable table renders, all filters/sorts active
- [x] View toggle: switching updates URL without scroll jump
- [x] URL state: `?project=openera&type=canonical-udm` populates both selects on load
- [x] Mobile (375px): toolbar wraps cleanly, cards render in domain view, no horizontal scroll
- [ ] CI Production Build job
- [ ] Reviewer to confirm domain ordering and project sub-heading copy reads well

## Closes [#61](https://github.com/ui-insight/AISPEG/issues/61) at 8/8

After this lands, all 8 children of #61 (Data Governance Stakeholder Polish Pass) are done. Ready to close the umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)