### PR TITLE
Lifecycle taxonomy UI: public-stage chips + two-tier filter

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -233,3 +233,50 @@ single category earns a brand-color treatment for a documented reason.
 **No gold on category chips, ever.** Gold is reserved for active
 filter-state and CTA emphasis sitewide; using it for taxonomy color
 would dilute the signal.
+
+## Lifecycle Status Treatment
+
+Defined in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md);
+implemented via [`lib/lifecycle-display.ts`](lib/lifecycle-display.ts).
+Two layers, two visual treatments.
+
+**Two-chip cluster on portfolio cards.** Stacked, top-right of the
+card header. The primary chip is the public stage; the secondary chip
+is the operational status.
+
+- **Primary (public stage)** carries stage-specific color so the rollup
+  is scannable at a glance:
+  - `Live` → Clearwater (signal: alive)
+  - `Building` → Huckleberry (signal: in motion)
+  - `Exploring` → Brand Silver (low intensity)
+  - `Retired` → Gray (low intensity)
+  - `Tracked` → Huckleberry-tint (matches the existing tracked
+    treatment from before the lifecycle taxonomy)
+- **Secondary (operational status)** is **always neutral** — same
+  `surface-alt + hairline + ink-muted` treatment as work-categories
+  chips, sized at `text-[10px]`. No per-status color, ever. The
+  restraint principle that applies to taxonomy applies here for the
+  same reason: ten distinct colors would cross the decoration line.
+
+**`tracked` suppresses the operational chip.** Externally-owned
+interventions don't follow the IIDS operational ladder, so the primary
+stage chip carries the whole signal — a second neutral chip would imply
+a granularity that doesn't exist for them.
+
+**Stat-strip and `/explore` breakdowns.** Public stage only. The
+operational granularity isn't useful at landing-density. Format:
+
+```
+14 interventions across 10 home units
+6 building · 6 live · 2 tracked
+```
+
+`/explore` tile breakdowns follow the same shape but suppress when the
+entire category sits in one stage (avoids `4 live` tautology).
+
+**Filters on `/portfolio`.** Two tiers: a top-level Stage row (5 chips
+in `PUBLIC_STAGE_ORDER`), and a drill-in Operational Status row that
+appears only when a non-`tracked` stage is active. Selecting an
+operational status implies its stage; URL params keep the two
+independent (`?stage=...` vs `?status=...`) so links can deep-link to
+either granularity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Five primary surfaces in the sidebar, plus an About link in the footer:
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| The Work | `/portfolio` | Postgres `applications` table (read via `lib/work.ts`); `lib/portfolio.ts` is the TS shadow + seed source for `scripts/seed-portfolio.ts` |
+| The Work | `/portfolio` | Postgres `applications` table (read via `lib/work.ts`); `lib/portfolio.ts` is the TS shadow + seed source for `scripts/seed-portfolio.ts`. Filter UI is two-tier: public stage (rollup) → operational status (drill-in), per [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md). |
 | Explore | `/explore` | `lib/work-categories.ts` (taxonomy) + `lib/portfolio.ts` (counts and representative names) — by-problem axis, complementary to `/portfolio`'s by-home-unit grouping |
 | Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz definition); Postgres `submissions` (responses) |
 | Reports | `/reports` | `lib/artifacts.ts` — unified timeline of briefs, activity reports, and external presentations |
@@ -167,7 +167,7 @@ vendor/                    # Vendored dependencies
 
 | To add… | Edit | Notes |
 |---|---|---|
-| An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
+| An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Set `status` honestly per the verification rules in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — `npm run verify:portfolio` polices it. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
 | A work category | `lib/work-categories.ts` (constant + label record) + tag relevant interventions | Audience-facing labels (a Dean's vocabulary). Header comment in the file documents add/rename/retire/promote mechanics. tsc enforces consistency across consumers. |
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
 | A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -5,6 +5,11 @@ import {
   WORK_CATEGORY_LABELS,
   type WorkCategory,
 } from "@/lib/work-categories";
+import {
+  PUBLIC_STAGE_LABEL,
+  stageBreakdown,
+} from "@/lib/lifecycle-display";
+import type { PublicStage } from "@/lib/portfolio";
 
 export const metadata = {
   title: "Explore | UI AI Initiative",
@@ -18,6 +23,9 @@ interface CategoryTile {
   description: string;
   count: number;
   representatives: string[];
+  // Public-stage breakdown for this category. Suppressed when the
+  // entire category sits in a single stage (avoids "4 live" tautology).
+  stageBreakdown: Array<{ stage: PublicStage; count: number }>;
 }
 
 function buildTiles(interventions: Intervention[]): CategoryTile[] {
@@ -25,12 +33,14 @@ function buildTiles(interventions: Intervention[]): CategoryTile[] {
     const matches = interventions.filter((i) =>
       (i.workCategories ?? []).includes(slug)
     );
+    const stages = stageBreakdown(matches);
     return {
       slug,
       label: WORK_CATEGORY_LABELS[slug].label,
       description: WORK_CATEGORY_LABELS[slug].description,
       count: matches.length,
       representatives: matches.slice(0, 2).map((i) => i.name),
+      stageBreakdown: stages.length > 1 ? stages : [],
     };
   });
 }
@@ -105,7 +115,7 @@ function CategoryTileCard({ tile }: { tile: CategoryTile }) {
       <p className="mt-2 text-sm leading-relaxed text-ink-muted">
         {tile.description}
       </p>
-      <p className="mt-3 flex-1 text-sm text-ink-muted">
+      <p className="mt-3 text-sm text-ink-muted">
         <span className="font-bold tabular-nums text-brand-black">
           {tile.count}
         </span>{" "}
@@ -120,6 +130,24 @@ function CategoryTileCard({ tile }: { tile: CategoryTile }) {
           </>
         )}
       </p>
+      {tile.stageBreakdown.length > 0 && (
+        <p className="mt-1 flex-1 text-xs text-ink-muted">
+          {tile.stageBreakdown.map((s, idx) => (
+            <span key={s.stage}>
+              {idx > 0 && (
+                <span aria-hidden className="text-brand-silver">
+                  {" · "}
+                </span>
+              )}
+              <span className="font-semibold tabular-nums text-brand-black">
+                {s.count}
+              </span>{" "}
+              {PUBLIC_STAGE_LABEL[s.stage].toLowerCase()}
+            </span>
+          ))}
+        </p>
+      )}
+      {tile.stageBreakdown.length === 0 && <div className="flex-1" />}
       <p className="mt-4 text-sm font-medium text-brand-black group-hover:underline">
         View &rarr;
       </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { getPubliclyVisible } from "@/lib/portfolio";
 import { artifacts, sortedArtifacts } from "@/lib/artifacts";
 import { summary as standardsSummary } from "@/lib/standards-watch";
+import { PUBLIC_STAGE_LABEL, stageBreakdown } from "@/lib/lifecycle-display";
 
 // Editorial pick of three featured interventions for the landing's
 // Work tile. Curated by IIDS — rotate when the work changes. There is
@@ -15,6 +16,7 @@ export default async function Home() {
   const interventionCount = all.length;
   const homeUnitCount = new Set(all.flatMap((i) => i.homeUnits)).size;
   const mostRecent = sortedArtifacts()[0]?.dateLabel;
+  const stageStats = stageBreakdown(all);
   const featuredPicks = FEATURED_PICKS
     .map((slug) => all.find((i) => i.slug === slug))
     .filter((i): i is NonNullable<typeof i> => i !== undefined);
@@ -60,6 +62,23 @@ export default async function Home() {
             </>
           )}
         </p>
+        {stageStats.length > 1 && (
+          <p className="mt-1 text-sm text-ink-muted">
+            {stageStats.map((s, idx) => (
+              <span key={s.stage}>
+                {idx > 0 && (
+                  <span aria-hidden className="text-brand-silver">
+                    {" · "}
+                  </span>
+                )}
+                <span className="font-bold tabular-nums text-brand-black">
+                  {s.count}
+                </span>{" "}
+                {PUBLIC_STAGE_LABEL[s.stage].toLowerCase()}
+              </span>
+            ))}
+          </p>
+        )}
       </section>
 
       <section>

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -12,6 +12,13 @@ import {
   WORK_CATEGORY_LABELS,
   type WorkCategory,
 } from "@/lib/work-categories";
+import {
+  PUBLIC_STAGE_ORDER,
+  STAGE_OPERATIONAL_ROLLUP,
+  isInterventionStatus,
+  publicStageFromStatus,
+} from "@/lib/lifecycle-display";
+import type { InterventionStatus, PublicStage } from "@/lib/portfolio";
 
 export const dynamic = "force-dynamic";
 
@@ -19,6 +26,7 @@ type SortMode = "default" | "name" | "blockers";
 
 interface PortfolioSearchParams {
   unit?: string;
+  stage?: string;
   status?: string;
   category?: string;
   blockers?: string;
@@ -27,6 +35,10 @@ interface PortfolioSearchParams {
 
 function isWorkCategory(v: string | undefined): v is WorkCategory {
   return !!v && (WORK_CATEGORIES as readonly string[]).includes(v);
+}
+
+function isPublicStage(v: string | undefined): v is PublicStage {
+  return !!v && (PUBLIC_STAGE_ORDER as readonly string[]).includes(v);
 }
 
 function isSortMode(v: string | undefined): v is SortMode {
@@ -66,7 +78,12 @@ export default async function PortfolioPage({
 }) {
   const params = await searchParams;
   const selectedUnit = params.unit?.trim() || null;
-  const selectedStatus = params.status?.trim() || null;
+  const selectedStage: PublicStage | null = isPublicStage(params.stage?.trim())
+    ? (params.stage!.trim() as PublicStage)
+    : null;
+  const rawStatus = params.status?.trim();
+  const selectedStatus: InterventionStatus | null =
+    rawStatus && isInterventionStatus(rawStatus) ? rawStatus : null;
   const selectedCategory: WorkCategory | null = isWorkCategory(
     params.category?.trim()
   )
@@ -80,13 +97,21 @@ export default async function PortfolioPage({
   // Build filter option lists from the unfiltered set so users see what's
   // available to filter by even after they've applied something.
   const homeUnitCounts = new Map<string, number>();
-  const statusCounts = new Map<string, number>();
+  const stageCounts = new Map<PublicStage, number>();
+  const operationalCounts = new Map<InterventionStatus, number>();
   const categoryCounts = new Map<WorkCategory, number>();
   for (const app of allApps) {
     for (const unit of app.homeUnits) {
       homeUnitCounts.set(unit, (homeUnitCounts.get(unit) ?? 0) + 1);
     }
-    statusCounts.set(app.status, (statusCounts.get(app.status) ?? 0) + 1);
+    const stage = publicStageFromStatus(app.status);
+    stageCounts.set(stage, (stageCounts.get(stage) ?? 0) + 1);
+    if (isInterventionStatus(app.status)) {
+      operationalCounts.set(
+        app.status,
+        (operationalCounts.get(app.status) ?? 0) + 1
+      );
+    }
     for (const cat of app.workCategories) {
       categoryCounts.set(cat, (categoryCounts.get(cat) ?? 0) + 1);
     }
@@ -94,9 +119,12 @@ export default async function PortfolioPage({
   const homeUnitOptions = Array.from(homeUnitCounts.entries())
     .map(([value, count]) => ({ value, label: value, count }))
     .sort((a, b) => a.label.localeCompare(b.label));
-  const statusOptions = Array.from(statusCounts.entries())
-    .map(([value, count]) => ({ value, label: value, count }))
-    .sort((a, b) => b.count - a.count);
+  const stageFilterOptions = PUBLIC_STAGE_ORDER.filter((s) =>
+    stageCounts.has(s)
+  ).map((stage) => ({ stage, count: stageCounts.get(stage)! }));
+  const operationalFilterOptions = Array.from(operationalCounts.entries()).map(
+    ([status, count]) => ({ status, count })
+  );
   // Category options follow the canonical taxonomy order from
   // lib/work-categories.ts. Categories with zero tagged interventions
   // are dropped — no point offering an empty filter.
@@ -108,10 +136,16 @@ export default async function PortfolioPage({
     count: categoryCounts.get(slug) ?? 0,
   }));
 
-  // Apply filters
+  // Apply filters. Stage matches if the row's status rolls up into the
+  // selected stage; an explicit operational status filter is more
+  // specific and supersedes stage.
   const filtered = allApps.filter((app) => {
     if (selectedUnit && !app.homeUnits.includes(selectedUnit)) return false;
     if (selectedStatus && app.status !== selectedStatus) return false;
+    if (selectedStage && !selectedStatus) {
+      const rollup = STAGE_OPERATIONAL_ROLLUP[selectedStage] as readonly string[];
+      if (!rollup.includes(app.status)) return false;
+    }
     if (selectedCategory && !app.workCategories.includes(selectedCategory))
       return false;
     if (blockersOnly && app.activeBlockers.length === 0) return false;
@@ -169,13 +203,15 @@ export default async function PortfolioPage({
       {/* Filter / sort UI */}
       <PortfolioFilters
         homeUnits={homeUnitOptions}
-        statuses={statusOptions}
+        stageOptions={stageFilterOptions}
+        operationalOptions={operationalFilterOptions}
         categories={categoryOptions}
         totalCount={allApps.length}
         filteredCount={filtered.length}
         blockerCount={blockerCount}
         selected={{
           unit: selectedUnit,
+          stage: selectedStage,
           status: selectedStatus,
           category: selectedCategory,
           blockers: blockersOnly,
@@ -229,7 +265,7 @@ export default async function PortfolioPage({
         ))}
 
       {/* Context callout — only shown when no filters active and no sort */}
-      {!selectedUnit && !selectedStatus && !selectedCategory && !blockersOnly && sortMode === "default" && (
+      {!selectedUnit && !selectedStage && !selectedStatus && !selectedCategory && !blockersOnly && sortMode === "default" && (
         <Callout eyebrow="How to read this inventory">
           <p className="text-sm leading-relaxed">
             Interventions are grouped by{" "}

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -2,15 +2,13 @@ import Link from "next/link";
 import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
 import { WORK_CATEGORY_LABELS } from "@/lib/work-categories";
-
-const statusStyles: Record<string, string> = {
-  Production: "bg-green-100 text-green-800",
-  Piloting: "bg-blue-100 text-blue-800",
-  Prototype: "bg-amber-100 text-amber-800",
-  Planned: "bg-gray-100 text-gray-700",
-  Tracked: "bg-brand-huckleberry/10 text-brand-huckleberry",
-  Archived: "bg-gray-100 text-gray-500",
-};
+import {
+  OPERATIONAL_LABEL,
+  PUBLIC_STAGE_CHIP,
+  PUBLIC_STAGE_LABEL,
+  isInterventionStatus,
+  publicStageFromStatus,
+} from "@/lib/lifecycle-display";
 
 const visibilityNote: Record<"public" | "embargoed" | "internal", string | null> = {
   public: null,
@@ -81,6 +79,13 @@ export default function PortfolioCard({
   const liveHost = app.liveUrl ? hostnameOf(app.liveUrl) : null;
   const ai4raLabel = ai4raChip[app.ai4raRelationship];
 
+  const stage = publicStageFromStatus(app.status);
+  // The operational chip is suppressed for `tracked` — the ladder
+  // doesn't apply to externally-owned interventions, so the primary
+  // stage chip carries the whole signal. (See ADR 0001.)
+  const showOperationalChip =
+    isInterventionStatus(app.status) && app.status !== "tracked";
+
   return (
     <article className="group relative flex h-full flex-col rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <div className="flex items-start justify-between gap-3">
@@ -100,13 +105,18 @@ export default function PortfolioCard({
             </p>
           )}
         </div>
-        <span
-          className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
-            statusStyles[app.status] ?? "bg-gray-100 text-gray-700"
-          }`}
-        >
-          {app.status}
-        </span>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <span
+            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${PUBLIC_STAGE_CHIP[stage]}`}
+          >
+            {PUBLIC_STAGE_LABEL[stage]}
+          </span>
+          {showOperationalChip && (
+            <span className="inline-flex items-center rounded-full border border-hairline bg-surface-alt px-1.5 py-0.5 text-[10px] font-medium text-ink-muted">
+              {OPERATIONAL_LABEL[app.status as keyof typeof OPERATIONAL_LABEL]}
+            </span>
+          )}
+        </div>
       </div>
 
       {app.tagline && (
@@ -142,11 +152,6 @@ export default function PortfolioCard({
         {app.externalDeployments.length > 0 && (
           <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-600">
             Also at {app.externalDeployments.join(", ")}
-          </span>
-        )}
-        {app.trackingOnly && (
-          <span className="rounded-full border border-brand-huckleberry/30 bg-brand-huckleberry/10 px-2 py-0.5 text-xs font-medium text-brand-huckleberry">
-            Tracked (not built by IIDS)
           </span>
         )}
         {app.workCategories.slice(0, 3).map((slug) => (

--- a/components/PortfolioFilters.tsx
+++ b/components/PortfolioFilters.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import {
+  OPERATIONAL_LABEL,
+  PUBLIC_STAGE_LABEL,
+  PUBLIC_STAGE_ORDER,
+  STAGE_OPERATIONAL_ROLLUP,
+  publicStageFromStatus,
+} from "@/lib/lifecycle-display";
+import type { InterventionStatus, PublicStage } from "@/lib/portfolio";
 
 // Pure URL-state filter chip group. The portfolio page builds the option
 // lists from the unfiltered data and passes them in; clicking a pill
@@ -13,16 +21,28 @@ interface FilterOption {
   count: number;
 }
 
+interface StageFilterOption {
+  stage: PublicStage;
+  count: number;
+}
+
+interface OperationalFilterOption {
+  status: InterventionStatus;
+  count: number;
+}
+
 export interface PortfolioFiltersProps {
   homeUnits: FilterOption[];
-  statuses: FilterOption[];
+  stageOptions: StageFilterOption[];
+  operationalOptions: OperationalFilterOption[];
   categories: FilterOption[];
   totalCount: number;
   filteredCount: number;
   blockerCount: number;
   selected: {
     unit: string | null;
-    status: string | null;
+    stage: PublicStage | null;
+    status: InterventionStatus | null;
     category: string | null;
     blockers: boolean;
     sort: "default" | "name" | "blockers";
@@ -74,7 +94,8 @@ function Chip({
 
 export default function PortfolioFilters({
   homeUnits,
-  statuses,
+  stageOptions,
+  operationalOptions,
   categories,
   totalCount,
   filteredCount,
@@ -83,6 +104,7 @@ export default function PortfolioFilters({
 }: PortfolioFiltersProps) {
   const filtersActive =
     !!selected.unit ||
+    !!selected.stage ||
     !!selected.status ||
     !!selected.category ||
     selected.blockers ||
@@ -91,11 +113,31 @@ export default function PortfolioFilters({
   // Helpers — when toggling a chip, preserve other selections.
   const baseParams = {
     unit: selected.unit,
+    stage: selected.stage,
     status: selected.status,
     category: selected.category,
     blockers: selected.blockers ? "1" : null,
     sort: selected.sort === "default" ? null : selected.sort,
   };
+
+  // The drill-in stage = either the explicitly-selected stage, or the
+  // stage that the selected operational status rolls up into. This way
+  // selecting "Production" auto-reveals the Live drill-in.
+  const activeStage: PublicStage | null =
+    selected.stage ??
+    (selected.status ? publicStageFromStatus(selected.status) : null);
+
+  // Operational chips visible in the drill-in: the rollup for the active
+  // stage, with counts pulled from the page's pre-computed totals.
+  const drillInOperational =
+    activeStage && activeStage !== "tracked"
+      ? STAGE_OPERATIONAL_ROLLUP[activeStage]
+          .map((status) => {
+            const opt = operationalOptions.find((o) => o.status === status);
+            return opt ? { status, count: opt.count } : null;
+          })
+          .filter((x): x is OperationalFilterOption => x !== null)
+      : [];
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
@@ -170,28 +212,71 @@ export default function PortfolioFilters({
         </div>
       </div>
 
-      {/* Status pills */}
+      {/* Stage pills (top tier) — public stage rollup from ADR 0001 */}
       <div className="mt-4">
         <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-gray-500">
-          Status
+          Stage
         </p>
         <div className="flex flex-wrap gap-1.5">
           <Chip
-            label="Any"
-            active={!selected.status}
-            href={buildHref({ ...baseParams, status: null })}
+            label="All"
+            count={totalCount}
+            active={!selected.stage && !selected.status}
+            href={buildHref({ ...baseParams, stage: null, status: null })}
           />
-          {statuses.map((s) => (
-            <Chip
-              key={s.value}
-              label={s.label}
-              count={s.count}
-              active={selected.status === s.value}
-              href={buildHref({ ...baseParams, status: s.value })}
-            />
-          ))}
+          {PUBLIC_STAGE_ORDER.map((stage) => {
+            const opt = stageOptions.find((o) => o.stage === stage);
+            if (!opt) return null;
+            return (
+              <Chip
+                key={stage}
+                label={PUBLIC_STAGE_LABEL[stage]}
+                count={opt.count}
+                active={activeStage === stage}
+                href={buildHref({
+                  ...baseParams,
+                  stage,
+                  // Selecting a stage clears any prior operational filter —
+                  // the user just zoomed back out one level.
+                  status: null,
+                })}
+              />
+            );
+          })}
         </div>
       </div>
+
+      {/* Operational drill-in (second tier) — only when a non-tracked stage is active */}
+      {drillInOperational.length > 0 && (
+        <div className="mt-3 rounded-lg border border-hairline bg-surface-alt/40 p-3">
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+            Operational status within {PUBLIC_STAGE_LABEL[activeStage!]}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <Chip
+              label="Any"
+              active={!selected.status}
+              href={buildHref({ ...baseParams, status: null })}
+            />
+            {drillInOperational.map((o) => (
+              <Chip
+                key={o.status}
+                label={OPERATIONAL_LABEL[o.status]}
+                count={o.count}
+                active={selected.status === o.status}
+                href={buildHref({
+                  ...baseParams,
+                  // Selecting an operational status implies its stage; we
+                  // null `stage` so the URL stays clean (the stage is
+                  // recoverable via publicStageFromStatus).
+                  stage: null,
+                  status: o.status,
+                })}
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Blocker toggle + sort */}
       <div className="mt-4 flex flex-wrap items-end justify-between gap-4">

--- a/lib/lifecycle-display.ts
+++ b/lib/lifecycle-display.ts
@@ -1,0 +1,114 @@
+// ============================================================
+// Lifecycle Display — UI helpers for ADR 0001
+// ============================================================
+// Centralised labels, colors, and rollups for the operational ladder
+// and public-stage axes. Imported by PortfolioCard, PortfolioFilters,
+// the landing stat strip, and the /explore tile breakdowns.
+//
+// Color rule (locked in .impeccable.md):
+//   - Public-stage chips carry stage-specific color (silver / huckleberry /
+//     clearwater / gray / huckleberry-tint).
+//   - Operational chips are ALWAYS neutral surface — same restraint as
+//     the work-categories chips. No per-status color.
+// ============================================================
+
+import {
+  computePublicStage,
+  type InterventionStatus,
+  type PublicStage,
+} from "./portfolio";
+
+export const PUBLIC_STAGE_LABEL: Record<PublicStage, string> = {
+  exploring: "Exploring",
+  building: "Building",
+  live: "Live",
+  retired: "Retired",
+  tracked: "Tracked",
+};
+
+// Tailwind class strings for each public-stage chip.
+// Each entry is a one-shot className for a chip with border + bg + text.
+export const PUBLIC_STAGE_CHIP: Record<PublicStage, string> = {
+  exploring: "border-brand-silver/40 bg-brand-silver/10 text-brand-silver",
+  building: "border-brand-huckleberry/30 bg-brand-huckleberry/10 text-brand-huckleberry",
+  live: "border-brand-clearwater/40 bg-brand-clearwater/10 text-brand-clearwater",
+  retired: "border-gray-200 bg-gray-50 text-gray-500",
+  tracked: "border-brand-huckleberry/30 bg-brand-huckleberry/10 text-brand-huckleberry",
+};
+
+// Reading-order list — used by the filter UI and the landing stat strip.
+// `tracked` is omitted from the conventional progression and tacked on
+// at the end since it's a meta-state that bypasses the ladder.
+export const PUBLIC_STAGE_ORDER: PublicStage[] = [
+  "exploring",
+  "building",
+  "live",
+  "retired",
+  "tracked",
+];
+
+export const OPERATIONAL_LABEL: Record<InterventionStatus, string> = {
+  idea: "Idea",
+  approved: "Approved",
+  building: "Building",
+  prototype: "Prototype",
+  piloting: "Piloting",
+  production: "Production",
+  maintained: "Maintained",
+  sunsetting: "Sunsetting",
+  archived: "Archived",
+  tracked: "Tracked",
+};
+
+// Inverse of computePublicStage — for the filter drill-in.
+// Lists the 1-N operational states that roll up into each public stage,
+// in approximate ladder order.
+export const STAGE_OPERATIONAL_ROLLUP: Record<PublicStage, InterventionStatus[]> = {
+  exploring: ["idea", "approved"],
+  building: ["building", "prototype"],
+  live: ["piloting", "production", "maintained"],
+  retired: ["sunsetting", "archived"],
+  tracked: ["tracked"],
+};
+
+// String-input version of computePublicStage. Postgres-sourced rows
+// carry status as a plain string; if a row has a status outside the
+// canonical 10-value union (drift, legacy data, etc.), bucket it as
+// `exploring` so the UI never crashes.
+export function publicStageFromStatus(status: string): PublicStage {
+  if (isInterventionStatus(status)) return computePublicStage(status);
+  return "exploring";
+}
+
+const STATUSES: ReadonlyArray<InterventionStatus> = [
+  "idea",
+  "approved",
+  "building",
+  "prototype",
+  "piloting",
+  "production",
+  "maintained",
+  "sunsetting",
+  "archived",
+  "tracked",
+];
+
+export function isInterventionStatus(s: string): s is InterventionStatus {
+  return (STATUSES as readonly string[]).includes(s);
+}
+
+// Aggregate stage counts across a list of items keyed by status. Used by
+// the landing stat strip and /explore tile breakdowns. Returns the stages
+// in PUBLIC_STAGE_ORDER, with zero-count stages dropped.
+export function stageBreakdown(
+  items: ReadonlyArray<{ status: string }>
+): Array<{ stage: PublicStage; count: number }> {
+  const counts = new Map<PublicStage, number>();
+  for (const item of items) {
+    const stage = publicStageFromStatus(item.status);
+    counts.set(stage, (counts.get(stage) ?? 0) + 1);
+  }
+  return PUBLIC_STAGE_ORDER.filter((s) => (counts.get(s) ?? 0) > 0).map(
+    (stage) => ({ stage, count: counts.get(stage)! })
+  );
+}


### PR DESCRIPTION
## Summary
- Step 4 of [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — surfaces the new two-layer model to stakeholders. Closes #167.
- Public stage is the primary signal (color); operational status is the secondary detail (always neutral).
- New `lib/lifecycle-display.ts` is the single source for stage labels, colors, and rollups — imported by PortfolioCard, PortfolioFilters, and the landing/explore pages.

## Visual changes

**Portfolio cards** — replaces the single status chip with a two-chip cluster (top-right of card header):
- Primary chip uses stage-specific color: `Live` (clearwater), `Building` (huckleberry), `Exploring` (silver), `Retired` (gray), `Tracked` (huckleberry-tint).
- Secondary chip is always neutral (`surface-alt` + `hairline` + `text-[10px]` + `ink-muted`) — no per-status color, ever. Same restraint pattern as the work-categories chips.
- `tracked` rows suppress the operational chip — the ladder doesn't apply to externally-owned interventions.

**Portfolio filter** — flat Status row replaced with a two-tier structure:
- Top tier: 5 stage chips (`All`, `Exploring`, `Building`, `Live`, `Retired`, `Tracked`), each with its own count.
- Drill-in: appears under the stage row when a non-`tracked` stage is active. Shows the 1–4 operational states that roll up into the stage. Selecting an operational status implies its stage; URL params keep the two clean (`?stage=` vs `?status=`).

**Landing stat strip** — gains a public-stage breakdown line (`6 building · 6 live · 2 tracked`). Only public stage — operational granularity isn't useful at this density.

**`/explore` tiles** — each category tile gets a stage breakdown line. Suppressed when the whole category sits in one stage (avoids "4 live" tautology).

## Docs
- `.impeccable.md` — new "Lifecycle Status Treatment" section locks the two-chip pattern, stage colors, and the always-neutral operational chip rule.
- `CLAUDE.md` — IA table's `The Work` row mentions the two-tier filter; intervention authoring row picks up a pointer to the verification rules.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes (170 static pages compiled)
- [x] `npm run verify:portfolio` still passes 0 errors / 0 warnings
- [x] Browser-verified: `/portfolio` (stage filter row + cards), `/portfolio?stage=building` (drill-in shows operational options), `/portfolio?stage=tracked` (drill-in suppressed, cards show only primary chip), `/` (stat strip with stage breakdown), `/explore` (mixed-stage tiles show breakdown, uniform-stage tiles suppress)
- [x] Screenshot of `/portfolio` confirms the cluster: huckleberry "Building" stage chip + neutral "Building" operational chip on the Audit Dashboard card
- [ ] CI green

## Refs
- Closes #167
- Refs ADR #164, schema PR #169, verifier PR #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)