### PR TITLE
Strategic Plan: priority detail page

### DIFF
--- a/app/standards/strategic-plan/pillars/[code]/page.tsx
+++ b/app/standards/strategic-plan/pillars/[code]/page.tsx
@@ -55,19 +55,22 @@ export default async function PillarDetailPage({
 
       <section className="space-y-3">
         {pillar.priorities.map((pr) => (
-          <article
+          <Link
             key={pr.code}
-            className="rounded-lg border border-hairline bg-white p-5"
+            href={`/standards/strategic-plan/priorities/${pr.code}`}
+            className="unstyled group block rounded-lg border border-hairline bg-white p-5 transition-colors hover:border-brand-black"
           >
-            <div className="flex items-start gap-4">
-              <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 font-mono text-xs font-semibold text-brand-black">
-                {pr.code}
-              </span>
-              <p className="text-sm leading-relaxed text-brand-black">
-                {pr.text}
-              </p>
-            </div>
-          </article>
+            <article>
+              <div className="flex items-start gap-4">
+                <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 font-mono text-xs font-semibold text-brand-black">
+                  {pr.code}
+                </span>
+                <p className="text-sm leading-relaxed text-brand-black group-hover:text-brand-clearwater">
+                  {pr.text}
+                </p>
+              </div>
+            </article>
+          </Link>
         ))}
       </section>
     </div>

--- a/app/standards/strategic-plan/priorities/[code]/page.tsx
+++ b/app/standards/strategic-plan/priorities/[code]/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getPillar,
+  getPriority,
+  priorities,
+} from "@/lib/strategic-plan/catalog";
+
+export function generateStaticParams() {
+  return priorities.map((p) => ({ code: p.code }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  const priority = getPriority(code);
+  if (!priority) return { title: "Priority not found — Strategic Plan" };
+  return {
+    title: `Priority ${priority.code} — Strategic Plan`,
+    description: priority.text,
+  };
+}
+
+export default async function PriorityDetailPage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  const priority = getPriority(code);
+  if (!priority) notFound();
+
+  const pillar = getPillar(priority.pillar);
+
+  return (
+    <div className="space-y-10">
+      <nav className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+        <Link
+          href="/standards/strategic-plan"
+          className="font-semibold text-ink-muted hover:text-brand-black"
+        >
+          ← All pillars
+        </Link>
+        {pillar && (
+          <>
+            <span className="text-ink-subtle">/</span>
+            <Link
+              href={`/standards/strategic-plan/pillars/${pillar.code}`}
+              className="font-semibold text-ink-muted hover:text-brand-black"
+            >
+              Pillar {pillar.code}: {pillar.name}
+            </Link>
+          </>
+        )}
+      </nav>
+
+      <header>
+        <p className="font-mono text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
+          Priority {priority.code}
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
+          {priority.text}
+        </h1>
+        {pillar && (
+          <p className="mt-3 text-sm text-ink-muted">
+            Under{" "}
+            <Link
+              href={`/standards/strategic-plan/pillars/${pillar.code}`}
+              className="font-semibold text-brand-black hover:text-brand-clearwater"
+            >
+              Pillar {pillar.code}: {pillar.name}
+            </Link>
+          </p>
+        )}
+      </header>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/standards/strategic-plan/priorities/[code]` — single-priority detail with full text, priority-code eyebrow, and a breadcrumb + "Under Pillar X" link back to the parent pillar.
- `generateStaticParams` covers all 20 priority codes; unknown codes 404.
- Pillar detail page now links each priority row to its detail route (hover state mirrors the pillars-index card pattern).

Reverse-direction "Projects advancing this priority" is out of scope here — that's slice 4 ([#102](https://github.com/ui-insight/AISPEG/issues/102)).

Closes #105. Part of [#100](https://github.com/ui-insight/AISPEG/issues/100).

## Test plan

- [ ] `npm run build` clean; all 20 priority pages prerender as SSG
- [ ] `npm run lint` clean
- [ ] `/standards/strategic-plan/priorities/A.3` renders the full priority text with breadcrumb and "Under Pillar A" link
- [ ] Pillar detail page priority rows are clickable and navigate to the correct detail page
- [ ] Unknown priority code (e.g. `/standards/strategic-plan/priorities/Z.99`) returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)