### PR TITLE
Build /explore page — category-tile entry point

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,0 +1,128 @@
+import Link from "next/link";
+import { getPubliclyVisible, type Intervention } from "@/lib/portfolio";
+import {
+  WORK_CATEGORIES,
+  WORK_CATEGORY_LABELS,
+  type WorkCategory,
+} from "@/lib/work-categories";
+
+export const metadata = {
+  title: "Explore | UI AI Initiative",
+  description:
+    "Browse AI interventions at the University of Idaho by the kind of operational work they help with.",
+};
+
+interface CategoryTile {
+  slug: WorkCategory;
+  label: string;
+  description: string;
+  count: number;
+  representatives: string[];
+}
+
+function buildTiles(interventions: Intervention[]): CategoryTile[] {
+  return WORK_CATEGORIES.map((slug) => {
+    const matches = interventions.filter((i) =>
+      (i.workCategories ?? []).includes(slug)
+    );
+    return {
+      slug,
+      label: WORK_CATEGORY_LABELS[slug].label,
+      description: WORK_CATEGORY_LABELS[slug].description,
+      count: matches.length,
+      representatives: matches.slice(0, 2).map((i) => i.name),
+    };
+  });
+}
+
+export default function ExplorePage() {
+  const interventions = getPubliclyVisible();
+  const tiles = buildTiles(interventions);
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Explore
+        </p>
+        <h1 className="mt-2 text-3xl font-black leading-tight sm:text-4xl">
+          Browse interventions by the kind of work they help with
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+          Find AI work tackling problems like yours &mdash; documents,
+          processes, coordination, reconciliation, and more. Each tile
+          counts the interventions tagged with that kind of work and links
+          straight into a filtered view of{" "}
+          <Link href="/portfolio" className="font-medium text-brand-black hover:underline">
+            The Work
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section
+        aria-label="Categories"
+        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        {tiles.map((tile) => (
+          <CategoryTileCard key={tile.slug} tile={tile} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function CategoryTileCard({ tile }: { tile: CategoryTile }) {
+  const isEmpty = tile.count === 0;
+
+  // Empty categories render as a non-interactive tile so the taxonomy
+  // stays visible (a Dean scanning for "knowledge retrieval" should see
+  // it even before something is tagged) without offering a dead link.
+  if (isEmpty) {
+    return (
+      <div className="flex h-full flex-col rounded-xl border border-hairline bg-white p-5 opacity-70">
+        <h2 className="text-base font-semibold text-brand-black">
+          {tile.label}
+        </h2>
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-ink-muted">
+          {tile.description}
+        </p>
+        <p className="mt-4 text-xs font-medium text-ink-muted">
+          No interventions tagged here yet
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={`/portfolio?category=${tile.slug}`}
+      className="group flex h-full flex-col rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+    >
+      <h2 className="text-base font-semibold text-brand-black">
+        {tile.label}
+      </h2>
+      <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+        {tile.description}
+      </p>
+      <p className="mt-3 flex-1 text-sm text-ink-muted">
+        <span className="font-bold tabular-nums text-brand-black">
+          {tile.count}
+        </span>{" "}
+        intervention{tile.count === 1 ? "" : "s"}
+        {tile.representatives.length > 0 && (
+          <>
+            {" "}
+            &middot;{" "}
+            <span className="text-brand-black">
+              {tile.representatives.join(", ")}
+            </span>
+          </>
+        )}
+      </p>
+      <p className="mt-4 text-sm font-medium text-brand-black group-hover:underline">
+        View &rarr;
+      </p>
+    </Link>
+  );
+}


### PR DESCRIPTION
The *"by problem"* axis as a dedicated surface. Closes #152 (Epic 4/5 in [#154](https://github.com/ui-insight/AISPEG/issues/154)).

## What changed

New route [`app/explore/page.tsx`](app/explore/page.tsx) — server-rendered, statically generated. 8-tile grid (4×2 desktop, 2×4 tablet, 1×8 mobile). Each tile counts the interventions tagged with that category and drills into `/portfolio?category=<slug>` — the facet shipped in [#151](https://github.com/ui-insight/AISPEG/issues/151).

## Source-of-truth choice

Sources from `lib/portfolio.ts` (TS) rather than the DB-backed `lib/work.ts`. Reasoning: `/explore` only needs static counts + representative names from the canonical taxonomy. The landing already takes this approach for its featured-pick lookup, and bypassing the DB lets `/explore` build statically (no per-request query, no DB-down failure mode).

## Design choices

- **Iterate `WORK_CATEGORIES` in canonical order** — not count-sorted, so layout stays stable as data changes
- **Empty-state is a non-interactive faded tile** with "No interventions tagged here yet" rather than dropping the category. Keeps the taxonomy visible to a Dean scanning for "knowledge retrieval" before anything is tagged there, without offering a dead link
- **Per-tile eyebrow dropped** — our taxonomy has no separate short-label, so an eyebrow would just repeat the heading. Page-level "EXPLORE" eyebrow remains for vertical hierarchy
- **No gold** — site-wide rule, focal-only

## Verification

- `npx tsc --noEmit` ✅
- `npm run build` ✅ (`/explore` builds as static `○`)
- **Local browser verification**:
  - Mobile (375×812): single-column, hero stacks correctly
  - Tablet (768×1024): 2-column, 4 rows
  - Desktop (1280×900): 4×2 grid, all 8 tiles visible above the fold
  - Empty-state for `knowledge-retrieval` renders correctly (faded, no link)
  - Drill-link target verified — `/portfolio?category=documents` (etc.) was confirmed end-to-end on dev when [#151](https://github.com/ui-insight/AISPEG/pull/161) merged

## Acceptance criteria

- [x] `/explore` route renders with the 8-tile grid
- [x] Each tile pulls data from `lib/work-categories.ts` (no hard-coded labels)
- [x] Each tile drill-link goes to `/portfolio?category=<slug>` and that filter renders correctly
- [x] Mobile, tablet, desktop layouts verified
- [x] Empty-tile state handled
- [x] Page H1 + eyebrow follow the documented page-heading-and-eyebrow rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)