### PR TITLE
Rebuild landing page hero, layout, and evidence

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,87 +1,147 @@
 import Link from "next/link";
 import { getPubliclyVisible } from "@/lib/portfolio";
+import { sortedArtifacts } from "@/lib/artifacts";
 
 export const dynamic = "force-dynamic";
 
-const cards = [
-  {
-    href: "/portfolio",
-    eyebrow: "The Work",
-    heading: "AI interventions across UI units",
-    body: "Projects, their operational owners, and current status.",
-    cta: "Explore the portfolio",
-    showCount: true,
-  },
-  {
-    href: "/builder-guide",
-    eyebrow: "Have an AI project idea?",
-    heading: "Submit a project",
-    body: "A short assessment scopes your idea, recommends a path, and connects you to a named owner at IIDS.",
-    cta: "Start the assessment",
-  },
-  {
-    href: "/reports",
-    eyebrow: "Reports",
-    heading: "Activity reports and presentations",
-    body: "Time-stamped artifacts: monthly briefs and executive communications.",
-    cta: "Browse reports",
-  },
-  {
-    href: "/standards",
-    eyebrow: "Institutional Standards",
-    heading: "Standards documentation",
-    body: "Software-development and user-experience standards governing AI work at the University of Idaho.",
-    cta: "View standards",
-  },
-];
+const RECENT_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
 
 export default async function Home() {
-  const portfolioCount = getPubliclyVisible().length;
+  const all = getPubliclyVisible();
+  const interventionCount = all.length;
+  const homeUnitCount = new Set(all.flatMap((i) => i.homeUnits)).size;
+  const mostRecent = sortedArtifacts()[0]?.dateLabel;
+  const recentPicks = RECENT_PICKS
+    .map((slug) => all.find((i) => i.slug === slug))
+    .filter((i): i is NonNullable<typeof i> => i !== undefined);
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-10">
       <section>
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Institutional AI Initiative
         </p>
-        <h1 className="mt-2 text-4xl font-black leading-tight tracking-tight text-ui-charcoal">
-          University of Idaho
+        <h1 className="mt-2 text-4xl leading-tight">
+          AI work at the University of Idaho
         </h1>
-        <p className="mt-4 max-w-2xl text-base leading-relaxed text-gray-600">
-          AI work at the University of Idaho, coordinated by the Institute
-          for Interdisciplinary Data Sciences.
+        <p className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-ink-muted">
+          <span>
+            <span className="font-semibold text-brand-black">
+              {interventionCount}
+            </span>{" "}
+            interventions across{" "}
+            <span className="font-semibold text-brand-black">
+              {homeUnitCount}
+            </span>{" "}
+            home units
+          </span>
+          <span aria-hidden className="text-brand-silver">
+            ·
+          </span>
+          {mostRecent && (
+            <>
+              <span>
+                most recent update{" "}
+                <span className="font-semibold text-brand-black">
+                  {mostRecent}
+                </span>
+              </span>
+              <span aria-hidden className="text-brand-silver">
+                ·
+              </span>
+            </>
+          )}
+          <span>coordinated by IIDS</span>
         </p>
       </section>
 
       <section>
-        <div className="grid gap-4 md:grid-cols-2">
-          {cards.map((card) => {
-            const heading =
-              card.showCount && card.href === "/portfolio"
-                ? `${portfolioCount} AI interventions across UI units`
-                : card.heading;
-            return (
-              <Link
-                key={card.href}
-                href={card.href}
-                className="group rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
-              >
-                <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
-                  {card.eyebrow}
+        <Link
+          href="/portfolio"
+          className="group block rounded-xl border border-hairline bg-white p-8 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            The Work
+          </p>
+          <h2 className="mt-2 text-2xl">
+            {interventionCount} AI interventions across UI units
+          </h2>
+          <p className="mt-2 text-sm text-ink-muted">
+            Projects, their operational owners, and current status.
+          </p>
+          <ul className="mt-6 divide-y divide-hairline border-y border-hairline">
+            {recentPicks.map((p) => (
+              <li key={p.slug} className="py-3">
+                <p className="text-base font-semibold text-brand-black">
+                  {p.name}
                 </p>
-                <h2 className="mt-2 text-xl font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
-                  {heading}
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed text-gray-600">
-                  {card.body}
+                <p className="mt-1 text-sm text-ink-muted">
+                  <em className="font-semibold text-brand-black">
+                    {p.operationalOwners[0].name}
+                  </em>
+                  {" · "}
+                  {p.homeUnits[0]}
                 </p>
-                <p className="mt-3 text-sm font-medium text-ui-gold-dark group-hover:underline">
-                  {card.cta} &rarr;
-                </p>
-              </Link>
-            );
-          })}
-        </div>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm font-medium text-brand-black group-hover:underline">
+            Explore the portfolio &rarr;
+          </p>
+        </Link>
+      </section>
+
+      <section>
+        <Link
+          href="/builder-guide"
+          className="group block rounded-xl bg-brand-gold p-8 transition-colors hover:bg-brand-gold-dark"
+        >
+          <p className="text-xs font-semibold uppercase tracking-wider text-brand-black/70">
+            Have an AI project idea?
+          </p>
+          <h2 className="mt-2 text-2xl text-brand-black">Submit a Project</h2>
+          <p className="mt-2 max-w-2xl text-base leading-relaxed text-brand-black/80">
+            A short assessment scopes your idea, recommends a path, and connects
+            you to a named owner at IIDS.
+          </p>
+          <p className="mt-4 text-sm font-bold uppercase tracking-wider text-brand-black group-hover:underline">
+            Start the assessment &rarr;
+          </p>
+        </Link>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Link
+          href="/reports"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Reports
+          </p>
+          <h3 className="mt-1 text-base">Activity reports and presentations</h3>
+          <p className="mt-1 text-sm text-ink-muted">
+            Time-stamped briefs and executive communications.
+          </p>
+          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
+            Browse &rarr;
+          </p>
+        </Link>
+        <Link
+          href="/standards"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Standards
+          </p>
+          <h3 className="mt-1 text-base">Standards documentation</h3>
+          <p className="mt-1 text-sm text-ink-muted">
+            Software-development and user-experience standards governing AI
+            work at UI.
+          </p>
+          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
+            View &rarr;
+          </p>
+        </Link>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

- Resolves the three P0/P1 issues from the 2026-05-02 `/critique` review of [`app/page.tsx`](app/page.tsx) with one cohesive design move: declarative hero, asymmetric layout, named owners.
- Closes #117 (hero teaches nothing new), #118 (uniform 4-card grid), #119 (no humans on the landing).
- Partial credit on #120 (gold demoted on the landing — sitewide sweep is its own task) and #121 (sidebar/landing label drift partially reconciled — full eyebrow/heading rule still wants documenting in `.impeccable.md`).

## What changed

- **Hero**: H1 is now `"AI work at the University of Idaho"` (declarative claim) instead of `"University of Idaho"` (sidebar duplicate). Inline state strip carries intervention count, home-unit count, most-recent-update date, and coordinator.
- **Layout**: replaced the 2×2 identical grid with three visual weights — a wide The Work tile listing three named operational owners (Michele Bartlett · Office of the President; Kim Salisbury · Division of Financial Affairs; Sarah Martonick · Office of Sponsored Programs (ORED)), a full-width Submit-a-Project gold CTA banner, and a paired secondary strip for Reports + Standards.
- **Color**: Pride Gold now appears in exactly **one** at-rest spot (the CTA banner). Eyebrows demoted to `text-brand-silver` (#808080); CTA arrows demoted to brand-black.
- **Labels**: `"Submit a project"` capitalized to `"Submit a Project"` matching sidebar; eyebrows on Reports, Standards, and The Work now match sidebar labels exactly, with headings as the rephrase.

## Data sources

No schema changes. Counts and dates pull from existing exports:
- `getPubliclyVisible()` from `lib/portfolio.ts`
- `sortedArtifacts()` from `lib/artifacts.ts`
- Featured slugs are a hand-curated three-entry constant (`RECENT_PICKS`) in the page

## Test plan

- [x] Desktop viewport (1280×2000): hero, wide tile, gold CTA banner, secondary strip render in correct vertical rhythm
- [x] Mobile viewport (375×1400): all sections stack cleanly, state strip wraps acceptably
- [x] Computed-style verification: eyebrow `rgb(128, 128, 128)` (brand-silver), CTA banner `rgb(241, 179, 0)` (Pride Gold), H1 weight 900 brand-black via `@layer base`
- [x] `npx tsc --noEmit` passes
- [ ] Reviewer: confirm the three featured interventions and the eyebrow/heading rephrase pattern are the right editorial choices

## Follow-ups (out of scope for this PR)

- **#120 sitewide gold sweep** — `/portfolio`, `/standards`, `/reports`, `/builder-guide` may still overuse gold. The landing fix doesn't propagate.
- **#121 finishing** — document the eyebrow/heading rule in `.impeccable.md` and audit the rest of the site for sidebar/heading drift.
- `/polish` final pass after the remaining issues land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)