### PR TITLE
Polish pass — finish the gold sweep, harmonize a few details

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,7 +12,7 @@ export default function AboutPage() {
     <div className="space-y-12">
       {/* Header */}
       <header>
-        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           About
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
@@ -56,12 +56,12 @@ export default function AboutPage() {
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <Link
             href="/portfolio"
-            className="group block rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+            className="group block rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
           >
-            <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
               The Work
             </p>
-            <h3 className="mt-2 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            <h3 className="mt-2 text-base font-semibold text-ui-charcoal">
               Portfolio of AI interventions
             </h3>
             <p className="mt-2 text-sm text-gray-600">
@@ -72,12 +72,12 @@ export default function AboutPage() {
           </Link>
           <Link
             href="/builder-guide"
-            className="group block rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+            className="group block rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
           >
-            <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
               Submit a Project
             </p>
-            <h3 className="mt-2 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            <h3 className="mt-2 text-base font-semibold text-ui-charcoal">
               9-step assessment
             </h3>
             <p className="mt-2 text-sm text-gray-600">
@@ -89,12 +89,12 @@ export default function AboutPage() {
           </Link>
           <Link
             href="/standards"
-            className="group block rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+            className="group block rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
           >
-            <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
               Standards
             </p>
-            <h3 className="mt-2 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            <h3 className="mt-2 text-base font-semibold text-ui-charcoal">
               Outstanding institutional standards
             </h3>
             <p className="mt-2 text-sm text-gray-600">
@@ -106,12 +106,12 @@ export default function AboutPage() {
           </Link>
           <Link
             href="/reports"
-            className="group block rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+            className="group block rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
           >
-            <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
               Reports
             </p>
-            <h3 className="mt-2 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            <h3 className="mt-2 text-base font-semibold text-ui-charcoal">
               Activity reports and briefs
             </h3>
             <p className="mt-2 text-sm text-gray-600">
@@ -149,7 +149,7 @@ export default function AboutPage() {
               Start with{" "}
               <Link
                 href="/builder-guide"
-                className="text-ui-gold-dark hover:underline"
+                className="text-brand-black hover:underline"
               >
                 Submit a Project
               </Link>
@@ -166,7 +166,7 @@ export default function AboutPage() {
               The{" "}
               <Link
                 href="/docs"
-                className="text-ui-gold-dark hover:underline"
+                className="text-brand-black hover:underline"
               >
                 Documentation
               </Link>{" "}
@@ -174,7 +174,7 @@ export default function AboutPage() {
               MindRouter integration. Use{" "}
               <Link
                 href="/portfolio"
-                className="text-ui-gold-dark hover:underline"
+                className="text-brand-black hover:underline"
               >
                 The Work
               </Link>{" "}
@@ -187,7 +187,7 @@ export default function AboutPage() {
 
       {/* AI4RA partnership */}
       <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Partnership
         </p>
         <h2 className="mt-2 text-lg font-semibold text-ui-charcoal">
@@ -211,7 +211,7 @@ export default function AboutPage() {
         <p className="mt-4 text-sm">
           <Link
             href="/ai4ra-ecosystem"
-            className="font-medium text-ui-gold-dark hover:underline"
+            className="font-medium text-brand-black hover:underline"
           >
             See the AI4RA ecosystem in detail &rarr;
           </Link>
@@ -220,7 +220,7 @@ export default function AboutPage() {
 
       {/* Repo / charter history */}
       <section className="rounded-xl bg-ui-charcoal p-6 text-white">
-        <h2 className="text-base font-semibold text-ui-gold">
+        <h2 className="text-base font-semibold text-white">
           A note on the repository name
         </h2>
         <p className="mt-3 text-sm leading-relaxed text-white/80">
@@ -275,7 +275,7 @@ export default function AboutPage() {
           channels. To submit a project idea, use{" "}
           <Link
             href="/builder-guide"
-            className="text-ui-gold-dark hover:underline"
+            className="text-brand-black hover:underline"
           >
             Submit a Project
           </Link>

--- a/app/ai4ra-ecosystem/page.tsx
+++ b/app/ai4ra-ecosystem/page.tsx
@@ -163,10 +163,10 @@ export default function AI4RAEcosystemPage() {
               href={p.repoUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+              className="group flex h-full flex-col rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
             >
               <div className="flex items-start justify-between gap-2">
-                <h3 className="text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+                <h3 className="text-base font-semibold text-ui-charcoal">
                   {p.name}
                 </h3>
                 {p.isPrivate && (
@@ -179,7 +179,7 @@ export default function AI4RAEcosystemPage() {
               <p className="mt-3 text-sm leading-relaxed text-gray-600">
                 {p.description}
               </p>
-              <p className="mt-auto pt-4 text-xs font-medium text-ui-gold-dark group-hover:underline">
+              <p className="mt-auto pt-4 text-xs font-medium text-brand-black group-hover:underline">
                 View on GitHub &rarr;
               </p>
             </a>
@@ -205,9 +205,9 @@ export default function AI4RAEcosystemPage() {
             <Link
               key={i.slug}
               href={`/portfolio/${i.slug}`}
-              className="group rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-ui-gold/40"
+              className="group rounded-lg border border-hairline bg-white p-4 transition-shadow hover:shadow-md"
             >
-              <p className="text-sm font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+              <p className="text-sm font-semibold text-ui-charcoal">
                 {i.name}
               </p>
               <p className="mt-1 text-xs text-gray-500">{i.tagline}</p>
@@ -229,7 +229,7 @@ export default function AI4RAEcosystemPage() {
         <p className="mt-3">
           <Link
             href="/portfolio"
-            className="font-medium text-ui-gold-dark hover:underline"
+            className="font-medium text-brand-black hover:underline"
           >
             See the UI portfolio &rarr;
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -96,7 +96,7 @@ export default async function Home() {
           href="/builder-guide"
           className="group block rounded-xl bg-brand-gold p-8 transition-colors hover:bg-brand-gold-dark"
         >
-          <p className="text-xs font-semibold uppercase tracking-wider text-brand-black/70">
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-black/70">
             Have an AI project idea?
           </p>
           <h2 className="mt-2 text-2xl text-brand-black">Submit a Project</h2>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -52,7 +52,7 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
         <span className="text-xs text-gray-400">{artifact.dateLabel}</span>
       </div>
 
-      <h2 className="mt-3 text-lg font-semibold text-ui-charcoal">
+      <h2 className="mt-3 text-lg font-bold text-ui-charcoal">
         {artifact.title}
         {isExternal && (
           <span className="ml-1 inline-flex translate-y-px text-gray-400">
@@ -111,7 +111,7 @@ function ArtifactCard({ artifact }: { artifact: Artifact }) {
 function FeaturedHero({ artifact }: { artifact: Artifact }) {
   const isExternal = !!artifact.external;
   const inner = (
-    <article className="group relative rounded-xl bg-brand-black p-7 text-white shadow-sm transition-shadow hover:shadow-md">
+    <article className="group relative rounded-xl bg-brand-black p-6 text-white shadow-sm transition-shadow hover:shadow-md">
       <div className="flex flex-wrap items-baseline gap-3">
         <span className="rounded-full bg-ui-gold/20 px-2.5 py-0.5 text-xs font-medium text-ui-gold">
           {artifact.subtitle ?? kindLabel(artifact.kind)}


### PR DESCRIPTION
The final polish pass for the [#122](https://github.com/ui-insight/AISPEG/issues/122) critique remediation arc.

## What this catches

[#124](https://github.com/ui-insight/AISPEG/pull/124) swept the four primary surfaces (`/portfolio`, `/standards`, `/reports`, `/builder-guide`) and shared components but missed `/about` and `/ai4ra-ecosystem`, which still carried the old hover-gold-border / gold-dark-eyebrow / gold-link-hover pattern. Plus a few consistency nits surfaced while reviewing the primary surfaces.

## Gold sweep — finish the work

- **`/about`** — 21 gold occurrences demoted following the #124 rules:
  - Page header eyebrow + four organization-card eyebrows + Partnership section eyebrow → `text-brand-silver`
  - Card hover-borders (`hover:border-ui-gold/40`) and heading group-hovers removed
  - Body links inside paragraphs → `text-brand-black` with underline-on-hover
  - The *"A note on the repository name"* h2 inside the dark callout moves from gold to white. Single-emphasis-on-dark is OK for a hero claim, but this is a parenthetical footnote, so the dark surface itself carries the emphasis.
- **`/ai4ra-ecosystem`** — 6 gold occurrences demoted: reference-project card hover-borders + heading hovers, the *"View on GitHub →"* CTA arrow, the related-intervention chips, and the *"See the UI portfolio"* link.

## Polish on the primary surfaces

- **Reports featured hero**: padding harmonised from `p-7` to `p-6` to match the brief cards. Tighter vertical rhythm without sacrificing emphasis.
- **Reports brief-card titles**: bumped from `font-semibold` to `font-bold` so the hierarchy against the body text and tag chips is sharper. Aligns with the brand's emphasis-via-weight philosophy.
- **Landing Submit-a-Project CTA banner eyebrow**: harmonized from `font-semibold` to `font-medium` so it matches every other eyebrow on the page. The banner's gold background already does the primary-CTA work; the eyebrow doesn't need extra weight.

## Test plan

- [x] Verified visually on `/about`, `/ai4ra-ecosystem`, `/reports`, `/`
- [x] `npx tsc --noEmit` passes
- [x] `grep` confirms zero gold remaining in `/about` and `/ai4ra-ecosystem`
- [x] Spot-checked the dark "A note on the repository name" panel — h2 reads cleanly in white

## Sitewide gold-keep set after this PR

The 23 remaining intentional gold uses are unchanged from #124:

- Sidebar active nav state and header eyebrow
- All form focus rings on `/builder-guide`
- Quiz selected/active states (radio + multi-select)
- Primary CTA buttons (`bg-ui-gold`)
- Progress bar fill
- Featured artifact hero card on `/reports`
- Featured project chip on the presidential brief
- `10–16x` productivity number on the feb-2026 dark callout
- `Callout` component's `emphasis` variant

## Tracking issue

[#122](https://github.com/ui-insight/AISPEG/issues/122) — once this lands, the polish pass is done. Recommended next step: re-run `/critique` to verify the design-health score moves from 26/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)