### PR TITLE
Mark Sprint 4 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,12 @@ sprint sequencing.
 - **Sprint 2** — The Work rebuild + Migration 005 (friction-ledger schema)
   + auth-gated `/internal`.
 - **Sprint 3** — ClickUp wiring + Submit-a-Project delivery improvements.
-- **Sprint 4** — Reports unification *(complete)*, About page *(complete)*,
-  `_archive/` deletion *(complete)*, `lib/data.ts` retirement *(complete)*,
-  `app/docs/*` cleanup *(in progress)*.
+- **Sprint 4** — *complete (May 2026)*. Reports unification (PR #90),
+  `_archive/` deletion (PR #91), Lovable cautionary tale salvaged into
+  Reports (PR #92), `lib/data.ts` retired with per-page colocation
+  (PR #93). The About page predated the sprint and is live at `/about`.
+  Remaining `app/docs/*` drift is tracked as
+  [#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98).
 
 ## Information architecture
 
@@ -104,7 +107,7 @@ app/                       # Next.js App Router
   reports/                 # Reports surface
   standards/               # Standards (sub-nav: ledger + data-model explorer)
   standards/data-model/    # Data Governance Explorer (UDM catalog + extensions)
-  ai4ra-ecosystem/         # AI4RA partnership reference (Sprint 4 salvage)
+  ai4ra-ecosystem/         # AI4RA partnership deep-dive (linked from /about)
   admin/                   # Registry + submissions admin
   api/                     # Next.js API routes
   docs/                    # Technical + user documentation

--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ the full plan, sprint sequencing, and decisions:
 - **Sprint 3** — ClickUp wiring + Submit-a-Project improvements: named-SLA
   acknowledgment, submitter-visible status page (`/intake/[token]`),
   similarity matching surfaced during assessment.
-- **Sprint 4** — Reports unification *(complete)*, About page *(complete)*,
-  `_archive/` deletion *(complete)*, `lib/data.ts` retirement *(complete)*,
-  `app/docs/*` cleanup *(in progress)*.
+- **Sprint 4** — *complete (May 2026)*. Reports unification (PR #90),
+  `_archive/` deletion (PR #91), Lovable cautionary tale salvaged into
+  Reports (PR #92), `lib/data.ts` retired with per-page colocation
+  (PR #93). The About page predated the sprint and is live at `/about`.
+  Remaining `app/docs/*` drift is tracked as
+  [#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98).
 
 ## Working on the codebase
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -298,16 +298,31 @@ delivery — named human, factual SLA, bookmarkable status URL,
 similarity-aware review. Status updates flow from manual edits to
 `submissions.status` for now; ClickUp eventually becomes the source.
 
-### Sprint 4 — Reports unification + About + cleanup
+### Sprint 4 — Reports unification + About + cleanup *(complete, May 2026)*
 
-- Merge `/presentations` + `/reports` into single `/reports` surface,
-  reverse-chronological.
-- Build `/about` page absorbing strategic frame, AI4RA partnership context,
-  AISPEG charter context, IIDS operator note. Selectively salvage from
-  `/approach` and `/knowledge` content.
-- Delete archived routes from `_archive/`.
-- Sweep dead code in `lib/data.ts` (everything no longer referenced).
-- Update `CLAUDE.md` and `README.md` to describe the new architecture.
+- ✅ Merge `/presentations` + `/reports` into single `/reports` surface,
+  reverse-chronological. Shipped in PR #90 (and the data-side merge
+  preceding it); `/presentations` retained as a redirect.
+- ✅ `/about` page absorbing strategic frame, AI4RA partnership context,
+  AISPEG charter context, IIDS operator note. Note: `/about` had
+  already shipped before this sprint formally opened; the sprint audit
+  confirmed it covered the intended scope.
+- ✅ Delete archived routes from `_archive/`. Shipped in PR #91 after a
+  salvage audit. The Lovable cautionary tale (the one entry worth
+  keeping) was recovered into Reports in PR #92 with IIDS-register
+  retoning.
+- ✅ Sweep dead code in `lib/data.ts`. Shipped in PR #93 — surprise
+  finding: there was no actual dead code. All 10 remaining exports were
+  per-report data, so the file was retired entirely and content was
+  colocated at `app/reports/<slug>/data.ts`.
+- ✅ Update `CLAUDE.md` and `README.md` to describe the new architecture
+  (rolled into PRs #90, #91, #92, #93 incrementally; final completion
+  sweep in this PR).
+- ⏭️ Deferred: `app/docs/*` drift cleanup. Audit performed at sprint
+  close found 5 distinct items worth addressing
+  ([#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98)).
+  Dev-facing docs, lower priority than the stakeholder surfaces shipped
+  this sprint.
 
 **Output:** old AISPEG-collaborator-era content is fully retired or salvaged.
 Codebase reflects the new architecture without legacy cruft.


### PR DESCRIPTION
## Summary

Closes out Sprint 4 in the docs.

All four Sprint 4 PRs landed:
- [#90 — Reports/Presentations cleanup](https://github.com/ui-insight/AISPEG/pull/90) (retired reveal.js infrastructure)
- [#91 — `_archive/` deletion](https://github.com/ui-insight/AISPEG/pull/91)
- [#92 — Lovable cautionary tale salvage](https://github.com/ui-insight/AISPEG/pull/92)
- [#93 — `lib/data.ts` retirement + per-page colocation](https://github.com/ui-insight/AISPEG/pull/93)

The `/about` page predated the sprint and was confirmed in scope during the audit. Remaining `app/docs/*` drift was split into 5 self-contained issues for separate pickup ([#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98)) — dev-facing docs, lower priority than the stakeholder surfaces this sprint shipped.

## Changes

- `CLAUDE.md` + `README.md` — drop the "in progress" marker, replace with a completion summary that links each delivered PR and the followup issues
- `CLAUDE.md` project structure — drop the now-stale "(Sprint 4 salvage)" annotation on `ai4ra-ecosystem/` (it's a deep-dive linked from `/about`, not a salvage candidate)
- `REFACTOR.md` Sprint 4 section — completion-stamped per-item status block; original plan stays readable, delivered state is captured with PR/issue references

## Test plan

- [x] No surface code touched
- [x] CLAUDE.md and README.md Sprint 4 lines link to PRs and issues correctly
- [x] REFACTOR.md retains the original plan structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)