### PR TITLE
Eyebrow rule by surface + RECENT_PICKS rename

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -173,3 +173,35 @@ bug; *"Submit a Project"* is the canonical form.
 
 **When updating navigation:** if you rename a sidebar entry, update the
 matching eyebrow or H1 on its destination page in the same change.
+
+## Eyebrow Color by Surface
+
+The default eyebrow treatment in [Form B above](#page-heading-and-eyebrow-rule)
+is `text-brand-silver` on a light surface. Other surfaces need different
+text colors so the eyebrow stays legible without breaking the eyebrow
+vocabulary. Pick by surface, not by mood.
+
+| Surface | Eyebrow color | Class | Where it shows up |
+|---|---|---|---|
+| Light (white, `surface-alt`) | Brand silver | `text-brand-silver` | Default. All landing-and-page eyebrows. |
+| Saturated light (Pride Gold, gold-tint, clearwater-tint) | Brand black at 70% opacity | `text-brand-black/70` | CTA panels, emphasis-tone callouts. Reserve for the rare gold/saturated focal moment. |
+| Dark (Brand Black, `ui-charcoal`) | White at 60% opacity | `text-white/60` | Sidebar header subtitle, dark callouts, the featured-artifact hero on `/reports` (subtitle line, not the kind chip). |
+
+**Always weight 500** (`font-medium`) **and `tracking-wider`** regardless
+of surface. The color is the only axis that varies.
+
+### Domain-accent eyebrows (exception, not the rule)
+
+The Data Model surfaces under `/standards/data-model/` use Brand
+Clearwater (`text-brand-clearwater`) for **domain labels** above the H1
+(*"Research administration,"* *"Strategic plan,"* etc.). These are not
+wayfinding eyebrows — they are categorical accents that distinguish
+domain context within a multi-domain catalog, and the color is
+load-bearing information. Keep them clearwater. Do not propagate this
+treatment to other pages as a default.
+
+**Test for "is this a domain-accent eyebrow?":** the label changes
+based on which item the user is viewing, and the color carries
+meaning beyond decoration. If both are true, clearwater is fine. If
+the eyebrow is fixed (e.g., *"The Work"* on every visit to
+`/portfolio`), it's a wayfinding eyebrow — use brand-silver.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,14 +4,19 @@ import { sortedArtifacts } from "@/lib/artifacts";
 
 export const dynamic = "force-dynamic";
 
-const RECENT_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
+// Editorial pick of three featured interventions for the landing's
+// Work tile. Curated by IIDS — rotate when the work changes. There is
+// no automated freshness signal on Intervention yet (no lastUpdated
+// field; tracked for a future schema extension), so framing must stay
+// editorial: the order is curator's choice, not "most recent."
+const FEATURED_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
 
 export default async function Home() {
   const all = getPubliclyVisible();
   const interventionCount = all.length;
   const homeUnitCount = new Set(all.flatMap((i) => i.homeUnits)).size;
   const mostRecent = sortedArtifacts()[0]?.dateLabel;
-  const recentPicks = RECENT_PICKS
+  const featuredPicks = FEATURED_PICKS
     .map((slug) => all.find((i) => i.slug === slug))
     .filter((i): i is NonNullable<typeof i> => i !== undefined);
 
@@ -70,7 +75,7 @@ export default async function Home() {
             Projects, their operational owners, and current status.
           </p>
           <ul className="mt-6 divide-y divide-hairline border-y border-hairline">
-            {recentPicks.map((p) => (
+            {featuredPicks.map((p) => (
               <li key={p.slug} className="py-3">
                 <p className="text-base font-semibold text-brand-black">
                   {p.name}


### PR DESCRIPTION
Closes #129, #130.

## #129 — eyebrow color by surface

Documents the eyebrow color rule for the three surface types in [`.impeccable.md`](.impeccable.md), extending the page-heading-and-eyebrow section landed in #125.

| Surface | Eyebrow color | Class |
|---|---|---|
| Light (white, `surface-alt`) | Brand silver | `text-brand-silver` |
| Saturated light (gold, clearwater-tint) | Brand black at 70% | `text-brand-black/70` |
| Dark (Brand Black, `ui-charcoal`) | White at 60% | `text-white/60` |

Plus a documented exception for "domain-accent eyebrows" — the clearwater labels on the Data Model sub-pages (*"Research administration,"* etc.) are categorical accents where color carries information, not wayfinding. A short test for when the exception applies is included.

**Audit:** there are no current eyebrow violations on the four primary surfaces. The gold Submit panel that originally surfaced this issue was removed in #134; all other landing/portfolio/standards/reports/about eyebrows are already `text-brand-silver`. Two residual `text-ui-gold-dark` eyebrows in `/internal/*` and `/intake/[token]` are out of scope for this PR (internal-only audience, folded into the polish cluster #132).

## #130 — `RECENT_PICKS` rename

The constant in [`app/page.tsx`](app/page.tsx) was named `RECENT_PICKS` but the data is editorial — three hand-curated slugs that don't change based on any timestamp. Renamed to `FEATURED_PICKS` with a curator-policy comment.

The visual treatment doesn't say *"recent"* anywhere user-visible, so no UI change is needed. Pure rename + comment. The rendered output is byte-identical (same three names render: Strategic Plan Dashboard, Audit Dashboard, Vandalizer).

The `lastUpdated` field on `Intervention` is still tracked as a future schema extension. If/when it lands, the `FEATURED_PICKS` approach can be swapped for a computed-by-recency selector without touching the page-level rendering.

## Diff stats

`2 files changed, +40 / -3`. Mostly the new `.impeccable.md` section.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Grep confirms no stale `RECENT_PICKS` or `recentPicks` references anywhere
- [x] Live page renders the same three named owners
- [x] `.impeccable.md` rule reads cleanly and the domain-accent exception is unambiguous

## Tracking

[#133](https://github.com/ui-insight/AISPEG/issues/133) — round-2 tracker. After this lands, only [#132](https://github.com/ui-insight/AISPEG/issues/132) (polish cluster) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)