### PR TITLE
Landing: reintroduce Submit/Standards/Reports as proof-point tiles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getPubliclyVisible } from "@/lib/portfolio";
-import { sortedArtifacts } from "@/lib/artifacts";
+import { artifacts, sortedArtifacts } from "@/lib/artifacts";
+import { summary as standardsSummary } from "@/lib/standards-watch";
 
 export const dynamic = "force-dynamic";
 
@@ -19,6 +20,8 @@ export default async function Home() {
   const featuredPicks = FEATURED_PICKS
     .map((slug) => all.find((i) => i.slug === slug))
     .filter((i): i is NonNullable<typeof i> => i !== undefined);
+  const standards = standardsSummary();
+  const reportCount = artifacts.length;
 
   return (
     <div className="space-y-10">
@@ -68,7 +71,7 @@ export default async function Home() {
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
             The Work
           </p>
-          <h2 className="mt-2 text-2xl">
+          <h2 className="mt-2 text-2xl font-semibold">
             {interventionCount} AI interventions across UI units
           </h2>
           <p className="mt-2 text-sm text-ink-muted">
@@ -98,12 +101,74 @@ export default async function Home() {
         </Link>
       </section>
 
-      <p className="text-sm text-ink-muted">
-        Have a project idea?{" "}
-        <Link href="/builder-guide" className="font-medium text-brand-black">
-          Start the assessment &rarr;
+      <section className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/builder-guide"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Submit a Project
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            9-step assessment
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            Routes to a named IIDS owner with a 2-business-day SLA.
+          </p>
+          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
+            Start &rarr;
+          </p>
         </Link>
-      </p>
+
+        <Link
+          href="/standards"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Standards
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            Software + UX standards
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            <span className="font-semibold text-brand-black">
+              {standards.outstanding}
+            </span>{" "}
+            outstanding asks. Oldest is{" "}
+            <span className="font-semibold text-brand-black">
+              {standards.oldestOutstanding} days
+            </span>{" "}
+            old.{" "}
+            <span className="font-semibold text-brand-black">
+              {standards.counts.published}
+            </span>{" "}
+            published.
+          </p>
+          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
+            View &rarr;
+          </p>
+        </Link>
+
+        <Link
+          href="/reports"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Reports
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            Activity reports + briefs
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            <span className="font-semibold text-brand-black">{reportCount}</span>{" "}
+            published. Latest:{" "}
+            <span className="font-semibold text-brand-black">{mostRecent}</span>.
+          </p>
+          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
+            Browse &rarr;
+          </p>
+        </Link>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
Closes #137, #138, #139.

The round-3 critique caught what insiders couldn't see: round-2's evaluator-first reshape (#134) collapsed the four-pillar IA to a single Work card on the home page. The blind agent's complaint was *"the page reads as a portfolio site, not a coordination site with four pillars."* Fair — we over-corrected.

This brings the other three pillars back as a smaller sibling strip, but with two key differences from the round-1 grid the original critique flagged.

## What's different from round-1

**1. Each tile carries a fact, not a description.**

| Tile | Proof point |
|---|---|
| Submit a Project | *"Routes to a named IIDS owner with a 2-business-day SLA."* |
| Standards | *"20 outstanding asks. Oldest is 77 days old. 0 published."* (live from `lib/standards-watch.ts`) |
| Reports | *"3 published. Latest: April 21, 2026."* (live from `lib/artifacts.ts`) |

The Standards tile in particular tells a Provost more about UI's governance posture in 12 words than a click-through could. *"77 days since the oldest of 20 outstanding asks, 0 published"* is exactly the evidence-forward voice the brand brief asks for.

**2. Hierarchy is preserved.**

- The Work tile stays wide with the only solid-gold button on the page.
- The three sibling tiles use `p-5`, `text-base h3`, no gold, hairline border.
- The gold CTA still wins as the focal moment.

## Card H2 hierarchy (#138)

`app/page.tsx:71` previously declared `<h2 className="mt-2 text-2xl">` and inherited `font-weight: 900` from the `@layer base main h2` rule in `globals.css`. The card H2 then read visually heavier than the page H1 — hierarchy inversion.

Fix: explicit `font-semibold`. The page H1 is now the only weight-900 element on the surface. *"Hierarchy through scale + weight contrast"* with **one weight per surface** discipline preserved.

## Submit visibility (#139)

Resolved by the Submit tile. The text-link footnote (*"Have a project idea? Start the assessment →"*) is gone — replaced by a peer tile carrying the SLA proof point. Audience #2 (submitters) get a visible affordance again; Audience #1 (evaluators) still see the gold Work-tile CTA as the focal action.

## Diff stats

`1 file changed, +72 / -7`. Adds three tiles, swaps one weight, removes one paragraph.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Verified at 1280×1400 desktop — three tiles in row, gold button still focal
- [x] Verified at 375×1700 mobile — tiles stack cleanly
- [x] Standards count is live (changes if `lib/standards-watch.ts` changes)
- [x] Reports count is live (changes if `lib/artifacts.ts` changes)
- [ ] Reviewer: confirm the SLA copy *"2-business-day SLA"* is accurate

## What this leaves open

From [#143](https://github.com/ui-insight/AISPEG/issues/143) round-3 tracker:

- #140 — define *"intervention"* and *"IIDS"* above the fold *(`/clarify`)*
- #141 — stat strip flat *(`/layout` or `/typeset`)*
- #142 — polish cluster: sidebar icons, mobile H1, `force-dynamic` *(`/polish`)*

Score projection: addresses Heuristics 4, 8, and indirectly 10. Round-3 target was 33+/40 if all P1 items land; this PR knocks out two of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)