### PR TITLE
Add workCategories taxonomy and tag the 15 interventions

### DIFF
--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -10,6 +10,8 @@
 // mcp-ecfr, etc.) live on /ai4ra-ecosystem, not here.
 // ============================================================
 
+import type { WorkCategory } from "./work-categories";
+
 export type Visibility =
   | "Public"       // Everything about this entry can be shown publicly
   | "Partial"      // Entry acknowledged; UI deployment details embargoed
@@ -78,6 +80,10 @@ export interface Intervention {
   tags?: string[];
   trackingOnly?: boolean;
   relatedSlugs?: string[];
+
+  // "By problem" exploration axis — see lib/work-categories.ts.
+  // One intervention can sit in 2-3 categories.
+  workCategories?: WorkCategory[];
 }
 
 export const interventions: Intervention[] = [
@@ -104,6 +110,7 @@ export const interventions: Intervention[] = [
     operationalExcellenceOutcome:
       "Makes strategic execution visible. Surfaces under-served priorities, cross-unit synergies, and misalignment. Supports investment prioritization conversations.",
     tech: ["React 19", "TypeScript", "Tailwind v4", "FastAPI", "PostgreSQL"],
+    workCategories: ["executive-analytics"],
   },
 
   // ============================================================
@@ -129,6 +136,7 @@ export const interventions: Intervention[] = [
       "Closes the audit follow-through loop. Reduces risk of observations lingering past target dates. Gives leadership a living compliance-posture view.",
     tech: ["React 19", "FastAPI", "PostgreSQL 16", "MindRouter", "Qwen3"],
     relatedSlugs: ["mindrouter", "dgx-stack", "template-app"],
+    workCategories: ["documents", "reconciliation"],
   },
 
   // ============================================================
@@ -158,6 +166,7 @@ export const interventions: Intervention[] = [
       "Faster newsletter turnaround. Enforces AP + UI style consistently across issues. Reduces manual editorial burden per issue.",
     tech: ["React 19", "FastAPI", "SQLAlchemy 2.0", "MindRouter"],
     relatedSlugs: ["mindrouter"],
+    workCategories: ["documents", "process"],
   },
 
   // ============================================================
@@ -182,6 +191,7 @@ export const interventions: Intervention[] = [
     dualDestinyPlanned: true,
     operationalFunction: "Embargoed.",
     operationalExcellenceOutcome: "Embargoed.",
+    workCategories: ["research-admin"],
   },
   {
     slug: "vandalizer",
@@ -209,6 +219,7 @@ export const interventions: Intervention[] = [
       "Staff time savings on document extraction. Higher extraction accuracy. Reusable extraction workflows. Citation-backed Q&A over RA document collections.",
     tech: ["React 19", "Python 3.11+", "FastAPI", "Docker"],
     relatedSlugs: ["embargoed-osp", "mindrouter", "dgx-stack", "processmapping"],
+    workCategories: ["documents", "research-admin"],
   },
   {
     slug: "processmapping",
@@ -231,6 +242,7 @@ export const interventions: Intervention[] = [
       "Shared vocabulary and visibility for RA processes. Identifies process/tool coverage gaps. Requirements source for automation. Onboarding and training asset.",
     tech: ["React 19", "TypeScript", "Vite", "FastAPI", "Python 3.11+"],
     relatedSlugs: ["embargoed-osp", "vandalizer"],
+    workCategories: ["process", "research-admin"],
   },
 
   // ============================================================
@@ -259,6 +271,7 @@ export const interventions: Intervention[] = [
       "On-prem, UDM-aligned ERA system with shared data semantics across ORED tooling. Enables AI features (extraction, lookup, classification) on research-admin data without third-party data egress. Reference deployment for AI4RA partners.",
     tech: ["React", "TypeScript", "Tailwind CSS", "FastAPI", "SQLAlchemy 2.0", "PostgreSQL 16"],
     relatedSlugs: ["vandalizer", "processmapping", "embargoed-osp"],
+    workCategories: ["research-admin"],
   },
 
   // ============================================================
@@ -283,6 +296,7 @@ export const interventions: Intervention[] = [
       "Tracks federal Executive Orders, applicability to UI, required actions, deadlines, responsible parties, and current posture.",
     operationalExcellenceOutcome:
       "Systematic EO response posture. Reduces scramble when new EOs drop. Living view of EO-driven obligations for leadership.",
+    workCategories: ["documents", "process"],
   },
 
   // ============================================================
@@ -310,6 +324,7 @@ export const interventions: Intervention[] = [
       "Consolidates fragmented student engagement tracking. Supports recruitment/retention reporting. Demonstrates unit-led co-build pattern — a repeatable path for other UI units to develop their own AI-assisted tooling.",
     tags: ["diffusion"],
     relatedSlugs: ["template-app"],
+    workCategories: ["coordination"],
   },
 
   // ============================================================
@@ -333,6 +348,7 @@ export const interventions: Intervention[] = [
     operationalExcellenceOutcome:
       "Cohort visibility for program leaders. Data-driven program improvement. Stronger NSF CAREER-grant pipeline.",
     tech: ["React", "TypeScript", "Vite", "FastAPI"],
+    workCategories: ["executive-analytics"],
   },
 
   // ============================================================
@@ -360,6 +376,7 @@ export const interventions: Intervention[] = [
       "Enables every downstream AI app at UI. Keeps data on-prem for compliance. Avoids per-seat vendor lock-in. Institutional audit trail. Fair access across research and operations workloads.",
     tech: ["Python 3.11+", "Docker", "Ollama", "vLLM", "Azure AD SSO"],
     relatedSlugs: ["dgx-stack", "audit-dashboard", "vandalizer", "ucm-daily-register"],
+    workCategories: ["ai-infrastructure"],
   },
   {
     slug: "dgx-stack",
@@ -382,6 +399,7 @@ export const interventions: Intervention[] = [
       "On-prem AI compute without cloud recurring costs. Supports compliance-sensitive and air-gapped workloads. Backbone for institutional OCR and LLM serving.",
     tech: ["Docker", "vLLM", "NVIDIA Container Toolkit", "CUDA 13"],
     relatedSlugs: ["mindrouter", "audit-dashboard", "vandalizer"],
+    workCategories: ["ai-infrastructure"],
   },
   {
     slug: "template-app",
@@ -411,6 +429,7 @@ export const interventions: Intervention[] = [
       "embargoed-osp",
       "nexus",
     ],
+    workCategories: ["ai-infrastructure"],
   },
 
   // ============================================================
@@ -456,6 +475,7 @@ export const interventions: Intervention[] = [
     operationalExcellenceOutcome:
       "Standardizes where institutional application modules live. Shared security posture, audit trail, and operational footprint across UI units. Reduces per-app hosting overhead and fragmentation.",
     relatedSlugs: ["template-app"],
+    workCategories: ["ai-infrastructure"],
   },
 ];
 

--- a/lib/work-categories.ts
+++ b/lib/work-categories.ts
@@ -1,0 +1,104 @@
+// ============================================================
+// Work Categories — "By problem" exploration axis
+// ============================================================
+// A taxonomy of the kinds of operational work UI's AI interventions help
+// with. Complementary to the home-unit grouping on /portfolio: a Dean
+// asking "I have a [reconciliation / scheduling / document review]
+// problem — is anyone already on it?" can scan by category instead of
+// by which unit owns the work.
+//
+// One intervention can sit in 2-3 categories (multi-tagged). Tags are
+// audience-facing (a Dean's vocabulary), not technical jargon.
+//
+// ------------------------------------------------------------
+// Evolution policy
+// ------------------------------------------------------------
+// Add a category:
+//   1. Append a slug to WORK_CATEGORIES.
+//   2. Add a matching entry in WORK_CATEGORY_LABELS.
+//   3. Tag relevant interventions in lib/portfolio.ts.
+//   ~5 minutes; tsc verifies the label record is exhaustive.
+//
+// Rename a category:
+//   Change the slug in both WORK_CATEGORIES and WORK_CATEGORY_LABELS.
+//   tsc surfaces every callsite that still uses the old slug
+//   (intervention tags + UI consumers) — fix in one pass.
+//
+// Retire a category:
+//   Remove the slug from WORK_CATEGORIES (and from WORK_CATEGORY_LABELS).
+//   tsc finds every intervention still tagged with it — untag in one
+//   pass. Don't soft-delete; if the category is gone, it's gone.
+//
+// Promote to first-class field:
+//   If a category later deserves its own subnavigation or schema
+//   relationship, the typed shape makes migration mechanical: grep for
+//   the slug, lift the matching interventions into whatever new shape
+//   is needed.
+// ============================================================
+
+export const WORK_CATEGORIES = [
+  "documents",
+  "process",
+  "coordination",
+  "reconciliation",
+  "executive-analytics",
+  "research-admin",
+  "knowledge-retrieval",
+  "ai-infrastructure",
+] as const;
+
+export type WorkCategory = (typeof WORK_CATEGORIES)[number];
+
+export const WORK_CATEGORY_LABELS: Record<
+  WorkCategory,
+  { label: string; description: string }
+> = {
+  documents: {
+    label: "Working with documents",
+    description:
+      "Extracting, reviewing, or finding answers in documents — contracts, reports, RFPs, audit findings.",
+  },
+  process: {
+    label: "Streamlining a process",
+    description:
+      "Mapping, automating, or removing bottlenecks from operational workflows.",
+  },
+  coordination: {
+    label: "Coordinating people and time",
+    description:
+      "Calendars, schedules, daily registers, multi-party logistics.",
+  },
+  reconciliation: {
+    label: "Reconciling accounts and records",
+    description:
+      "Financial reviews, audit cycles, matching transactions to source data.",
+  },
+  "executive-analytics": {
+    label: "Executive visibility",
+    description:
+      "Dashboards, strategic alignment, portfolio-level rollups for leadership.",
+  },
+  "research-admin": {
+    label: "Research administration",
+    description:
+      "Proposal lifecycle, awards, sponsor compliance, ORED operations.",
+  },
+  "knowledge-retrieval": {
+    label: "Searching institutional knowledge",
+    description:
+      "Retrieval and Q&A over policies, history, decisions — RAG-style.",
+  },
+  "ai-infrastructure": {
+    label: "AI infrastructure",
+    description:
+      "LLM gateways, GPU stacks, agent platforms — the plumbing other interventions run on, not a problem on its own.",
+  },
+};
+
+export function getWorkCategoryLabel(slug: WorkCategory): string {
+  return WORK_CATEGORY_LABELS[slug].label;
+}
+
+export function getWorkCategoryDescription(slug: WorkCategory): string {
+  return WORK_CATEGORY_LABELS[slug].description;
+}


### PR DESCRIPTION
Foundational data work for the *"By problem" exploration axis* epic ([#154](https://github.com/ui-insight/AISPEG/issues/154)). No UI surface yet — chips, filters, and `/explore` land in #150–#153.

## What changed

- **New** [`lib/work-categories.ts`](lib/work-categories.ts) — 8-category `as const` taxonomy + derived `WorkCategory` union + `WORK_CATEGORY_LABELS` record + evolution-policy header (add / rename / retire / promote).
- **Schema** — `Intervention.workCategories?: WorkCategory[]` added in `lib/portfolio.ts`. Optional + multi-valued.
- **Tagging** — all 14 publicly-visible interventions tagged. `oit-data-modernization` deliberately left untagged as a tracking-only stub.

## Tag map

| Intervention | Tags |
|---|---|
| stratplan | `executive-analytics` |
| audit-dashboard | `documents`, `reconciliation` |
| ucm-daily-register | `documents`, `process` |
| embargoed-osp | `research-admin` |
| vandalizer | `documents`, `research-admin` |
| processmapping | `process`, `research-admin` |
| openera | `research-admin` |
| execord | `documents`, `process` |
| sem-experiential | `coordination` |
| rfd-career | `executive-analytics` |
| mindrouter | `ai-infrastructure` |
| dgx-stack | `ai-infrastructure` |
| template-app | `ai-infrastructure` |
| nexus | `ai-infrastructure` |

Five multi-tagged entries — validates the multi-tag design per the issue's acceptance criteria.

## Verification

- `npx tsc --noEmit` ✅
- `npm run build` ✅

## Acceptance criteria

- [x] `lib/work-categories.ts` exists with constant, type, and label record
- [x] `Intervention.workCategories?: WorkCategory[]` added; existing interventions hand-tagged
- [x] At least one intervention is multi-tagged (five are)
- [x] `npx tsc --noEmit` passes
- [x] Header comment documents the add/rename/retire/promote flow

Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)