### PR TITLE
Strategic Plan: alignment field on portfolio entries + chips on cards

### DIFF
--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
 import { WORK_CATEGORY_LABELS } from "@/lib/work-categories";
+import { getPriority } from "@/lib/strategic-plan/catalog";
 import {
   OPERATIONAL_LABEL,
   PUBLIC_STAGE_CHIP,
@@ -165,6 +166,27 @@ export default function PortfolioCard({
         {app.workCategories.length > 3 && (
           <span className="rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-xs font-medium text-brand-black">
             +{app.workCategories.length - 3}
+          </span>
+        )}
+        {app.strategicPlanAlignment.slice(0, 3).map((code) => {
+          const priority = getPriority(code);
+          return (
+            <Link
+              key={code}
+              href={`/standards/strategic-plan/priorities/${code}`}
+              title={priority ? priority.text : undefined}
+              className="unstyled relative z-10 rounded-full border border-brand-clearwater/40 bg-brand-clearwater/10 px-2 py-0.5 font-mono text-xs font-semibold text-brand-clearwater hover:bg-brand-clearwater hover:text-white"
+            >
+              {code}
+            </Link>
+          );
+        })}
+        {app.strategicPlanAlignment.length > 3 && (
+          <span
+            className="rounded-full border border-brand-clearwater/40 bg-brand-clearwater/10 px-2 py-0.5 font-mono text-xs font-semibold text-brand-clearwater"
+            title={app.strategicPlanAlignment.slice(3).join(", ")}
+          >
+            +{app.strategicPlanAlignment.length - 3}
           </span>
         )}
       </div>

--- a/db/migrations/008_strategic_plan_alignment.sql
+++ b/db/migrations/008_strategic_plan_alignment.sql
@@ -1,0 +1,16 @@
+-- Migration 008: strategic_plan_alignment column on applications
+--
+-- Adds the project-side half of the bidirectional project ↔ strategic-plan
+-- relationship (epic #100, slice #101). Each row carries an array of
+-- priority codes (e.g. {"A.1", "D.2"}) drawn from the typed catalog at
+-- lib/strategic-plan/catalog.ts. The set ships empty for every existing
+-- intervention; IIDS fills in alignment over time.
+--
+-- Validation: unknown codes are caught at build time by
+-- scripts/verify-portfolio.ts (CI-gated). The DB column is intentionally
+-- a plain TEXT[] without a CHECK constraint — the catalog is the source
+-- of truth, and gating in TypeScript keeps the rule colocated with the
+-- rest of the portfolio shape verification (ADR 0001 pattern).
+
+ALTER TABLE applications
+  ADD COLUMN strategic_plan_alignment TEXT[] NOT NULL DEFAULT '{}'::text[];

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -122,6 +122,12 @@ export interface Intervention {
   // "By problem" exploration axis — see lib/work-categories.ts.
   // One intervention can sit in 2-3 categories.
   workCategories?: WorkCategory[];
+
+  // Strategic-plan priority codes this intervention advances (e.g.
+  // ["A.1", "D.2"]). Codes must match a Priority in
+  // lib/strategic-plan/catalog.ts; scripts/verify-portfolio.ts fails the
+  // build on unknown codes. Ship empty; IIDS fills in over time.
+  strategicPlanAlignment?: string[];
 }
 
 export const interventions: Intervention[] = [

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -98,6 +98,7 @@ export interface Application {
   trackingOnly: boolean;
   relatedSlugs: string[];
   workCategories: WorkCategory[];
+  strategicPlanAlignment: string[];
   clickupTaskId: string | null;
   updatedAt: string;
 }
@@ -135,6 +136,7 @@ interface ApplicationRow {
   tracking_only: boolean;
   related_slugs: string[];
   work_categories: string[];
+  strategic_plan_alignment: string[];
   clickup_task_id: string | null;
   updated_at: string;
 }
@@ -181,6 +183,7 @@ function toApplication(row: ApplicationRow): Application {
     trackingOnly: row.tracking_only,
     relatedSlugs: row.related_slugs ?? [],
     workCategories: ((row.work_categories ?? []) as WorkCategory[]),
+    strategicPlanAlignment: row.strategic_plan_alignment ?? [],
     clickupTaskId: row.clickup_task_id,
     updatedAt: row.updated_at,
   };
@@ -225,6 +228,7 @@ const APPLICATION_COLUMNS = `
   features, tech,
   tracking_only, related_slugs,
   work_categories,
+  strategic_plan_alignment,
   clickup_task_id, updated_at
 `;
 

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -293,6 +293,7 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        sensitivity, complexity, userbase, auth_level,
        integrations, data_sources, university_systems, output_types,
        work_categories,
+       strategic_plan_alignment,
        iids_sponsor, feature_complete, live_url_is_staging,
        pilot_cohort, production_scope, support_contact,
        sunset_date, replaced_by
@@ -312,9 +313,10 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
        $29, $30, $31, $32,
        $33, $34, $35, $36,
        $37,
-       $38, $39, $40,
-       $41::jsonb, $42, $43,
-       $44, $45
+       $38,
+       $39, $40, $41,
+       $42::jsonb, $43, $44,
+       $45, $46
      )
      RETURNING id`,
     [
@@ -355,6 +357,7 @@ async function seedIntervention(i: Intervention): Promise<{ id: string; blockers
       wizard.university_systems,
       wizard.output_types,
       i.workCategories ?? [],
+      i.strategicPlanAlignment ?? [],
       i.iidsSponsor,
       i.featureComplete ?? null,
       i.liveUrlIsStaging ?? null,

--- a/scripts/verify-portfolio.ts
+++ b/scripts/verify-portfolio.ts
@@ -16,18 +16,41 @@
 
 import { interventions } from "../lib/portfolio.js";
 import { verifyAll, type VerificationProblem } from "../lib/portfolio-verification.js";
+import { priorities } from "../lib/strategic-plan/catalog.js";
 
 function format(p: VerificationProblem): string {
   const tag = p.severity === "error" ? "ERROR " : "WARN  ";
   return `  [${tag}] ${p.slug.padEnd(28)} (${p.claimedStatus})\n           ${p.problem}\n           rule: ${p.rule}`;
 }
 
+function verifyStrategicPlanAlignment(): VerificationProblem[] {
+  const validCodes = new Set(priorities.map((p) => p.code));
+  const problems: VerificationProblem[] = [];
+  for (const i of interventions) {
+    const codes = i.strategicPlanAlignment ?? [];
+    for (const code of codes) {
+      if (!validCodes.has(code)) {
+        problems.push({
+          slug: i.slug,
+          claimedStatus: i.status,
+          problem: `unknown strategic-plan priority code "${code}" — not present in lib/strategic-plan/catalog.ts`,
+          rule: "strategic-plan-alignment",
+          severity: "error",
+        });
+      }
+    }
+  }
+  return problems;
+}
+
 function main(): void {
-  const all = verifyAll(interventions);
+  const lifecycleProblems = verifyAll(interventions);
+  const stratPlanProblems = verifyStrategicPlanAlignment();
+  const all = [...lifecycleProblems, ...stratPlanProblems];
   const errors = all.filter((p) => p.severity === "error");
   const warnings = all.filter((p) => p.severity === "warning");
 
-  console.log(`Verifying ${interventions.length} interventions against ADR 0001 rules ...\n`);
+  console.log(`Verifying ${interventions.length} interventions against ADR 0001 rules and strategic-plan alignment ...\n`);
 
   if (warnings.length > 0) {
     console.log(`Warnings (${warnings.length}):`);


### PR DESCRIPTION
## Summary

Adds the project-side half of the bidirectional project ↔ strategic-plan relationship. Each `Intervention` can declare `strategicPlanAlignment: string[]` of priority codes (e.g. `["A.1", "D.2"]`) drawn from the typed catalog landed in #103.

- **Migration 008** — adds `strategic_plan_alignment TEXT[] NOT NULL DEFAULT '{}'` to `applications`.
- **`lib/portfolio.ts`** — new optional field on `Intervention`.
- **`lib/work.ts`** — reads the column on every applications query.
- **`scripts/seed-portfolio.ts`** — copies the field into the DB on reseed.
- **`scripts/verify-portfolio.ts`** — validates each declared code against the priority catalog and fails the build on unknown codes (CI-gated via the existing `verify-portfolio` job).
- **`components/PortfolioCard.tsx`** — compact code chips with the full priority text on hover (native `title` attribute), each linking to the priority detail page from [#105](https://github.com/ui-insight/AISPEG/issues/105). Capped at 3 visible with a `+N` overflow chip mirroring the work-categories pattern. Brand-clearwater accent for differentiation.

Ships **empty** across all 14 interventions per [#100](https://github.com/ui-insight/AISPEG/issues/100)'s plan — IIDS fills in alignment over time.

Closes #101. Part of [#100](https://github.com/ui-insight/AISPEG/issues/100).

## Test plan

- [ ] `npm run build` clean
- [ ] `npm run verify:portfolio` passes (14 interventions, 0 errors)
- [ ] Negative test: temporarily adding `strategicPlanAlignment: ["BOGUS"]` to any entry causes `verify:portfolio` to fail with "unknown strategic-plan priority code" — verified locally
- [ ] Migration 008 applies cleanly in dev (`npm run migrate`)
- [ ] After reseed (`npm run seed:portfolio`), `applications.strategic_plan_alignment` exists and is `{}` for every row
- [ ] Hand-edit one intervention to add `strategicPlanAlignment: ["A.1", "D.2"]`, reseed, and confirm chips render on `/portfolio` cards with hover tooltip showing the full priority text and click navigating to the priority detail page
- [ ] `npm run lint` clean

## Visual verification

Skipped in this PR — `/portfolio` requires a connected dev DB to render, which wasn't available during development. Build + verify + lint all pass; the card-rendering change is small and follows the existing chip pattern. Verify in dev once a DB is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)