### PR TITLE
Polish cluster: H1 weight, mobile backdrop, sidebar order

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default async function Home() {
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Institutional AI Initiative
         </p>
-        <h1 className="mt-2 text-4xl leading-tight">
+        <h1 className="mt-2 text-4xl font-black leading-tight">
           AI work at the University of Idaho
         </h1>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 const primaryItems = [
   { href: "/", label: "Home", icon: "squares" },
   { href: "/portfolio", label: "The Work", icon: "grid" },
-  { href: "/standards", label: "Standards", icon: "shield" },
   { href: "/builder-guide", label: "Submit a Project", icon: "compass" },
+  { href: "/standards", label: "Standards", icon: "shield" },
   { href: "/reports", label: "Reports", icon: "document" },
 ];
 
@@ -84,7 +84,7 @@ export default function Sidebar() {
 
       {mobileOpen && (
         <div
-          className="fixed inset-0 z-30 bg-black/50 lg:hidden"
+          className="fixed inset-0 z-30 bg-brand-black/50 lg:hidden"
           onClick={() => setMobileOpen(false)}
         />
       )}


### PR DESCRIPTION
Closes #132. Last open issue from the round-2 [tracker](https://github.com/ui-insight/AISPEG/issues/133).

## Scope

#132 originally bundled five items. Two were resolved as a side effect of #134's evaluator-first reshape:

- ❌ ~Reports landing card body duplicates the heading~ — the Reports card was removed from the landing entirely.
- ❌ ~"Coordinated by IIDS" appears three times~ — the lede absorbed the phrase, the state strip dropped it, leaving two verbatim mentions sitewide (sidebar header + lede). At threshold.

The remaining three landed in this PR.

## What changed

**1. Landing H1 declares `font-black` explicitly.** Previously [`app/page.tsx`](app/page.tsx) had `text-4xl leading-tight` only, with weight 900 inherited from the `@layer base main h1` cascade in [`app/globals.css`](app/globals.css). Now self-contained — the heading keeps its weight even if it ever moves out of `<main>`.

**2. Mobile drawer backdrop on [`components/Sidebar.tsx:87`](components/Sidebar.tsx) changed from `bg-black/50` → `bg-brand-black/50`.** The detector previously flagged the prior token as the `pure-black-white` antipattern. The brand-tinted neutral matches the rest of the dark surfaces (sidebar body, About repo callout) at `#191919`.

**3. Sidebar order: `Home / The Work / Submit a Project / Standards / Reports`.** The prior order put Standards before Submit, inverting the typical practitioner flow (submit → standards-check, not the reverse). Cheap reorder in [`components/Sidebar.tsx:7-13`](components/Sidebar.tsx).

## Diff stats

`2 files changed, +3 / -3`. Three one-token edits.

## Verification

- [x] `npx impeccable --json app/page.tsx app/layout.tsx components/Sidebar.tsx` returns `[]` (exit 0) — the previously-flagged Sidebar finding is resolved.
- [x] `npx tsc --noEmit` passes.
- [x] Live page: H1 computed `font-weight: 900` confirmed via `preview_inspect`.
- [x] Sidebar order verified visually: Home / The Work / Submit a Project / Standards / Reports.

## Round-2 closing state

After this merges, all six round-2 issues are closed:

- ✅ #127 — hero lede (closed by #134)
- ✅ #128 — Submit demote (closed by #134)
- ✅ #129 — eyebrow rule by surface (closed by #135)
- ✅ #130 — `FEATURED_PICKS` rename (closed by #135)
- ✅ #131 — Reports + Standards architectural decision (closed by #134)
- ✅ #132 — polish cluster (this PR)

Then the [#133](https://github.com/ui-insight/AISPEG/issues/133) tracker can close after a third `/critique` re-run records the final score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)