### PR TITLE
Collapse zero-canonical-UDM stat to prose (closes #74)

### DIFF
--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -247,9 +247,25 @@ export default async function ProjectDetailPage({
                 Tables in catalog
               </dt>
               <dd className="mt-0.5 text-brand-black">
-                <span className="font-semibold">{project.tableCount}</span> total
-                {" — "}
-                {project.canonicalUdmCount} canonical, {project.projectExtensionCount} project-specific
+                {project.tableCount === 0 ? (
+                  "No tables in the catalog yet."
+                ) : project.canonicalUdmCount === 0 ? (
+                  <>
+                    <span className="font-semibold">{project.tableCount}</span> total
+                    {" — all project-specific"}
+                  </>
+                ) : project.projectExtensionCount === 0 ? (
+                  <>
+                    <span className="font-semibold">{project.tableCount}</span> total
+                    {" — all canonical UDM"}
+                  </>
+                ) : (
+                  <>
+                    <span className="font-semibold">{project.tableCount}</span> total
+                    {" — "}
+                    {project.canonicalUdmCount} canonical, {project.projectExtensionCount} project-specific
+                  </>
+                )}
               </dd>
             </div>
             <div>


### PR DESCRIPTION
## Summary

The /critique deep-dive flagged "AI-dashboard-without-data" zero-state cells across the Data Model explorer (issue #74). An audit found that the vocabulary-detail and table-detail pages had already been refactored to explanatory prose by the preceding distill / polish passes. This PR closes the last remaining gap: the project-detail page's "Tables in catalog" stat, which still rendered "X total — 0 canonical, X project-specific" for projects with zero canonical UDM tables (`processmapping` and `stratplan`).

The fix collapses to:
- `processmapping` / `stratplan`: **"10 total — all project-specific"** (was: "10 total — 0 canonical, 10 project-specific")
- Defensive case (`tableCount === 0`, no project hits this today): **"No tables in the catalog yet."**
- Both > 0 (`openera`, `audit-dashboard`, `ucm-daily-register`): unchanged — "32 total — 20 canonical, 12 project-specific"

## Verification

- `npm run lint` clean
- `npm run build` green; all 5 project detail pages prerender
- Browser preview confirmed for `processmapping` (zero-canonical), `stratplan` (zero-canonical), `openera` and `audit-dashboard` (both non-zero — unchanged behavior)
- `ActionItemStatus` (the issue's named example for vocab pages) was already clean prior to this PR

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] processmapping renders "10 total — all project-specific"
- [x] stratplan renders "6 total — all project-specific"
- [x] openera, audit-dashboard, ucm-daily-register render unchanged

## Screenshot — processmapping after the fix

`TABLES IN CATALOG` now reads cleanly without the bold-zero artifact:

> 10 total — all project-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)