### PR TITLE
Sitewide gold sweep — Pride Gold demoted to its rare role

### DIFF
--- a/app/builder-guide/page.tsx
+++ b/app/builder-guide/page.tsx
@@ -834,7 +834,7 @@ function ResultsView({
           <ul className="mt-3 space-y-2">
             {tier.techStack.map((item) => (
               <li key={item} className="flex items-start gap-2 text-sm text-gray-600">
-                <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-ui-gold" />
+                <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-silver" />
                 {item}
               </li>
             ))}
@@ -859,7 +859,7 @@ function ResultsView({
           <code className="rounded bg-gray-100 px-3 py-1.5 text-sm font-mono text-ui-charcoal">
             {tier.githubTemplate}
           </code>
-          <span className="rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+          <span className="rounded-full border border-hairline bg-surface-alt px-2.5 py-0.5 text-xs font-medium text-brand-black">
             Placeholder
           </span>
         </div>
@@ -878,7 +878,7 @@ function ResultsView({
             <Link
               key={std}
               href={`/standards/${std}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-ui-gold/30 bg-ui-gold/10 px-3 py-1 text-xs font-medium text-ui-gold-dark hover:bg-ui-gold/20 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full border border-brand-clearwater/30 bg-brand-clearwater/10 px-3 py-1 text-xs font-medium text-brand-clearwater hover:bg-brand-clearwater/20 transition-colors"
             >
               <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
@@ -1258,7 +1258,7 @@ export default function BuilderGuidePage() {
                   <button
                     key={s.id}
                     onClick={() => handleJumpToStep(i)}
-                    className="w-full rounded-xl border border-gray-200 bg-white p-4 text-left hover:border-ui-gold transition-colors"
+                    className="w-full rounded-xl border border-hairline bg-white p-4 text-left transition-shadow hover:shadow-md"
                   >
                     <div className="flex items-center justify-between">
                       <p className="text-xs font-medium uppercase tracking-wide text-gray-500">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -126,7 +126,7 @@ export default async function PortfolioPage({
           {blockerCount > 0 &&
             ` · ${blockerCount} active blocker${blockerCount === 1 ? "" : "s"}`}
           {" · "}
-          <Link href="/builder-guide" className="text-ui-gold-dark hover:underline">
+          <Link href="/builder-guide" className="text-brand-black hover:underline">
             Submit a new AI project &rarr;
           </Link>
         </p>
@@ -154,7 +154,7 @@ export default async function PortfolioPage({
             No interventions match the current filters.{" "}
             <Link
               href="/portfolio"
-              className="text-ui-gold-dark hover:underline"
+              className="text-brand-black hover:underline"
             >
               Clear filters
             </Link>
@@ -200,12 +200,12 @@ export default async function PortfolioPage({
             <strong>UI home unit</strong>. Each card shows the operational
             owner, current status, and any active blockers (with a counter
             of days since the block began). Tags signal relationships:{" "}
-            <span className="inline-block rounded-full border border-ui-gold/30 bg-ui-gold/10 px-2 py-0.5 text-xs font-medium text-ui-gold-dark">
+            <span className="inline-block rounded-full border border-brand-lupine/30 bg-brand-lupine/10 px-2 py-0.5 text-xs font-medium text-brand-lupine">
               AI4RA Core
             </span>{" "}
             means the work is part of the NSF-funded UI+SUU partnership and
             has a dual open-source / UI-implementation identity;{" "}
-            <span className="inline-block rounded-full border border-brand-lupine/30 bg-brand-lupine/10 px-2 py-0.5 text-xs font-medium text-brand-lupine">
+            <span className="inline-block rounded-full border border-brand-clearwater/40 bg-brand-clearwater/10 px-2 py-0.5 text-xs font-medium text-brand-clearwater">
               Capability diffusion
             </span>{" "}
             flags interventions where a non-IIDS UI unit is co-building;{" "}
@@ -230,7 +230,7 @@ export default async function PortfolioPage({
         <p className="mt-2 text-sm">
           <Link
             href="/ai4ra-ecosystem"
-            className="font-medium text-ui-gold-dark hover:underline"
+            className="font-medium text-brand-black hover:underline"
           >
             See the AI4RA ecosystem &rarr;
           </Link>

--- a/app/reports/feb-2026/page.tsx
+++ b/app/reports/feb-2026/page.tsx
@@ -16,7 +16,7 @@ export default function FebReportPage() {
     <div className="space-y-10">
       {/* Breadcrumb */}
       <nav className="text-sm text-gray-500">
-        <Link href="/reports" className="hover:text-ui-gold-dark">
+        <Link href="/reports" className="hover:text-brand-black">
           Reports &amp; Briefs
         </Link>
         <span className="mx-2">/</span>
@@ -24,7 +24,7 @@ export default function FebReportPage() {
       </nav>
 
       <div>
-        <p className="text-sm font-medium uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-sm font-medium uppercase tracking-wider text-brand-silver">
           Origin story
         </p>
         <h1 className="mt-1 text-3xl font-black tracking-tight text-brand-black">
@@ -34,7 +34,7 @@ export default function FebReportPage() {
           A snapshot of the 26-day sprint that proved agentic development could
           work at institutional scale. These metrics are a point-in-time proof
           of concept &mdash; for the current portfolio of active projects, see{" "}
-          <Link href="/portfolio" className="text-ui-gold-dark hover:underline">
+          <Link href="/portfolio" className="text-brand-black hover:underline">
             Portfolio
           </Link>
           .

--- a/app/reports/lovable-vibe-coding-2026/page.tsx
+++ b/app/reports/lovable-vibe-coding-2026/page.tsx
@@ -39,7 +39,7 @@ export default function LovableCautionaryTalePage() {
   return (
     <article className="space-y-10">
       <nav className="text-sm text-gray-500">
-        <Link href="/reports" className="hover:text-ui-gold-dark">
+        <Link href="/reports" className="hover:text-brand-black">
           Reports
         </Link>
         <span className="mx-2">/</span>
@@ -49,7 +49,7 @@ export default function LovableCautionaryTalePage() {
       </nav>
 
       <header>
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
           A cautionary tale &middot; April 21, 2026
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
@@ -104,7 +104,7 @@ export default function LovableCautionaryTalePage() {
         </div>
       </section>
 
-      <blockquote className="rounded-xl border-l-0 border-t-4 border-brand-gold bg-brand-gold/5 p-6">
+      <blockquote className="rounded-xl border border-hairline bg-surface-alt p-6">
         <p className="text-lg italic leading-relaxed text-brand-black">
           &ldquo;The real risk of vibe coding isn&apos;t AI writing insecure
           code. It&apos;s humans shipping code they never had a chance to
@@ -145,8 +145,8 @@ export default function LovableCautionaryTalePage() {
         </div>
       </section>
 
-      <section className="rounded-xl border border-brand-gold bg-brand-gold/5 p-6">
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-gold-dark">
+      <section className="rounded-xl border border-brand-clearwater/30 bg-brand-clearwater/5 p-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-clearwater">
           How UI&apos;s institutional posture differs
         </h2>
         <ul className="mt-3 space-y-2">
@@ -157,7 +157,7 @@ export default function LovableCautionaryTalePage() {
             >
               <span
                 aria-hidden="true"
-                className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-gold"
+                className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-clearwater"
               />
               <span>{item}</span>
             </li>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
 };
 
 const kindStyles: Record<ArtifactKind, string> = {
-  "activity-report": "bg-ui-gold/15 text-ui-gold-dark",
+  "activity-report": "bg-brand-clearwater/10 text-brand-clearwater",
   brief: "bg-blue-100 text-blue-800",
   presentation: "bg-emerald-100 text-emerald-800",
 };
@@ -42,7 +42,7 @@ function ExternalIcon() {
 function ArtifactCard({ artifact }: { artifact: Artifact }) {
   const isExternal = !!artifact.external;
   const cardInner = (
-    <article className="group relative h-full rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md">
+    <article className="group relative h-full rounded-xl border border-hairline bg-white p-6 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <span
           className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${kindStyles[artifact.kind]}`}
@@ -52,7 +52,7 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
         <span className="text-xs text-gray-400">{artifact.dateLabel}</span>
       </div>
 
-      <h2 className="mt-3 text-lg font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+      <h2 className="mt-3 text-lg font-semibold text-ui-charcoal">
         {artifact.title}
         {isExternal && (
           <span className="ml-1 inline-flex translate-y-px text-gray-400">
@@ -61,7 +61,7 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
         )}
       </h2>
       {artifact.subtitle && (
-        <p className="mt-1 text-sm font-medium text-ui-gold-dark">
+        <p className="mt-1 text-sm font-medium text-brand-silver">
           {artifact.subtitle}
         </p>
       )}

--- a/app/reports/presidential-brief-feb-2026/page.tsx
+++ b/app/reports/presidential-brief-feb-2026/page.tsx
@@ -18,7 +18,7 @@ export default function PresidentialBriefPage() {
     <div className="space-y-10">
       {/* Breadcrumb */}
       <nav className="text-sm text-gray-500">
-        <Link href="/reports" className="hover:text-ui-gold-dark">
+        <Link href="/reports" className="hover:text-brand-black">
           Reports
         </Link>
         <span className="mx-2">/</span>
@@ -27,7 +27,7 @@ export default function PresidentialBriefPage() {
 
       {/* Header */}
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
           Brief · February 7, 2026
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
@@ -140,8 +140,8 @@ export default function PresidentialBriefPage() {
             </tbody>
           </table>
         </div>
-        <div className="mt-4 rounded-lg bg-ui-gold/10 px-4 py-3">
-          <p className="text-sm font-medium text-ui-gold-dark">
+        <div className="mt-4 rounded-lg border border-hairline bg-surface-alt px-4 py-3">
+          <p className="text-sm font-semibold text-brand-black">
             28x increase in daily commit rate from pre-agentic to full team
             adoption.
           </p>

--- a/app/standards/data-model/projects/[slug]/page.tsx
+++ b/app/standards/data-model/projects/[slug]/page.tsx
@@ -68,7 +68,7 @@ function ColumnRow({
       <td className="py-2 pr-4 font-mono text-xs text-ui-charcoal">
         {column.name}
         {column.primaryKey && (
-          <span className="ml-2 rounded bg-ui-gold/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+          <span className="ml-2 rounded border border-hairline bg-surface-alt px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-black">
             PK
           </span>
         )}

--- a/app/standards/data-model/tables/[project]/[table]/page.tsx
+++ b/app/standards/data-model/tables/[project]/[table]/page.tsx
@@ -102,7 +102,7 @@ function ColumnRow({
       <td className="py-2 pr-4 font-mono text-xs text-ui-charcoal">
         <span>{column.name}</span>
         {column.primaryKey && (
-          <span className="ml-2 rounded bg-ui-gold/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+          <span className="ml-2 rounded border border-hairline bg-surface-alt px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-black">
             PK
           </span>
         )}
@@ -310,7 +310,7 @@ export default async function TableDetailPage({
                     {c.name}
                   </span>
                   {c.primaryKey && (
-                    <span className="rounded bg-ui-gold/20 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+                    <span className="rounded border border-hairline bg-surface-alt px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-black">
                       PK
                     </span>
                   )}

--- a/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
+++ b/app/standards/data-model/vocabularies/[domain]/[group]/page.tsx
@@ -267,7 +267,7 @@ export default async function VocabularyDetailPage({
                   key={u.project}
                   className="rounded-lg border border-gray-200 bg-white p-4"
                 >
-                  <p className="text-[11px] font-semibold uppercase tracking-wider text-ui-gold-dark">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
                     {project?.domain ?? ""}
                   </p>
                   <p className="mt-1">

--- a/app/standards/layout.tsx
+++ b/app/standards/layout.tsx
@@ -8,7 +8,7 @@ export default function StandardsLayout({
   return (
     <div>
       <header className="mb-10 border-b border-gray-200">
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
           Institutional Standards
         </p>
         <div className="mt-4">

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -70,7 +70,7 @@ function StandardRow({ item }: { item: StandardsWatchItem }) {
                 href={item.responseUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-ui-gold-dark underline"
+                className="text-brand-black underline"
               >
                 Response artifact
               </a>
@@ -80,7 +80,7 @@ function StandardRow({ item }: { item: StandardsWatchItem }) {
       </div>
 
       <details className="mt-4 group">
-        <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-ui-gold-dark">
+        <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-brand-black">
           Show requested detail ({item.details.length} sub-items)
         </summary>
         <ul className="mt-3 space-y-2 border-l-2 border-gray-100 pl-4">

--- a/components/DocPage.tsx
+++ b/components/DocPage.tsx
@@ -43,7 +43,7 @@ export function DocPage({
       </div>
 
       {/* Content */}
-      <div className="prose prose-sm max-w-none prose-headings:text-ui-charcoal prose-h2:text-xl prose-h2:mt-10 prose-h2:mb-4 prose-h3:text-base prose-h3:mt-6 prose-p:text-gray-600 prose-li:text-gray-600 prose-strong:text-ui-charcoal prose-code:bg-gray-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none prose-a:text-ui-gold-dark prose-a:no-underline hover:prose-a:underline">
+      <div className="prose prose-sm max-w-none prose-headings:text-ui-charcoal prose-h2:text-xl prose-h2:mt-10 prose-h2:mb-4 prose-h3:text-base prose-h3:mt-6 prose-p:text-gray-600 prose-li:text-gray-600 prose-strong:text-ui-charcoal prose-code:bg-gray-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none prose-a:text-brand-black prose-a:font-medium prose-a:no-underline hover:prose-a:underline">
         {children}
       </div>
     </div>
@@ -66,24 +66,24 @@ export function DocCard({
   return (
     <Link
       href={href}
-      className="group rounded-xl border border-gray-200 bg-white p-5 shadow-sm hover:border-ui-gold/50 hover:shadow-md transition-all"
+      className="group rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
     >
       <div className="flex items-start gap-3">
         <span className="text-2xl">{icon}</span>
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-ui-charcoal group-hover:text-ui-gold-dark transition-colors">
+            <h3 className="text-sm font-semibold text-ui-charcoal">
               {title}
             </h3>
             {badge && (
-              <span className="rounded-full bg-ui-gold/15 px-2 py-0.5 text-xs font-medium text-ui-gold-dark">
+              <span className="rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-xs font-medium text-brand-black">
                 {badge}
               </span>
             )}
           </div>
           <p className="mt-1 text-xs text-gray-500">{description}</p>
         </div>
-        <svg className="h-4 w-4 text-gray-300 group-hover:text-ui-gold transition-colors mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="h-4 w-4 text-gray-300 group-hover:text-brand-black transition-colors mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
         </svg>
       </div>

--- a/components/InterventionDetail.tsx
+++ b/components/InterventionDetail.tsx
@@ -142,7 +142,7 @@ export default function InterventionDetail({
     <div className="space-y-10">
       {/* Breadcrumb */}
       <nav className="text-sm text-gray-500">
-        <Link href={basePath} className="hover:text-ui-gold-dark">
+        <Link href={basePath} className="hover:text-brand-black">
           {audience === "internal" ? "Internal portfolio" : "Portfolio"}
         </Link>
         {app.homeUnits[0] && (
@@ -160,7 +160,7 @@ export default function InterventionDetail({
         <div className="flex flex-wrap items-center gap-2">
           <StatusBadge status={app.status} />
           {app.ai4raRelationship !== "None" && (
-            <span className="rounded-full border border-ui-gold/30 bg-ui-gold/10 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+            <span className="rounded-full border border-brand-lupine/30 bg-brand-lupine/10 px-2.5 py-0.5 text-xs font-medium text-brand-lupine">
               AI4RA {app.ai4raRelationship}
             </span>
           )}
@@ -195,7 +195,7 @@ export default function InterventionDetail({
           <p className="mt-2 text-lg text-gray-600">{app.tagline}</p>
         )}
         {app.funding && (
-          <p className="mt-2 text-sm font-medium text-ui-gold-dark">
+          <p className="mt-2 text-sm font-medium text-gray-600">
             {app.funding}
           </p>
         )}
@@ -293,7 +293,7 @@ export default function InterventionDetail({
               href={app.liveUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-brand-black"
             >
               Live site &rarr;
             </a>
@@ -303,7 +303,7 @@ export default function InterventionDetail({
               href={app.docsUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-ui-gold/40"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-ui-charcoal hover:border-brand-black"
             >
               Documentation &rarr;
             </a>
@@ -372,7 +372,7 @@ export default function InterventionDetail({
                 className="flex items-start gap-2 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700"
               >
                 <svg
-                  className="mt-0.5 h-4 w-4 shrink-0 text-ui-gold"
+                  className="mt-0.5 h-4 w-4 shrink-0 text-brand-black"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -421,9 +421,9 @@ export default function InterventionDetail({
               <Link
                 key={r.slug}
                 href={`${basePath}/${r.slug}`}
-                className="group rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-ui-gold/40"
+                className="group rounded-lg border border-hairline bg-white p-4 transition-shadow hover:shadow-md"
               >
-                <p className="text-sm font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+                <p className="text-sm font-semibold text-ui-charcoal">
                   {r.name}
                 </p>
                 {r.tagline && (

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -22,7 +22,7 @@ export default function LessonCard({
         {recommendations.map((rec, i) => (
           <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
             <svg
-              className="mt-0.5 h-4 w-4 shrink-0 text-ui-gold"
+              className="mt-0.5 h-4 w-4 shrink-0 text-brand-black"
               fill="currentColor"
               viewBox="0 0 20 20"
             >

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -81,10 +81,10 @@ export default function PortfolioCard({
   const ai4raLabel = ai4raChip[app.ai4raRelationship];
 
   return (
-    <article className="group relative flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-brand-gold hover:shadow-md">
+    <article className="group relative flex h-full flex-col rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="text-base font-semibold text-brand-black group-hover:text-brand-gold-dark transition-colors">
+          <h3 className="text-base font-semibold text-brand-black">
             <Link
               href={`${basePath}/${app.slug}`}
               className="unstyled before:absolute before:inset-0"
@@ -124,7 +124,7 @@ export default function PortfolioCard({
 
       <div className="mt-4 flex flex-wrap gap-1.5">
         {ai4raLabel && (
-          <span className="rounded-full border border-brand-gold bg-brand-gold/15 px-2 py-0.5 text-xs font-semibold text-brand-gold-dark">
+          <span className="rounded-full border border-brand-lupine/30 bg-brand-lupine/10 px-2 py-0.5 text-xs font-semibold text-brand-lupine">
             {ai4raLabel}
           </span>
         )}
@@ -176,7 +176,7 @@ export default function PortfolioCard({
           <span className="font-medium text-green-700">OIT-endorsed</span>
         )}
         {app.funding && (
-          <span className="truncate font-medium text-brand-gold-dark">
+          <span className="truncate font-medium text-gray-600">
             {app.funding}
           </span>
         )}

--- a/components/PortfolioFilters.tsx
+++ b/components/PortfolioFilters.tsx
@@ -52,7 +52,7 @@ function Chip({
       href={href}
       className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
         active
-          ? "border-ui-gold bg-ui-gold/15 text-ui-gold-dark"
+          ? "border-ui-gold bg-ui-gold/15 text-brand-black"
           : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
       }`}
     >
@@ -60,7 +60,7 @@ function Chip({
       {typeof count === "number" && (
         <span
           className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${
-            active ? "bg-ui-gold/30 text-ui-gold-dark" : "bg-gray-100 text-gray-500"
+            active ? "bg-brand-black/10 text-brand-black" : "bg-gray-100 text-gray-500"
           }`}
         >
           {count}
@@ -111,7 +111,7 @@ export default function PortfolioFilters({
         {filtersActive && (
           <Link
             href="/portfolio"
-            className="text-xs font-medium text-ui-gold-dark hover:underline"
+            className="text-xs font-medium text-brand-black hover:underline"
           >
             Clear filters &times;
           </Link>

--- a/components/PrincipleCard.tsx
+++ b/components/PrincipleCard.tsx
@@ -24,7 +24,7 @@ export default function PrincipleCard({
         className="flex w-full items-start gap-4 p-6 text-left"
       >
         <div className="flex-1">
-          <span className="inline-block rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-medium text-ui-gold-dark">
+          <span className="inline-block rounded-full border border-hairline bg-surface-alt px-2.5 py-0.5 text-xs font-medium text-brand-black">
             {category}
           </span>
           <h3 className="mt-2 text-lg font-semibold text-ui-charcoal">

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -38,7 +38,7 @@ export default function ProjectDetail({
         <div className="flex-1">
           <div className="flex flex-wrap items-center gap-3">
             <h3 className="text-lg font-semibold text-ui-charcoal">{name}</h3>
-            <span className="rounded-full bg-ui-gold/15 px-2.5 py-0.5 text-xs font-semibold text-ui-gold-dark">
+            <span className="rounded-full border border-hairline bg-surface-alt px-2.5 py-0.5 text-xs font-semibold text-brand-black">
               {multiplier}
             </span>
           </div>

--- a/components/ProjectTable.tsx
+++ b/components/ProjectTable.tsx
@@ -100,7 +100,7 @@ export default function ProjectTable({ projects, totals }: ProjectTableProps) {
               </td>
               <td className="px-6 py-3 text-right text-gray-500">{p.lowEstimate}</td>
               <td className="px-6 py-3 text-right text-gray-500">{p.highEstimate}</td>
-              <td className="px-6 py-3 text-right font-semibold text-ui-gold-dark">
+              <td className="px-6 py-3 text-right font-bold text-brand-black">
                 {p.multiplier}
               </td>
             </tr>
@@ -115,7 +115,7 @@ export default function ProjectTable({ projects, totals }: ProjectTableProps) {
             </td>
             <td className="px-6 py-3 text-right text-gray-600">{totals.lowEstimate}</td>
             <td className="px-6 py-3 text-right text-gray-600">{totals.highEstimate}</td>
-            <td className="px-6 py-3 text-right text-ui-gold-dark">{totals.multiplier}</td>
+            <td className="px-6 py-3 text-right font-bold text-brand-black">{totals.multiplier}</td>
           </tr>
         </tfoot>
       </table>


### PR DESCRIPTION
Closes #120.

## Summary

After the landing rebuild in #123 closed #117/#118/#119, the same gold overuse pattern remained on `/portfolio`, `/standards`, `/reports`, and `/builder-guide` and on shared components. This PR finishes the sitewide sweep agreed in [#122](https://github.com/ui-insight/AISPEG/issues/122).

Total gold occurrences across the four pages and shared components: **79 → 23**. The 23 that remain all align with [`.impeccable.md`](.impeccable.md): focus outlines, active states, primary CTAs, and one-focal-element-per-dark-surface emphasis.

## Demoted (overuse)

- Eyebrows (`text-xs uppercase tracking-wider`) → `text-brand-silver`
- Body links / breadcrumbs → `text-brand-black` with the global teal-underline treatment
- Card hover-borders (`hover:border-ui-gold/40`) → removed, `hover:shadow-md` only
- Card heading group-hovers → removed
- Type/category chips → redistributed by meaning:
  - AI4RA → `brand-lupine`
  - Activity-report kind chip → `brand-clearwater`
  - "Required standards" chips → `brand-clearwater`
  - PK column markers, "Placeholder", "Featured" (light surfaces) → neutral `surface-alt` + `border-hairline`
- `lovable-vibe-coding` gold callouts → blockquote demoted to neutral; "How UI differs" panel moved to `brand-clearwater`
- Decorative gold dots, checkmark icons, funding text → `brand-black` or `brand-silver`
- `ProjectTable` multiplier column → `text-brand-black font-bold` (emphasis via weight, not color)

## Kept (legitimate)

- Sidebar active nav state + header eyebrow
- All form focus rings on `/builder-guide`
- Quiz selected/active states (radio + multi-select)
- Primary CTA buttons (`bg-ui-gold`)
- Progress bar fill
- Featured artifact hero card on `/reports` (gold-on-dark)
- Featured project chip on the presidential brief (gold-on-dark, single-word status marker)
- `10–16x` productivity number on the feb-2026 dark callout (single focal emphasis)
- `Callout` component's `emphasis` variant

## Test plan

- [x] Verified visually on `/`, `/reports`, `/standards`, `/builder-guide` desktop
- [x] `npx tsc --noEmit` passes (no output)
- [x] Grep confirms 23 remaining gold occurrences, all in the keep list above
- [ ] Reviewer: confirm Lupine for AI4RA and Clearwater for activity-report / standards-required are the right category-color picks (these are the bigger judgment calls)
- [ ] Reviewer: confirm the lovable-vibe-coding tonal shift (gold panels → neutral + clearwater) reads correctly for that report's contrast structure

## Follow-ups

- #121 (sidebar/landing label drift) is the only remaining issue from the [tracking issue](https://github.com/ui-insight/AISPEG/issues/122).
- `/polish` final pass after #121 lands.
- Re-run `/critique` to verify the score improves from 26/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)