### PR TITLE
Wire /explore into sidebar nav and update docs

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -205,3 +205,31 @@ based on which item the user is viewing, and the color carries
 meaning beyond decoration. If both are true, clearwater is fine. If
 the eyebrow is fixed (e.g., *"The Work"* on every visit to
 `/portfolio`), it's a wayfinding eyebrow — use brand-silver.
+
+## Work Categories Taxonomy
+
+`lib/work-categories.ts` defines the *"by problem"* axis used on
+`/explore`, on `/portfolio` filter chips, and on each portfolio card.
+The taxonomy is audience-facing — labels are written in a Dean's
+vocabulary (*"Working with documents,"* *"Reconciling accounts and
+records"*), not technical jargon.
+
+The canonical add / rename / retire / promote policy lives in the
+header comment of `lib/work-categories.ts`. Pointers, not duplication —
+the typed module is the source of truth.
+
+| Operation | What changes | Cost |
+|---|---|---|
+| Add a category | Constant + label record + tag interventions | ~5 min; tsc verifies the label record stays exhaustive |
+| Rename a category | Slug edit in two places | tsc surfaces every callsite (intervention tags + UI consumers) |
+| Retire a category | Remove from constant | tsc finds every still-tagged intervention; untag in one pass |
+| Promote to first-class field | Lift matching interventions into a new shape | Mechanical — grep the slug |
+
+**Visual treatment:** chips are neutral (`surface-alt` background +
+`hairline` border + `brand-black` text). No per-category color coding —
+that would cross the *Restraint > decoration* line. Revisit only if a
+single category earns a brand-color treatment for a documented reason.
+
+**No gold on category chips, ever.** Gold is reserved for active
+filter-state and CTA emphasis sitewide; using it for taxonomy color
+would dilute the signal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,12 @@ sprint sequencing.
 
 ## Information architecture
 
-Four primary surfaces in the sidebar, plus an About link in the footer:
+Five primary surfaces in the sidebar, plus an About link in the footer:
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| The Work | `/portfolio` | `lib/portfolio.ts` (TS for now; migrating to Postgres `applications` in Sprint 2) |
+| The Work | `/portfolio` | Postgres `applications` table (read via `lib/work.ts`); `lib/portfolio.ts` is the TS shadow + seed source for `scripts/seed-portfolio.ts` |
+| Explore | `/explore` | `lib/work-categories.ts` (taxonomy) + `lib/portfolio.ts` (counts and representative names) — by-problem axis, complementary to `/portfolio`'s by-home-unit grouping |
 | Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz definition); Postgres `submissions` (responses) |
 | Reports | `/reports` | `lib/artifacts.ts` — unified timeline of briefs, activity reports, and external presentations |
 | Standards | `/standards` | `lib/standards-watch.ts` (ledger entries; commit-worthy) |
@@ -103,6 +104,7 @@ app/                       # Next.js App Router
   page.tsx                 # Landing — four-card steering page
   layout.tsx               # Root layout, sidebar, metadata
   portfolio/               # The Work
+  explore/                 # Explore — "by problem" axis, category-tile entry
   builder-guide/           # Submit a Project (assessment quiz)
   reports/                 # Reports surface
   standards/               # Standards (sub-nav: ledger + data-model explorer)
@@ -119,7 +121,9 @@ components/                # Reusable components
   DocPage.tsx              # Docs layout primitives
 
 lib/                       # Domain logic
-  portfolio.ts             # Intervention inventory (typed)
+  portfolio.ts             # Intervention inventory (typed; seed source for the applications table)
+  work.ts                  # Postgres-backed query module for /portfolio (reads applications + blockers)
+  work-categories.ts       # "By problem" taxonomy — typed slugs + audience-facing labels (drives /explore + the /portfolio category facet)
   standards-watch.ts       # Standards ledger
   artifacts.ts             # Unified Reports timeline — briefs, activity reports, external talks
   builder-guide-data.ts    # Assessment quiz + scoring + tiers
@@ -133,7 +137,7 @@ lib/                       # Domain logic
     catalog.ts             # AUTO-GENERATED — projects + tables (do not edit)
     vocabularies.ts        # AUTO-GENERATED — controlled vocabularies (do not edit)
 
-db/migrations/             # SQL migrations (001 → 004; 005 lands in Sprint 2)
+db/migrations/             # SQL migrations (001 → 006)
 
 scripts/                   # Node scripts run via tsx
   build-governance-catalog.ts # Reads vendor/data-governance/ → emits lib/governance/{catalog,vocabularies}.ts
@@ -163,7 +167,8 @@ vendor/                    # Vendored dependencies
 
 | To add… | Edit | Notes |
 |---|---|---|
-| An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. |
+| An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
+| A work category | `lib/work-categories.ts` (constant + label record) + tag relevant interventions | Audience-facing labels (a Dean's vocabulary). Header comment in the file documents add/rename/retire/promote mechanics. tsc enforces consistency across consumers. |
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
 | A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |
 | A canonical UDM table tag | `lib/governance/canonical-udm-tables.ts` | Hand-curated v1 list. The data-governance catalog JSONs do not yet carry canonical/extension classification — once they do, this module retires. |

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 const primaryItems = [
   { href: "/", label: "Home", icon: "house" },
   { href: "/portfolio", label: "The Work", icon: "grid" },
+  { href: "/explore", label: "Explore", icon: "search" },
   { href: "/builder-guide", label: "Submit a Project", icon: "compass" },
   { href: "/standards", label: "Standards", icon: "shield" },
   { href: "/reports", label: "Reports", icon: "document" },
@@ -43,6 +44,13 @@ function NavIcon({ icon, className }: { icon: string; className?: string }) {
           <circle cx="12" cy="12" r="10" strokeWidth={2} />
           <polygon points="16.24,7.76 14.12,14.12 7.76,16.24 9.88,9.88" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
           <circle cx="12" cy="12" r="1" fill="currentColor" strokeWidth={0} />
+        </svg>
+      );
+    case "search":
+      return (
+        <svg className={c} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <circle cx="11" cy="11" r="7" strokeWidth={2} />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.3-4.3" />
         </svg>
       );
     case "document":


### PR DESCRIPTION
Final step in the *"by problem"* exploration axis epic. Closes #153 (Epic 5/5 in [#154](https://github.com/ui-insight/AISPEG/issues/154)) — wraps the epic.

## What changed

### Sidebar
[`components/Sidebar.tsx`](components/Sidebar.tsx) gains an **Explore** entry between **The Work** and **Submit a Project**. New order: `Home / The Work / Explore / Submit a Project / Standards / Reports`.

**Icon:** magnifying glass (new \`search\` case in \`NavIcon\`). Visually distinct from house, grid, compass, shield, document, book — verified by glance-scan against the rail in the running preview.

### `.impeccable.md`
New *Work Categories Taxonomy* section. Documents the evolution policy as a **pointer** to the canonical header comment in [`lib/work-categories.ts`](lib/work-categories.ts) — pointers, not prose, so the design doc and the typed module can't drift. Includes:

- Add / rename / retire / promote table (the operations and their costs)
- Visual treatment rule (neutral chips, no per-category color coding)
- Explicit *"no gold on category chips, ever"* line — gold is reserved for active filter-state and CTA emphasis sitewide

### `CLAUDE.md`
Refreshed to reflect the post-Sprint-2 reality:

- **IA table**: `/explore` added; "Four primary surfaces" → "Five"; The Work's source-of-truth line corrected (Postgres-backed via `lib/work.ts`, with `lib/portfolio.ts` as the TS shadow + seed source — the old "TS for now; migrating to Postgres in Sprint 2" was stale)
- **`lib/` structure**: `work.ts` + `work-categories.ts` picked up
- **"Adding content" table**: new "A work category" row; the intervention row gets a reseed reminder
- **Migrations note**: `001 → 004; 005 lands in Sprint 2` → `001 → 006`
- **`app/` structure**: `explore/` directory listed

### Decision: dropped the optional landing cross-link
The issue called out a possible *"Or browse by problem area →"* link inside the Work tile and asked for the call to be made in PR. Dropped. Sidebar entry is sufficient discoverability; an inline link would split the Work tile's primary CTA, crowd the landing, and work against the established critique-arc plateau plus the *Restraint > decoration* principle.

## Verification

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- **Local preview**: Sidebar renders correctly on `/` (Explore inactive, white/translucent) and on `/explore` (active, gold). Icon is distinct.

## Acceptance criteria

- [x] Sidebar shows "Explore" between The Work and Submit a Project
- [x] Sidebar icon visually distinct from all other sidebar icons
- [x] (Optional) Landing cross-link — explicit decision to drop, rationale in PR body
- [x] `.impeccable.md` documents the taxonomy evolution policy
- [x] `CLAUDE.md` IA table includes `/explore` as a primary surface

## Epic [#154](https://github.com/ui-insight/AISPEG/issues/154) status

After this merges:
- [x] [#149](https://github.com/ui-insight/AISPEG/issues/149) — Add `workCategories` taxonomy and tag the 15 interventions
- [x] [#150](https://github.com/ui-insight/AISPEG/issues/150) — Render `workCategories` chips on portfolio cards
- [x] [#151](https://github.com/ui-insight/AISPEG/issues/151) — Add category facet to `/portfolio` filter UI
- [x] [#152](https://github.com/ui-insight/AISPEG/issues/152) — Build `/explore` page
- [x] [#153](https://github.com/ui-insight/AISPEG/issues/153) — Wire `/explore` into sidebar nav + update docs

The end-to-end epic acceptance criterion ("`/explore` and `/portfolio?category=<slug>` both work end-to-end") was verified on dev when [#161](https://github.com/ui-insight/AISPEG/pull/161) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)