### PR TITLE
Strategic Plan: drift CI + submodule-freshness advisory

### DIFF
--- a/.github/workflows/strategic-plan-drift.yml
+++ b/.github/workflows/strategic-plan-drift.yml
@@ -1,0 +1,69 @@
+name: Strategic Plan Drift
+
+# Mirrors .github/workflows/governance-drift.yml for the strategic-plan
+# vendored catalog. Fails the build when the committed
+# lib/strategic-plan/catalog.ts no longer matches what would be produced
+# from vendor/strategic-plan — i.e. someone bumped the submodule without
+# regenerating, or hand-edited the auto-generated file.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "vendor/strategic-plan/**"
+      - "lib/strategic-plan/**"
+      - "app/standards/strategic-plan/**"
+      - "scripts/build-strategic-plan-catalog.*"
+      - ".github/workflows/strategic-plan-drift.yml"
+
+jobs:
+  drift:
+    name: Validate strategic-plan catalog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          # vendor/strategic-plan is private; default GITHUB_TOKEN can't reach it.
+          # PORTFOLIO_GH_TOKEN is the same org secret used by governance workflows.
+          token: ${{ secrets.PORTFOLIO_GH_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Snapshot committed catalog
+        run: cp lib/strategic-plan/catalog.ts /tmp/committed-catalog.ts
+
+      - name: Regenerate catalog from submodule
+        run: npm run build:strategic-plan
+
+      - name: Diff regenerated against committed
+        run: |
+          set -e
+          if ! diff -u /tmp/committed-catalog.ts lib/strategic-plan/catalog.ts > /tmp/drift.diff; then
+            {
+              echo "## Strategic-plan catalog drift detected"
+              echo
+              echo "The committed \`lib/strategic-plan/catalog.ts\` does not match what \`npm run build:strategic-plan\` produces from the vendored submodule. Either the submodule was bumped without regenerating, or the file was hand-edited (it shouldn't be — it's auto-generated)."
+              echo
+              echo "**Fix:** run \`npm run build:strategic-plan\` locally and commit the result."
+              echo
+              echo '<details><summary>diff (committed → regenerated)</summary>'
+              echo
+              echo '```diff'
+              cat /tmp/drift.diff
+              echo '```'
+              echo
+              echo '</details>'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "## Strategic-plan catalog drift check" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "PASS — committed catalog matches submodule." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/strategic-plan-pr-summary.yml
+++ b/.github/workflows/strategic-plan-pr-summary.yml
@@ -1,0 +1,109 @@
+name: Strategic Plan PR Summary
+
+# Advisory submodule-freshness comment for vendor/strategic-plan, mirroring
+# the freshness job in governance-pr-summary.yml. Posts/updates a single
+# comment via an HTML marker when the pinned submodule SHA is more than
+# STALE_AFTER_DAYS behind upstream main. Does NOT fail the build.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  STALE_AFTER_DAYS: "14"
+
+jobs:
+  freshness:
+    name: Strategic-plan submodule freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          # vendor/strategic-plan is private; default GITHUB_TOKEN can't reach it.
+          token: ${{ secrets.PORTFOLIO_GH_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Compute submodule lag
+        id: lag
+        run: |
+          set -e
+          cd vendor/strategic-plan
+
+          pinned_sha=$(git rev-parse HEAD)
+          pinned_date_iso=$(git log -1 --format=%cI "$pinned_sha")
+
+          git fetch origin main --quiet
+          upstream_sha=$(git rev-parse origin/main)
+
+          echo "pinned_sha=$pinned_sha" >> "$GITHUB_OUTPUT"
+          echo "pinned_date_iso=$pinned_date_iso" >> "$GITHUB_OUTPUT"
+          echo "upstream_sha=$upstream_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Render freshness advisory
+        id: render
+        env:
+          PINNED_SHA: ${{ steps.lag.outputs.pinned_sha }}
+          PINNED_COMMIT_DATE_ISO: ${{ steps.lag.outputs.pinned_date_iso }}
+          UPSTREAM_HEAD_SHA: ${{ steps.lag.outputs.upstream_sha }}
+          OUTPUT_PATH: /tmp/strategic-plan-freshness.md
+        run: |
+          set -e
+          npx tsx scripts/strategic-plan-freshness.ts
+          if [ -s /tmp/strategic-plan-freshness.md ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Strategic-plan submodule freshness"
+              echo
+              cat /tmp/strategic-plan-freshness.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upsert stale-advisory comment
+        if: steps.render.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          body=$(cat /tmp/strategic-plan-freshness.md)
+          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- strategic-plan-bot:freshness -->")) | .id' \
+            | head -1 || true)
+          if [ -n "$existing_id" ]; then
+            gh api "repos/$REPO/issues/comments/$existing_id" -X PATCH -f body="$body"
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body="$body"
+          fi
+
+      - name: Delete prior advisory when no longer stale
+        if: steps.render.outputs.stale == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- strategic-plan-bot:freshness -->")) | .id' \
+            | head -1 || true)
+          if [ -n "$existing_id" ]; then
+            gh api "repos/$REPO/issues/comments/$existing_id" -X DELETE
+          fi

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "governance:pr-summary": "tsx scripts/governance-pr-summary.ts",
     "governance:pr-summary:test": "tsx --env-file=.test-governance/test.env scripts/governance-pr-summary.ts",
     "governance:freshness": "tsx scripts/governance-freshness.ts",
+    "strategic-plan:freshness": "tsx scripts/strategic-plan-freshness.ts",
     "start": "next start",
     "lint": "eslint .",
     "migrate": "tsx --env-file=.env.local scripts/migrate.ts",

--- a/scripts/strategic-plan-freshness.ts
+++ b/scripts/strategic-plan-freshness.ts
@@ -1,0 +1,107 @@
+/**
+ * Compares the vendored strategic-plan submodule pointer against upstream
+ * `main` and emits a markdown advisory when the pinned commit is more than
+ * STALE_AFTER_DAYS old.
+ *
+ * Mirrors scripts/governance-freshness.ts — kept as a sibling rather than
+ * generalizing to a shared utility because the marker, header, and remediation
+ * commands diverge per submodule and inlining keeps each PR comment readable.
+ *
+ * Inputs (env):
+ *   PINNED_SHA                 SHA the submodule is pinned to in this PR (required)
+ *   PINNED_COMMIT_DATE_ISO     ISO-8601 commit date of PINNED_SHA          (required)
+ *   UPSTREAM_HEAD_SHA          current upstream main HEAD SHA              (optional, for context)
+ *   STALE_AFTER_DAYS           threshold in days, default 14
+ *   OUTPUT_PATH                file to write markdown to (default: stdout)
+ *
+ * Exits 0 in all cases — advisory only.
+ */
+import { writeFileSync } from "node:fs";
+
+const MARKER = "<!-- strategic-plan-bot:freshness -->";
+
+const PINNED_SHA = process.env.PINNED_SHA || "";
+const PINNED_COMMIT_DATE_ISO = process.env.PINNED_COMMIT_DATE_ISO || "";
+const UPSTREAM_HEAD_SHA = process.env.UPSTREAM_HEAD_SHA || "";
+const STALE_AFTER_DAYS = parseInt(process.env.STALE_AFTER_DAYS || "14", 10);
+const OUTPUT_PATH = process.env.OUTPUT_PATH || "";
+
+if (!PINNED_SHA || !PINNED_COMMIT_DATE_ISO) {
+  console.error(
+    "PINNED_SHA and PINNED_COMMIT_DATE_ISO are required. Refusing to run.",
+  );
+  process.exit(2);
+}
+
+const pinnedDate = new Date(PINNED_COMMIT_DATE_ISO);
+if (Number.isNaN(pinnedDate.getTime())) {
+  console.error(`Invalid PINNED_COMMIT_DATE_ISO: ${PINNED_COMMIT_DATE_ISO}`);
+  process.exit(2);
+}
+
+const now = new Date();
+const ageMs = now.getTime() - pinnedDate.getTime();
+const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+
+function emit(content: string) {
+  if (OUTPUT_PATH) {
+    writeFileSync(OUTPUT_PATH, content);
+  } else {
+    process.stdout.write(content);
+  }
+}
+
+const shortPinned = PINNED_SHA.slice(0, 7);
+const shortHead = UPSTREAM_HEAD_SHA ? UPSTREAM_HEAD_SHA.slice(0, 7) : "";
+const isPointingAtHead =
+  UPSTREAM_HEAD_SHA && PINNED_SHA === UPSTREAM_HEAD_SHA;
+
+if (ageDays <= STALE_AFTER_DAYS) {
+  console.error(
+    `Submodule pointer is fresh: pinned ${shortPinned} (${ageDays} day(s) old, threshold ${STALE_AFTER_DAYS}).`,
+  );
+  emit("");
+  process.exit(0);
+}
+
+const lines: string[] = [];
+lines.push(MARKER);
+lines.push("## Vendored strategic-plan submodule is behind upstream");
+lines.push("");
+lines.push(
+  `The vendored submodule pointer at \`vendor/strategic-plan\` is pinned to \`${shortPinned}\`, ` +
+    `which was committed **${ageDays} day(s) ago** ` +
+    `(threshold: ${STALE_AFTER_DAYS} days).`,
+);
+lines.push("");
+if (UPSTREAM_HEAD_SHA && !isPointingAtHead) {
+  lines.push(
+    `Upstream \`main\` is currently at \`${shortHead}\`. To refresh:`,
+  );
+  lines.push("");
+  lines.push("```bash");
+  lines.push("git submodule update --remote vendor/strategic-plan");
+  lines.push('git add vendor/strategic-plan && git commit -m "Bump strategic-plan"');
+  lines.push("```");
+  lines.push("");
+  lines.push(
+    "Then re-run `npm run build:strategic-plan` to regenerate `lib/strategic-plan/catalog.ts`.",
+  );
+} else if (isPointingAtHead) {
+  lines.push(
+    "The submodule is pinned at upstream `main` HEAD, but that HEAD itself is older than the threshold. " +
+      "No action needed in this repo — upstream simply hasn't moved.",
+  );
+}
+lines.push("");
+lines.push(
+  "_This is an advisory comment from `strategic-plan-pr-summary.yml`. It does not block the build. " +
+    `Threshold is configurable via the \`STALE_AFTER_DAYS\` workflow env var (currently ${STALE_AFTER_DAYS}). ` +
+    "This comment is updated in place across pushes._",
+);
+
+emit(lines.join("\n"));
+console.error(
+  `Submodule pointer is STALE: pinned ${shortPinned} (${ageDays} day(s) old, threshold ${STALE_AFTER_DAYS}).`,
+);
+process.exit(0);


### PR DESCRIPTION
## Summary

Mirrors the governance CI patterns for the new strategic-plan catalog so upstream changes don't land silently.

- **`strategic-plan-drift.yml`** — runs on PRs that touch `vendor/strategic-plan/**`, `lib/strategic-plan/**`, `app/standards/strategic-plan/**`, or the build script. Re-runs `npm run build:strategic-plan` and fails the build when the committed `lib/strategic-plan/catalog.ts` no longer matches what would be regenerated. Catches both submodule bumps without regen and hand-edits of the auto-generated file.
- **`strategic-plan-pr-summary.yml`** — advisory freshness comment posted (and updated in place via HTML marker) when the pinned submodule pointer is more than `STALE_AFTER_DAYS` behind upstream `main`. Does **not** fail the build.
- **`scripts/strategic-plan-freshness.ts`** — sibling of `governance-freshness.ts` with the strategic-plan marker and remediation snippet. Kept inline rather than generalized so each PR comment reads cleanly.
- **`package.json`** — adds `strategic-plan:freshness` npm-script alias for local use, matching the existing `governance:freshness`.

The optional "catalog change summary" PR comment from the issue's stretch goal isn't included — the strategic-plan catalog changes far less frequently than data-governance, so the per-PR diff isn't worth the duplication for now. Easy to add later if it becomes useful.

Closes #104. Part of [#100](https://github.com/ui-insight/AISPEG/issues/100).

## Test plan

- [ ] Drift workflow triggers on this PR (its own paths trigger it via `.github/workflows/strategic-plan-drift.yml`) and passes — committed catalog matches regen
- [ ] PR-summary workflow runs and posts (or omits) the freshness comment correctly
- [ ] Verified locally: `cp lib/strategic-plan/catalog.ts /tmp/before.ts && npm run build:strategic-plan && diff /tmp/before.ts lib/strategic-plan/catalog.ts` is empty
- [ ] Negative test (manual): edit `lib/strategic-plan/catalog.ts`, push to a draft branch, confirm drift workflow fails with the diff in the step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)