### PR TITLE
Render workCategories chips on portfolio cards

### DIFF
--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
+import { WORK_CATEGORY_LABELS } from "@/lib/work-categories";
 
 const statusStyles: Record<string, string> = {
   Production: "bg-green-100 text-green-800",
@@ -146,6 +147,19 @@ export default function PortfolioCard({
         {app.trackingOnly && (
           <span className="rounded-full border border-brand-huckleberry/30 bg-brand-huckleberry/10 px-2 py-0.5 text-xs font-medium text-brand-huckleberry">
             Tracked (not built by IIDS)
+          </span>
+        )}
+        {app.workCategories.slice(0, 3).map((slug) => (
+          <span
+            key={slug}
+            className="rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-xs font-medium text-brand-black"
+          >
+            {WORK_CATEGORY_LABELS[slug].label}
+          </span>
+        ))}
+        {app.workCategories.length > 3 && (
+          <span className="rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-xs font-medium text-brand-black">
+            +{app.workCategories.length - 3}
           </span>
         )}
       </div>

--- a/db/migrations/006_work_categories.sql
+++ b/db/migrations/006_work_categories.sql
@@ -1,0 +1,34 @@
+-- Migration 006: Work Categories
+--
+-- Adds the "by problem" exploration axis to applications. Each row
+-- carries 0–3 audience-facing category slugs (e.g. 'documents',
+-- 'process', 'reconciliation') so /portfolio cards can show the
+-- kinds of operational work each intervention helps with.
+--
+-- Source of truth for the slug set is lib/work-categories.ts. We
+-- intentionally don't add a CHECK constraint enumerating the slugs
+-- here — the typed module on the app side is the audit trail, and
+-- pinning the slug list at the DB layer would couple migration
+-- cadence to taxonomy edits. Membership is enforced by the typed
+-- Intervention shape during seed.
+--
+-- Companion to:
+--   - lib/work-categories.ts (taxonomy)
+--   - lib/portfolio.ts (Intervention.workCategories)
+--   - scripts/seed-portfolio.ts (port into applications.work_categories)
+
+BEGIN;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS work_categories TEXT[] NOT NULL DEFAULT '{}';
+
+-- GIN index — same pattern as the other multi-valued classification
+-- arrays (sensitivity, integrations, etc.) so a future category
+-- facet on /portfolio can filter cheaply via @> array overlap.
+CREATE INDEX IF NOT EXISTS idx_applications_work_categories
+  ON applications USING GIN (work_categories);
+
+INSERT INTO schema_migrations (version) VALUES ('006_work_categories')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -14,6 +14,7 @@
 
 import "server-only";
 import { query } from "./db";
+import type { WorkCategory } from "./work-categories";
 
 export type VisibilityTier = "public" | "embargoed" | "internal";
 export type BlockerSeverity = "low" | "medium" | "high";
@@ -96,6 +97,7 @@ export interface Application {
   tech: string[];
   trackingOnly: boolean;
   relatedSlugs: string[];
+  workCategories: WorkCategory[];
   clickupTaskId: string | null;
   updatedAt: string;
 }
@@ -132,6 +134,7 @@ interface ApplicationRow {
   tech: string[];
   tracking_only: boolean;
   related_slugs: string[];
+  work_categories: string[];
   clickup_task_id: string | null;
   updated_at: string;
 }
@@ -177,6 +180,7 @@ function toApplication(row: ApplicationRow): Application {
     tech: row.tech ?? [],
     trackingOnly: row.tracking_only,
     relatedSlugs: row.related_slugs ?? [],
+    workCategories: ((row.work_categories ?? []) as WorkCategory[]),
     clickupTaskId: row.clickup_task_id,
     updatedAt: row.updated_at,
   };
@@ -220,6 +224,7 @@ const APPLICATION_COLUMNS = `
   operational_function, operational_excellence_outcome,
   features, tech,
   tracking_only, related_slugs,
+  work_categories,
   clickup_task_id, updated_at
 `;
 

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -301,7 +301,8 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        features, tech,
        tracking_only, related_slugs,
        sensitivity, complexity, userbase, auth_level,
-       integrations, data_sources, university_systems, output_types
+       integrations, data_sources, university_systems, output_types,
+       work_categories
      )
      VALUES (
        $1, $2, $3, $4,
@@ -316,7 +317,8 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        $25, $26,
        $27, $28,
        $29, $30, $31, $32,
-       $33, $34, $35, $36
+       $33, $34, $35, $36,
+       $37
      )
      RETURNING id`,
     [
@@ -356,6 +358,7 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
       wizard.data_sources,
       wizard.university_systems,
       wizard.output_types,
+      i.workCategories ?? [],
     ]
   );
 


### PR DESCRIPTION
End-to-end wiring of the `workCategories` taxonomy from [#149](https://github.com/ui-insight/AISPEG/issues/149) through to the rendered card. Closes #150 (Epic 2/5 in [#154](https://github.com/ui-insight/AISPEG/issues/154)).

## Architecture note

`/portfolio` is DB-backed (Sprint 2 landed in [Migration 005](db/migrations/005_friction_ledger.sql)) — the rendered card reads from the `applications` table via `lib/work.ts`, not directly from `lib/portfolio.ts`. So the chip render needs the full plumb, not just the component edit.

## What changed

| Layer | File | Change |
|---|---|---|
| DB | [`db/migrations/006_work_categories.sql`](db/migrations/006_work_categories.sql) | `ALTER applications ADD work_categories TEXT[]` + GIN index |
| Seed | [`scripts/seed-portfolio.ts`](scripts/seed-portfolio.ts) | Include `workCategories` in INSERT |
| Query | [`lib/work.ts`](lib/work.ts) | `workCategories` on `Application` + `ApplicationRow`, mapped in `toApplication`, added to `APPLICATION_COLUMNS` |
| UI | [`components/PortfolioCard.tsx`](components/PortfolioCard.tsx) | Render up to 3 chips + `+N` overflow |

## Design choices

- **No CHECK constraint on slugs at the DB layer.** `lib/work-categories.ts` is the audit trail; pinning slugs in the DB would couple migration cadence to taxonomy edits. Membership is enforced by the typed `Intervention` shape during seed.
- **Neutral chip styling** — `surface-alt` background + `hairline` border + `brand-black` text. Resists per-category color coding per the issue brief and brand-fidelity principle (no decorative variety).
- **Cap at 3 + `+N`** — most interventions carry 1–2 categories, so the overflow won't fire often.

## Verification

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- **Browser verification deferred to dev deploy** — local Postgres tunnel isn't up, so the running preview can't render the card path. Will verify on `aispeg-dev.insight.uidaho.edu` after merge + reseed.

## Deploy + reseed plan (post-merge)

1. SSH to `devops@openera.insight.uidaho.edu`
2. `git pull --ff-only origin main`
3. `docker compose --profile dev up -d --build aispeg-dev`
4. Run Migration 006 against `aispeg_dev`
5. Re-run `scripts/seed-portfolio.ts` per the throwaway-container pattern
6. Visit https://aispeg-dev.insight.uidaho.edu/portfolio and confirm chips render

## Acceptance criteria

- [x] Each portfolio card displays its `workCategories` as small chips
- [x] Chips render in a sensible order alongside existing tags
- [x] If `workCategories` is empty/undefined, no empty space appears (graceful — `slice(0, 3).map` over `[]` yields nothing)
- [ ] Visual regression check at desktop and mobile (post-merge dev deploy)
- [x] Chip labels come from `WORK_CATEGORY_LABELS` (not hard-coded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)