### PR TITLE
Add OpenERA to portfolio (closes #87)

### DIFF
--- a/lib/governance/project-framing.ts
+++ b/lib/governance/project-framing.ts
@@ -5,12 +5,11 @@
 // stakeholder-readable framing the .impeccable.md principle #1 requires
 // ("every claim names a human"). This module supplies that.
 //
-// Source-of-truth note: 4 of 5 governance projects (audit-dashboard, processmapping,
-// stratplan, ucm-daily-register) also exist in lib/portfolio.ts. The lede / owner
-// data here is hand-written for the data-model surface specifically; when a
-// fact diverges between this file and portfolio.ts, treat portfolio.ts as
-// canonical and update here. OpenERA is not yet a portfolio entry — see
-// `portfolioSlug: undefined` below.
+// Source-of-truth note: all 5 governance projects (audit-dashboard, openera,
+// processmapping, stratplan, ucm-daily-register) also exist in lib/portfolio.ts.
+// The lede / owner data here is hand-written for the data-model surface
+// specifically; when a fact diverges between this file and portfolio.ts, treat
+// portfolio.ts as canonical and update here.
 
 interface ProjectOwner {
   name: string;
@@ -41,10 +40,7 @@ const FRAMINGS: ProjectFraming[] = [
   },
   {
     slug: "openera",
-    // TODO: Add a portfolio entry for OpenERA in lib/portfolio.ts so this
-    // surface can join cleanly to the rest of /portfolio. Until then, the
-    // owner below is the ORED default — confirm with Sarah before public
-    // ramp-up.
+    portfolioSlug: "openera",
     lede:
       "OpenERA is the institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration.",
     homeUnit: "Office of Research and Economic Development",

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -234,6 +234,34 @@ export const interventions: Intervention[] = [
   },
 
   // ============================================================
+  // Office of Research and Economic Development
+  // ============================================================
+  {
+    slug: "openera",
+    name: "OpenERA",
+    tagline:
+      "Open electronic research administration system — canonical UDM implementor for sponsored research.",
+    description:
+      "Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures.",
+    homeUnits: ["Office of Research and Economic Development"],
+    operationalOwners: [
+      { name: "Sarah Martonick", title: "UI implementation owner" },
+    ],
+    buildParticipants: ["IIDS"],
+    status: "Production",
+    visibility: "Public",
+    ai4raRelationship: "Core",
+    dualDestinyPlanned: true,
+    repoUrl: "https://github.com/ui-insight/OpenERA",
+    operationalFunction:
+      "Sponsored-research administration: proposal lifecycle, award management, compliance, and reporting for ORED. Anchors the institutional research-admin data layer that Vandalizer, ProcessMapping, and adjacent ORED tools build against.",
+    operationalExcellenceOutcome:
+      "On-prem, UDM-aligned ERA system with shared data semantics across ORED tooling. Enables AI features (extraction, lookup, classification) on research-admin data without third-party data egress. Reference deployment for AI4RA partners.",
+    tech: ["React", "TypeScript", "Tailwind CSS", "FastAPI", "SQLAlchemy 2.0", "PostgreSQL 16"],
+    relatedSlugs: ["vandalizer", "processmapping", "embargoed-osp"],
+  },
+
+  // ============================================================
   // ORED + Office of General Counsel (dual home)
   // ============================================================
   {


### PR DESCRIPTION
## Summary

- Adds OpenERA as a `lib/portfolio.ts` entry under a new "Office of Research and Economic Development" section header (matches `HOME_UNIT_GROUP_ORDER` slot 3). 32 tables / 20 canonical UDM / 12 project extensions, AI4RA Core dual-destiny, public repo, Sarah Martonick as UI implementation owner.
- Sets `portfolioSlug: "openera"` in `lib/governance/project-framing.ts`, removes the TODO comment, and updates the source-of-truth note to reflect that all 5 governance projects now have portfolio entries. The framing overlay stays as the data-model surface's voice (per the issue's "keep overlay" option).

Owner attribution carries forward from the existing public framing overlay — no escalation in the public claim, but worth confirming with Sarah independently before broader public ramp.

The entry will only appear on `/portfolio` after `npm run seed:portfolio` runs against the live DB, since runtime reads go through `lib/work.ts` against the `applications` table (per Sprint 2 architecture in `REFACTOR.md`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` green; `/standards/data-model/projects/openera` prerenders
- [x] Browser preview: data-model OpenERA page renders with correct lede, owner, home unit, and table counts
- [ ] Confirm Sarah Martonick attribution before broader public ramp
- [ ] Re-seed `applications` so OpenERA appears on `/portfolio` (Sprint 2 follow-up, not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)