### PR TITLE
Lifecycle taxonomy schema: extend Intervention + Migration 007

### DIFF
--- a/app/admin/registry/new/page.tsx
+++ b/app/admin/registry/new/page.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
+// Lifecycle taxonomy from ADR 0001 — see lib/portfolio.ts InterventionStatus.
 const STATUS_OPTIONS = [
-  "idea", "approved", "in-development", "staging", "production", "retired",
-  "Planned", "Prototype", "Piloting", "Production", "Tracked", "Archived",
+  "idea", "approved", "building", "prototype", "piloting",
+  "production", "maintained", "sunsetting", "archived", "tracked",
 ];
 
 const VISIBILITY_OPTIONS = ["public", "embargoed", "internal"] as const;

--- a/db/migrations/007_lifecycle_taxonomy.sql
+++ b/db/migrations/007_lifecycle_taxonomy.sql
@@ -1,0 +1,40 @@
+-- Migration 007: Lifecycle Taxonomy
+--
+-- Mirrors the operational-ladder fields from ADR 0001 into the
+-- applications table. The TS module (lib/portfolio.ts) is the source
+-- of truth for the InterventionStatus / PublicStage / ProductionScope
+-- vocabularies; per the ADR, no CHECK constraints are added at the DB
+-- layer (same rationale as 006_work_categories: keep migration cadence
+-- decoupled from taxonomy edits).
+--
+-- The verification rules for each status are spec'd in the ADR and
+-- enforced by lib/portfolio-verification.ts (lands in a follow-up PR).
+-- This migration is the data shape only.
+--
+-- Companion to:
+--   - docs/adr/0001-product-lifecycle-taxonomy.md
+--   - lib/portfolio.ts (Intervention shape extensions)
+--   - scripts/seed-portfolio.ts (ports the new fields into this table)
+
+BEGIN;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS iids_sponsor         TEXT,
+  ADD COLUMN IF NOT EXISTS feature_complete     BOOLEAN,
+  ADD COLUMN IF NOT EXISTS live_url_is_staging  BOOLEAN,
+  ADD COLUMN IF NOT EXISTS pilot_cohort         JSONB,
+  ADD COLUMN IF NOT EXISTS production_scope     TEXT,
+  ADD COLUMN IF NOT EXISTS support_contact      TEXT,
+  ADD COLUMN IF NOT EXISTS sunset_date          DATE,
+  ADD COLUMN IF NOT EXISTS replaced_by          TEXT;
+
+-- Index on production_scope so the upcoming /portfolio facet (drill-in
+-- by operational status under the public-stage rollup) can filter
+-- production rows by scope without a sequential scan.
+CREATE INDEX IF NOT EXISTS idx_applications_production_scope
+  ON applications(production_scope);
+
+INSERT INTO schema_migrations (version) VALUES ('007_lifecycle_taxonomy')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/docs/adr/0001-product-lifecycle-taxonomy.md
+++ b/docs/adr/0001-product-lifecycle-taxonomy.md
@@ -31,10 +31,10 @@ The day-to-day status IIDS tracks. Each state has a verification rule that can b
 | `building` | Building | `repoUrl` set; `lastCommitDate` within last 60 days; no `liveUrl` (or `liveUrl` is staging-only — flagged via a `liveUrlIsStaging: true`); `pilotCohort` empty. |
 | `prototype` | Prototype | Demo-able; `liveUrl` may be set (often staging). `pilotCohort` empty. **Either** `lastCommitDate` is older than 30 days **OR** `featureComplete: true` is explicitly set. |
 | `piloting` | Piloting | `liveUrl` accessible to a **named cohort**. `pilotCohort` populated with `size > 0` and a bounded `scope` (single unit OR named individuals OR an explicit "limited beta" descriptor). |
-| `production` | Production | `liveUrl` accessible **beyond the original pilot cohort**: `productionScope` is `"home-unit"` (entire home unit's users), `"institution-wide"`, or `"external"` (institutional + outside-UI deployments). `supportContact` populated. |
-| `maintained` | Maintained | In production. **No commits to `main` in the last 90 days.** No open feature issues — only `bug`-, `security`-, or `chore`-labeled issues. |
+| `production` | Production | A **publicly-accessible artifact** exists beyond the original pilot cohort: either (a) a `liveUrl` reachable beyond the pilot, or (b) a public `repoUrl` (`isPrivateRepo: false` or unset) where the repo itself is the consumable deliverable — the path that covers infrastructure, scaffolds, and self-hostable appliances. `productionScope` is `"home-unit"` (entire home unit's users), `"institution-wide"`, or `"external"` (institutional + outside-UI deployments). `supportContact` populated. |
+| `maintained` | Maintained | Inherits production's accessibility rule (liveUrl OR public repo). **No commits to `main` in the last 90 days.** No open feature issues — only `bug`-, `security`-, or `chore`-labeled issues. |
 | `sunsetting` | Sunsetting | `sunsetDate` set (ISO date, future or recent past). `replacedBy` populated — either a successor intervention `slug` or the literal string `manual-process`. |
-| `archived` | Archived | `liveUrl` returns 404, is null, or domain is dead. Service stopped. Record kept for institutional memory. |
+| `archived` | Archived | `liveUrl` returns 404, is null, or domain is dead (or, for repo-as-artifact deliverables, `repoUrl` is archived/deleted). Service stopped. Record kept for institutional memory. |
 | `tracked` *(meta)* | Tracked | Not built by IIDS. `trackingOnly: true`. Bypasses the operational ladder; the public stage is its own bucket. |
 
 ### Layer 2: Public stage rollup (5 buckets)
@@ -66,6 +66,10 @@ Three options were considered: own stage, roll into whatever the external owner 
 ### 3. `featureComplete` flag, not pure commit-cadence
 
 Pure commit-cadence has false positives — a healthy maintained project with sporadic commits would read as a prototype. The cost of authoring discipline (one boolean) is lower than the cost of stakeholders reading misleading status. The flag is verified, not just claimed: if `featureComplete: true` but the project has no `liveUrl` and the repo's main branch is empty, the verification fails.
+
+### 4. `production` accepts a public repo as the artifact, not just `liveUrl`
+
+The first draft of the rules required a `liveUrl` for `production`. That broke for two real cases in the portfolio: `template-app` is a scaffold consumed by cloning, and `dgx-stack` is a self-hostable appliance — neither is a hosted webapp, and both are honestly in production use. The semantic the rule is reaching for is "**is there a publicly-accessible artifact someone outside the build team can use right now?**" For hosted apps, that's `liveUrl`. For infrastructure, scaffolds, and self-hostable deliverables, the public repo *is* the consumable artifact. Either satisfies the rule. The verifier checks that `repoUrl` is set and `isPrivateRepo` is not true — a private repo with no liveUrl fails, as it should.
 
 ## Schema additions to `Intervention`
 

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -17,13 +17,37 @@ export type Visibility =
   | "Partial"      // Entry acknowledged; UI deployment details embargoed
   | "Internal-only"; // Not shown on the public site at all
 
+// Operational ladder — see docs/adr/0001-product-lifecycle-taxonomy.md.
+// 9 lifecycle states + 1 meta state (`tracked`). Verification rules for
+// each are spec'd in the ADR; the verifier itself lands in a follow-up PR.
 export type InterventionStatus =
-  | "Planned"
-  | "Prototype"    // Built, not yet in use with real users
-  | "Piloting"     // Deployed prototype in use with a limited group
-  | "Production"   // Deployed for regular institutional use
-  | "Tracked"      // Not built by IIDS; tracking-only stub
-  | "Archived";
+  | "idea"
+  | "approved"
+  | "building"
+  | "prototype"
+  | "piloting"
+  | "production"
+  | "maintained"
+  | "sunsetting"
+  | "archived"
+  | "tracked";
+
+// Public-stage rollup — what stakeholders see on /portfolio, /explore, and
+// the landing stat strip. Computed from `status` via `computePublicStage`.
+export type PublicStage =
+  | "exploring"
+  | "building"
+  | "live"
+  | "retired"
+  | "tracked";
+
+export type ProductionScope = "home-unit" | "institution-wide" | "external";
+
+export interface PilotCohort {
+  size: number;
+  scope: string;
+  namedUsers?: string[];
+}
 
 export type AI4RARelationship =
   | "Core"         // Dual-destiny: AI4RA OSS project + UI deployment
@@ -57,6 +81,20 @@ export interface Intervention {
   status: InterventionStatus;
   visibility: Visibility;
   institutionalReviewStatus?: InstitutionalReviewStatus;
+
+  // Lifecycle taxonomy — see docs/adr/0001-product-lifecycle-taxonomy.md.
+  // Required transitively by the verification rules for certain statuses
+  // (e.g. `production` requires `productionScope` + `supportContact`,
+  // `piloting` requires `pilotCohort`). Optional on the type so the audit
+  // PR can land before the verifier; the verifier polices the transitives.
+  iidsSponsor: string;
+  featureComplete?: boolean;
+  liveUrlIsStaging?: boolean;
+  pilotCohort?: PilotCohort;
+  productionScope?: ProductionScope;
+  supportContact?: string;
+  sunsetDate?: string;   // ISO date
+  replacedBy?: string;   // successor slug or "manual-process"
 
   // AI4RA
   ai4raRelationship: AI4RARelationship;
@@ -100,9 +138,12 @@ export const interventions: Intervention[] = [
     homeUnits: ["Office of the President"],
     operationalOwners: [{ name: "Michele Bartlett" }],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    productionScope: "institution-wide",
+    supportContact: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/StratPlanTacticsMB",
     liveUrl: "https://strategicplan.insight.uidaho.edu",
     operationalFunction:
@@ -126,9 +167,10 @@ export const interventions: Intervention[] = [
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [{ name: "Kim Salisbury" }],
     buildParticipants: ["IIDS"],
-    status: "Prototype",
+    status: "building",
     visibility: "Partial",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/AuditDashboard",
     operationalFunction:
       "Audit observation lifecycle: ingest report PDF → extract observations and action items → assign responsible parties → monitor closure with overdue alerts. Replaces spreadsheet tracking.",
@@ -155,9 +197,11 @@ export const interventions: Intervention[] = [
       { name: "Jodi Walker" },
     ],
     buildParticipants: ["IIDS"],
-    status: "Prototype",
+    status: "prototype",
     visibility: "Public",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    featureComplete: false,
     repoUrl: "https://github.com/ui-insight/UCMDailyRegister",
     liveUrl: "https://ucmnews.insight.uidaho.edu",
     operationalFunction:
@@ -185,10 +229,11 @@ export const interventions: Intervention[] = [
     homeUnits: ["Office of Sponsored Programs (ORED)"],
     operationalOwners: [{ name: "Sarah Martonick" }],
     buildParticipants: ["IIDS"],
-    status: "Prototype",
+    status: "building",
     visibility: "Partial",
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
+    iidsSponsor: "Barrie Robison",
     operationalFunction: "Embargoed.",
     operationalExcellenceOutcome: "Embargoed.",
     workCategories: ["research-admin"],
@@ -205,11 +250,14 @@ export const interventions: Intervention[] = [
       { name: "John Brunsfeld", title: "Lead developer" },
     ],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
     externalDeployments: ["Southern Utah University"],
+    iidsSponsor: "John Brunsfeld",
+    productionScope: "external",
+    supportContact: "John Brunsfeld",
     repoUrl: "https://github.com/ui-insight/vandalizer",
     liveUrl: "https://vandalizer.uidaho.edu",
     funding: "NSF GRANTED Award #2427549",
@@ -230,10 +278,12 @@ export const interventions: Intervention[] = [
     homeUnits: ["Office of Sponsored Programs (ORED)"],
     operationalOwners: [{ name: "Barrie Robison" }],
     buildParticipants: ["IIDS"],
-    status: "Prototype",
+    status: "prototype",
     visibility: "Public",
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
+    iidsSponsor: "Barrie Robison",
+    featureComplete: false,
     repoUrl: "https://github.com/ui-insight/ProcessMapping",
     liveUrl: "https://processmapping.insight.uidaho.edu",
     operationalFunction:
@@ -260,10 +310,11 @@ export const interventions: Intervention[] = [
       { name: "Sarah Martonick", title: "UI implementation owner" },
     ],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "building",
     visibility: "Public",
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
+    iidsSponsor: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/OpenERA",
     operationalFunction:
       "Sponsored-research administration: proposal lifecycle, award management, compliance, and reporting for ORED. Anchors the institutional research-admin data layer that Vandalizer, ProcessMapping, and adjacent ORED tools build against.",
@@ -287,9 +338,11 @@ export const interventions: Intervention[] = [
     homeUnits: ["Office of Research and Economic Development", "Office of General Counsel"],
     operationalOwners: [{ name: "Sarah Martonick" }],
     buildParticipants: ["IIDS"],
-    status: "Prototype",
+    status: "prototype",
     visibility: "Partial",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    featureComplete: false,
     repoUrl: "https://github.com/ui-insight/ExecOrd",
     isPrivateRepo: true,
     operationalFunction:
@@ -314,9 +367,10 @@ export const interventions: Intervention[] = [
       { name: "Dean Kahler", title: "Vice Provost of SEM" },
     ],
     buildParticipants: ["IIDS", "SEM"],
-    status: "Prototype",
+    status: "building",
     visibility: "Public",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/SEM-experiential",
     operationalFunction:
       "Single record of student engagement: events, attendance, organizations. Foundation for verified experience transcripts.",
@@ -339,9 +393,11 @@ export const interventions: Intervention[] = [
     homeUnits: ["Research Faculty Development (ORED)"],
     operationalOwners: [{ name: "Eric Torok" }],
     buildParticipants: ["IIDS"],
-    status: "Piloting",
+    status: "piloting",
     visibility: "Public",
     ai4raRelationship: "Adjacent",
+    iidsSponsor: "Barrie Robison",
+    pilotCohort: { size: 12, scope: "CAREER Club cohort" },
     repoUrl: "https://github.com/ui-insight/RFD-career",
     operationalFunction:
       "Visualizes CAREER Club cohort and individual-participant progress against workbook rubric milestones.",
@@ -364,10 +420,13 @@ export const interventions: Intervention[] = [
     homeUnits: ["IIDS"],
     operationalOwners: [{ name: "Luke Sheneman" }],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
+    iidsSponsor: "Luke Sheneman",
+    productionScope: "external",
+    supportContact: "Luke Sheneman",
     repoUrl: "https://github.com/ui-insight/MindRouter",
     liveUrl: "https://mindrouter.ai",
     operationalFunction:
@@ -388,10 +447,13 @@ export const interventions: Intervention[] = [
     homeUnits: ["IIDS"],
     operationalOwners: [{ name: "Luke Sheneman" }],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     ai4raRelationship: "Adjacent",
     externalDeployments: ["Southern Utah University"],
+    iidsSponsor: "Luke Sheneman",
+    productionScope: "external",
+    supportContact: "Luke Sheneman",
     repoUrl: "https://github.com/ui-insight/dgx-stack",
     operationalFunction:
       "On-prem LLM + OCR appliance. Serves as a backend node to MindRouter. Provides the OCR used by Audit Dashboard, Vandalizer, OpenERA. Supports air-gapped workloads.",
@@ -411,10 +473,13 @@ export const interventions: Intervention[] = [
     homeUnits: ["IIDS"],
     operationalOwners: [{ name: "Barrie Robison" }],
     buildParticipants: ["IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     institutionalReviewStatus: "Under OIT review",
     ai4raRelationship: "Adjacent",
+    iidsSponsor: "Luke Sheneman",
+    productionScope: "institution-wide",
+    supportContact: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/TEMPLATE-app",
     operationalFunction:
       "Standardizes how new UI business apps start. Enforces data governance, security, documentation, CI/CD, and agentic-development norms from day one. Consumed by SEM-experiential, Audit Dashboard, StratPlanTactics.",
@@ -444,9 +509,10 @@ export const interventions: Intervention[] = [
     homeUnits: ["Office of Information Technology"],
     operationalOwners: [],
     buildParticipants: ["OIT", "Huron Consulting"],
-    status: "Tracked",
+    status: "tracked",
     visibility: "Public",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
     operationalFunction:
       "Enterprise data modernization scope to be confirmed.",
     operationalExcellenceOutcome:
@@ -466,9 +532,12 @@ export const interventions: Intervention[] = [
       { name: "Colin Addington" },
     ],
     buildParticipants: ["OIT", "IIDS"],
-    status: "Production",
+    status: "production",
     visibility: "Public",
     ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    productionScope: "institution-wide",
+    supportContact: "Kali Armitage",
     tech: ["React", "FastAPI", "OIT managed infrastructure"],
     operationalFunction:
       "Hosts UI application modules on OIT-managed secure infrastructure with a consistent runtime, identity, and security baseline. Target deployment surface for new UI apps that need institutional hosting.",
@@ -482,6 +551,27 @@ export const interventions: Intervention[] = [
 // ============================================================
 // Helpers
 // ============================================================
+
+// Operational status → public stage rollup. See ADR 0001.
+export function computePublicStage(status: InterventionStatus): PublicStage {
+  switch (status) {
+    case "idea":
+    case "approved":
+      return "exploring";
+    case "building":
+    case "prototype":
+      return "building";
+    case "piloting":
+    case "production":
+    case "maintained":
+      return "live";
+    case "sunsetting":
+    case "archived":
+      return "retired";
+    case "tracked":
+      return "tracked";
+  }
+}
 
 export function getInterventionBySlug(slug: string): Intervention | undefined {
   return interventions.find((i) => i.slug === slug);

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -302,7 +302,10 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        tracking_only, related_slugs,
        sensitivity, complexity, userbase, auth_level,
        integrations, data_sources, university_systems, output_types,
-       work_categories
+       work_categories,
+       iids_sponsor, feature_complete, live_url_is_staging,
+       pilot_cohort, production_scope, support_contact,
+       sunset_date, replaced_by
      )
      VALUES (
        $1, $2, $3, $4,
@@ -318,7 +321,10 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        $27, $28,
        $29, $30, $31, $32,
        $33, $34, $35, $36,
-       $37
+       $37,
+       $38, $39, $40,
+       $41::jsonb, $42, $43,
+       $44, $45
      )
      RETURNING id`,
     [
@@ -359,6 +365,14 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
       wizard.university_systems,
       wizard.output_types,
       i.workCategories ?? [],
+      i.iidsSponsor,
+      i.featureComplete ?? null,
+      i.liveUrlIsStaging ?? null,
+      i.pilotCohort ? JSON.stringify(i.pilotCohort) : null,
+      i.productionScope ?? null,
+      i.supportContact ?? null,
+      i.sunsetDate ?? null,
+      i.replacedBy ?? null,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Step 2 of [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — lands the data shape for the new operational ladder. Verifier (step 3) and UI (step 4) follow.
- Replaces `InterventionStatus` with the 10 lowercase slugs; adds `PublicStage` union + `computePublicStage` rollup; adds 8 authored fields to `Intervention`; mirrors columns into `applications` via Migration 007.
- All 15 interventions re-classified with honest data through an audit pass — not a mechanical mapping.
- Includes a small ADR refinement (sub-decision #4) so `production` accepts a public `repoUrl` as the deliverable artifact, not just `liveUrl`. This covers infrastructure (`dgx-stack`) and scaffolds (`template-app`) cleanly without an exemption — the verifier in #166 ships with the refined rule.

## Re-classification
| Slug | New status | Public stage | Why |
|---|---|---|---|
| `stratplan` | `production` | live | `productionScope: institution-wide`, exec review across 25 units |
| `audit-dashboard` | `building` | building | active dev, no liveUrl |
| `ucm-daily-register` | `prototype` | building | not in real editorial use yet |
| `embargoed-osp` | `building` | building | active dev, embargoed |
| `vandalizer` | `production` | live | `productionScope: external` (SUU deployment) |
| `processmapping` | `prototype` | building | demo-able, not in regular use |
| `openera` | `building` | building | beyond prototype but no real users / no liveUrl |
| `execord` | `prototype` | building | embargoed, demoable |
| `sem-experiential` | `building` | building | co-build with SEM, no liveUrl |
| `rfd-career` | `piloting` | live | `pilotCohort: { size: 12, scope: "CAREER Club cohort" }` |
| `mindrouter` | `production` | live | `productionScope: external`, open-sourced |
| `dgx-stack` | `production` | live | `productionScope: external` — repo-as-artifact (self-hostable appliance) |
| `template-app` | `production` | live | `productionScope: institution-wide` — repo-as-artifact (scaffold) |
| `oit-data-modernization` | `tracked` | tracked | unchanged |
| `nexus` | `production` | live | `productionScope: institution-wide` |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [x] Migration 007 applied to dev DB
- [x] `scripts/seed-portfolio.ts` reseeded all 15 rows successfully
- [x] Spot-checked `applications` rows: new columns populated correctly (production_scope, support_contact, iids_sponsor, pilot_cohort)
- [ ] CI green

## Refs
- Closes #165
- Refs ADR #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)