### PR TITLE
Reconcile sidebar and page heading labels

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -134,3 +134,42 @@ invent a parallel aesthetic.
    evidence-forward, owner-named, compliance-aware AI work. The site
    chrome must live up to that — every design choice should be defensible
    as functional.
+
+## Page Heading and Eyebrow Rule
+
+The sidebar is the canonical wayfinding surface — its labels are the
+short navigational handles. Each destination page must thread the same
+label through to its heading area so users always know where they are.
+
+**Rule:** A page's heading thread must include the sidebar label
+verbatim. Two valid forms:
+
+- **Form A — H1 = sidebar label exactly.** Use when the sidebar label
+  is itself the most direct page subject (e.g., `/reports` → H1
+  *"Reports"*). No eyebrow needed; the sidebar is right there.
+- **Form B — H1 declarative + eyebrow = sidebar label.** Use when the
+  page deserves a more substantive H1. The eyebrow above the H1 must
+  match the sidebar label exactly, in `text-brand-silver`, uppercase,
+  tracking-wider, weight 500. This anchors a declarative claim back to
+  the sidebar without the H1 having to restate it.
+
+**Examples in the codebase:**
+
+- `/` → eyebrow *"Institutional AI Initiative"* + H1 *"AI work at the
+  University of Idaho"* (Form B; "Home" is generic so the initiative
+  name is the anchor).
+- `/portfolio` → eyebrow *"The Work"* + H1 *"AI Interventions for
+  Operational Excellence"* (Form B).
+- `/standards` → eyebrow *"Standards"* (in `app/standards/layout.tsx`)
+  + H1 *"Software-development and user-experience standards"* (Form B).
+- `/reports` → H1 *"Reports"* (Form A).
+- `/builder-guide` → H1 *"Submit a Project"* (Form A).
+- `/about` → eyebrow *"About"* + H1 *"The Institutional AI Initiative"*
+  (Form B).
+
+**Capitalization:** Sidebar uses Title Case. Page headings and eyebrows
+must agree with the sidebar's casing exactly. *"Submit a project"* is a
+bug; *"Submit a Project"* is the canonical form.
+
+**When updating navigation:** if you rename a sidebar entry, update the
+matching eyebrow or H1 on its destination page in the same change.

--- a/app/builder-guide/page.tsx
+++ b/app/builder-guide/page.tsx
@@ -1180,7 +1180,7 @@ export default function BuilderGuidePage() {
     return (
       <div className="space-y-10">
         <div>
-          <h1 className="text-3xl font-black tracking-tight text-brand-black">Submit a project</h1>
+          <h1 className="text-3xl font-black tracking-tight text-brand-black">Submit a Project</h1>
           <p className="mt-2 text-ink-muted">
             Your assessment and recommendations.
           </p>
@@ -1203,7 +1203,7 @@ export default function BuilderGuidePage() {
     <div className="space-y-10">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-black tracking-tight text-brand-black">Submit a project</h1>
+        <h1 className="text-3xl font-black tracking-tight text-brand-black">Submit a Project</h1>
         <p className="mt-2 max-w-3xl text-ink-muted">
           Nine short questions. The assessment classifies the project,
           surfaces similar work already in the inventory, and routes the

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -104,7 +104,10 @@ export default async function PortfolioPage({
     <div className="space-y-10">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-black tracking-tight text-brand-black">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          The Work
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
           AI Interventions for Operational Excellence
         </h1>
         <p className="mt-2 max-w-3xl text-gray-600">

--- a/app/standards/layout.tsx
+++ b/app/standards/layout.tsx
@@ -9,7 +9,7 @@ export default function StandardsLayout({
     <div>
       <header className="mb-10 border-b border-gray-200">
         <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
-          Institutional Standards
+          Standards
         </p>
         <div className="mt-4">
           <StandardsSubNav />


### PR DESCRIPTION
Closes #121.

## Summary

Finishes the sidebar/page-heading reconciliation flagged by [`/critique`](https://github.com/ui-insight/AISPEG/issues/122). The landing-card half closed in #123; this PR documents the rule and sweeps the destination pages.

## What changed

### 1. Rule documented in [`.impeccable.md`](.impeccable.md)

A page's heading thread must include the sidebar label verbatim. Two valid forms:

- **Form A** — `H1 = sidebar label exactly` (e.g., `/reports` → H1 *"Reports"*)
- **Form B** — `H1 declarative + eyebrow = sidebar label` (e.g., `/portfolio` → eyebrow *"The Work"* + H1 *"AI Interventions for Operational Excellence"*)

Casing must match the sidebar exactly. Future renames must update both surfaces in the same change.

### 2. Page sweep

| Page | Before | After | Form |
|---|---|---|---|
| /portfolio | no eyebrow, declarative H1 | eyebrow *"The Work"* + H1 unchanged | B |
| /standards | eyebrow *"Institutional Standards"* | eyebrow *"Standards"* (matches sidebar) | B |
| /builder-guide | H1 *"Submit a project"* | H1 *"Submit a Project"* (Title Case) | A |
| /reports | already H1 *"Reports"* | unchanged | A |
| /about | already eyebrow + declarative H1 | unchanged | B |

### 3. Live-verified

- `/standards` eyebrow now renders `"STANDARDS"` ✓
- `/builder-guide` H1 now renders `"Submit a Project"` ✓
- `/portfolio` renders the DB-fallback page locally (Postgres offline in dev). Source change is correct.

## Branch interaction with #124

This branch was cut from `main` before [#124](https://github.com/ui-insight/AISPEG/pull/124) (sitewide gold sweep) merged, so the eyebrow on `/standards` still renders `text-ui-gold-dark` here in isolation. When both PRs merge to main, the gold→silver color change from #124 stacks cleanly on top of the label change in this PR (different attribute, different line). No conflict expected.

If #124 merges first, this PR will need a trivial rebase (or GitHub will show no conflict and merge clean). If this merges first, #124 will rebase clean.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Live-verified label changes on `/standards` and `/builder-guide`
- [x] `.impeccable.md` rule reads correctly
- [ ] Reviewer: confirm "The Work" as the eyebrow for the portfolio page (rather than e.g., "Portfolio" or "Interventions") — it matches the sidebar but is a creative label

## Tracking issue

[#122](https://github.com/ui-insight/AISPEG/issues/122) — once #124 and this PR both merge, all five priority issues from the 2026-05-02 critique are closed. Remaining: `/polish` final pass + re-run `/critique`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)