### PR TITLE
Strategic Plan: reverse direction — projects advancing each priority

### DIFF
--- a/app/standards/strategic-plan/pillars/[code]/page.tsx
+++ b/app/standards/strategic-plan/pillars/[code]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getPillar, pillars } from "@/lib/strategic-plan/catalog";
+import { countProjectsForPriority } from "@/lib/strategic-plan/project-alignment";
 
 export function generateStaticParams() {
   return pillars.map((p) => ({ code: p.code }));
@@ -54,24 +55,34 @@ export default async function PillarDetailPage({
       </header>
 
       <section className="space-y-3">
-        {pillar.priorities.map((pr) => (
-          <Link
-            key={pr.code}
-            href={`/standards/strategic-plan/priorities/${pr.code}`}
-            className="unstyled group block rounded-lg border border-hairline bg-white p-5 transition-colors hover:border-brand-black"
-          >
-            <article>
-              <div className="flex items-start gap-4">
-                <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 font-mono text-xs font-semibold text-brand-black">
-                  {pr.code}
-                </span>
-                <p className="text-sm leading-relaxed text-brand-black group-hover:text-brand-clearwater">
-                  {pr.text}
-                </p>
-              </div>
-            </article>
-          </Link>
-        ))}
+        {pillar.priorities.map((pr) => {
+          const projectCount = countProjectsForPriority(pr.code);
+          return (
+            <Link
+              key={pr.code}
+              href={`/standards/strategic-plan/priorities/${pr.code}`}
+              className="unstyled group block rounded-lg border border-hairline bg-white p-5 transition-colors hover:border-brand-black"
+            >
+              <article>
+                <div className="flex items-start gap-4">
+                  <span className="shrink-0 rounded bg-gray-100 px-2 py-0.5 font-mono text-xs font-semibold text-brand-black">
+                    {pr.code}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm leading-relaxed text-brand-black group-hover:text-brand-clearwater">
+                      {pr.text}
+                    </p>
+                    <p className="mt-1.5 text-xs text-ink-muted">
+                      {projectCount === 0
+                        ? "No IIDS projects aligned"
+                        : `${projectCount} IIDS ${projectCount === 1 ? "project" : "projects"}`}
+                    </p>
+                  </div>
+                </div>
+              </article>
+            </Link>
+          );
+        })}
       </section>
     </div>
   );

--- a/app/standards/strategic-plan/priorities/[code]/page.tsx
+++ b/app/standards/strategic-plan/priorities/[code]/page.tsx
@@ -5,6 +5,8 @@ import {
   getPriority,
   priorities,
 } from "@/lib/strategic-plan/catalog";
+import { getProjectsForPriority } from "@/lib/strategic-plan/project-alignment";
+import { OPERATIONAL_LABEL } from "@/lib/lifecycle-display";
 
 export function generateStaticParams() {
   return priorities.map((p) => ({ code: p.code }));
@@ -76,6 +78,65 @@ export default async function PriorityDetailPage({
           </p>
         )}
       </header>
+
+      <ProjectsAdvancingPriority code={priority.code} />
     </div>
+  );
+}
+
+function ProjectsAdvancingPriority({ code }: { code: string }) {
+  const projects = getProjectsForPriority(code);
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h2 className="text-xl font-black tracking-tight text-brand-black">
+          Projects advancing this priority
+        </h2>
+        <p className="mt-1 text-sm text-ink-muted">
+          {projects.length === 0
+            ? "No IIDS projects have declared alignment with this priority yet."
+            : `${projects.length} ${projects.length === 1 ? "IIDS project has" : "IIDS projects have"} declared alignment.`}
+        </p>
+      </header>
+
+      {projects.length > 0 && (
+        <ul className="space-y-3">
+          {projects.map((p) => (
+            <li
+              key={p.slug}
+              className="rounded-lg border border-hairline bg-white p-5"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="text-base font-semibold text-brand-black">
+                    <Link
+                      href={`/portfolio/${p.slug}`}
+                      className="unstyled hover:text-brand-clearwater"
+                    >
+                      {p.name}
+                    </Link>
+                  </h3>
+                  <p className="mt-1 text-sm text-ink-muted">
+                    {p.tagline}
+                  </p>
+                  {(p.ownerNames.length > 0 || p.homeUnits.length > 0) && (
+                    <p className="mt-2 text-xs text-gray-500">
+                      {p.homeUnits[0] && <span>{p.homeUnits[0]}</span>}
+                      {p.homeUnits[0] && p.ownerNames.length > 0 && " · "}
+                      {p.ownerNames.slice(0, 2).join(", ")}
+                      {p.ownerNames.length > 2 && ` +${p.ownerNames.length - 2}`}
+                    </p>
+                  )}
+                </div>
+                <span className="inline-flex shrink-0 items-center rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-[11px] font-medium text-ink-muted">
+                  {OPERATIONAL_LABEL[p.status]}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/lib/strategic-plan/project-alignment.ts
+++ b/lib/strategic-plan/project-alignment.ts
@@ -1,0 +1,52 @@
+// ============================================================
+// Strategic Plan ↔ Portfolio reverse-direction lookups
+// ============================================================
+// Returns the portfolio entries that have declared alignment with a
+// given priority code. Reads directly from lib/portfolio.ts (the typed
+// seed source) so the strategic-plan pages stay statically renderable
+// — no DB coupling. Once ClickUp wiring lands and lib/portfolio.ts
+// retires, swap this to read from Postgres via lib/work.ts.
+// ============================================================
+
+import { interventions, type Intervention } from "../portfolio";
+
+export interface AlignedProject {
+  slug: string;
+  name: string;
+  tagline: string;
+  status: Intervention["status"];
+  homeUnits: string[];
+  ownerNames: string[];
+  visibility: Intervention["visibility"];
+}
+
+function toAlignedProject(i: Intervention): AlignedProject {
+  return {
+    slug: i.slug,
+    name: i.name,
+    tagline: i.tagline,
+    status: i.status,
+    homeUnits: i.homeUnits,
+    ownerNames: i.operationalOwners.map((o) => o.name),
+    visibility: i.visibility,
+  };
+}
+
+// Public-facing lookup. Excludes "Internal-only" entries so the
+// strategic-plan UI matches what /portfolio surfaces to anonymous
+// readers. Embargoed ("Partial") entries are included — same rule
+// PortfolioCard / lib/work.ts uses for the public audience.
+export function getProjectsForPriority(code: string): AlignedProject[] {
+  return interventions
+    .filter(
+      (i) =>
+        i.visibility !== "Internal-only" &&
+        (i.strategicPlanAlignment ?? []).includes(code),
+    )
+    .map(toAlignedProject)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function countProjectsForPriority(code: string): number {
+  return getProjectsForPriority(code).length;
+}


### PR DESCRIPTION
## Summary

Closes the bidirectional loop on the Strategic Plan Alignment Explorer. Pillars and priorities can now answer "which IIDS projects advance this?".

- **`lib/strategic-plan/project-alignment.ts`** — new helper module. `getProjectsForPriority(code)` returns the portfolio entries whose `strategicPlanAlignment` includes the given code, sorted by name; `countProjectsForPriority(code)` returns just the count for the inline pillar-row use. Excludes `Internal-only` entries; includes `Partial` (embargoed) to match `/portfolio`'s public audience rule.
- **Pillar detail page** (`app/standards/strategic-plan/pillars/[code]/page.tsx`) — each priority row now shows the project count beneath the priority text ("1 IIDS project" / "3 IIDS projects" / "No IIDS projects aligned").
- **Priority detail page** (`app/standards/strategic-plan/priorities/[code]/page.tsx`) — new "Projects advancing this priority" section. When populated, lists each project as a card linked to `/portfolio/[slug]` with name, tagline, home unit, operational owners, and current operational status chip. When empty, surfaces an honest message: *"No IIDS projects have declared alignment with this priority yet."*

Reads directly from `lib/portfolio.ts` (the typed seed source), so the strategic-plan pages stay statically renderable — no DB coupling. Once ClickUp wiring lands and `lib/portfolio.ts` retires, the helper swaps to read from Postgres via `lib/work.ts`.

Closes #102. Part of [#100](https://github.com/ui-insight/AISPEG/issues/100).

## Test plan

- [ ] `npm run build` clean; all 5 pillar pages and 20 priority pages prerender as SSG
- [ ] `npm run lint` clean
- [ ] `npm run verify:portfolio` clean
- [ ] **Empty state** verified locally: `/standards/strategic-plan/pillars/E` shows "No IIDS projects aligned" under each priority; `/standards/strategic-plan/priorities/E.2` shows the "No IIDS projects have declared alignment" message
- [ ] **Populated state** verified locally: temporarily added `strategicPlanAlignment: ["E.2", "A.3"]` to `audit-dashboard`, confirmed E.2's pillar row updated to "1 IIDS project" and the priority detail page rendered the audit-dashboard card with home unit + owner + Building chip — then reverted before commit
- [ ] Adding alignment to a portfolio entry and rebuilding shows up without code changes (validated by the smoke test above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)