### PR TITLE
Strategic Plan: stakeholder framing per pillar

### DIFF
--- a/app/standards/strategic-plan/page.tsx
+++ b/app/standards/strategic-plan/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { pillars } from "@/lib/strategic-plan/catalog";
+import { getPillarFraming } from "@/lib/strategic-plan/pillar-framing";
 
 export const metadata = {
   title: "Strategic Plan — Standards",
@@ -27,25 +28,33 @@ export default function StrategicPlanIndexPage() {
       </header>
 
       <section className="grid gap-4 md:grid-cols-2">
-        {pillars.map((p) => (
-          <Link
-            key={p.code}
-            href={`/standards/strategic-plan/pillars/${p.code}`}
-            className="unstyled group block rounded-lg border border-hairline bg-white p-5 transition-colors hover:border-brand-black"
-          >
-            <p className="font-mono text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
-              Pillar {p.code}
-            </p>
-            <h3 className="mt-1 text-lg font-bold tracking-tight text-brand-black group-hover:text-brand-clearwater">
-              {p.name}
-            </h3>
-            <p className="mt-3 text-sm text-ink-muted">
-              <span className="font-semibold text-brand-black">
-                {p.priorities.length} {p.priorities.length === 1 ? "priority" : "priorities"}
-              </span>
-            </p>
-          </Link>
-        ))}
+        {pillars.map((p) => {
+          const framing = getPillarFraming(p.code);
+          return (
+            <Link
+              key={p.code}
+              href={`/standards/strategic-plan/pillars/${p.code}`}
+              className="unstyled group block rounded-lg border border-hairline bg-white p-5 transition-colors hover:border-brand-black"
+            >
+              <p className="font-mono text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
+                Pillar {p.code}
+              </p>
+              <h3 className="mt-1 text-lg font-bold tracking-tight text-brand-black group-hover:text-brand-clearwater">
+                {p.name}
+              </h3>
+              {framing && (
+                <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+                  {framing}
+                </p>
+              )}
+              <p className="mt-3 text-sm text-ink-muted">
+                <span className="font-semibold text-brand-black">
+                  {p.priorities.length} {p.priorities.length === 1 ? "priority" : "priorities"}
+                </span>
+              </p>
+            </Link>
+          );
+        })}
       </section>
     </div>
   );

--- a/app/standards/strategic-plan/pillars/[code]/page.tsx
+++ b/app/standards/strategic-plan/pillars/[code]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getPillar, pillars } from "@/lib/strategic-plan/catalog";
 import { countProjectsForPriority } from "@/lib/strategic-plan/project-alignment";
+import { getPillarFraming } from "@/lib/strategic-plan/pillar-framing";
 
 export function generateStaticParams() {
   return pillars.map((p) => ({ code: p.code }));
@@ -29,6 +30,7 @@ export default async function PillarDetailPage({
   const { code } = await params;
   const pillar = getPillar(code);
   if (!pillar) notFound();
+  const framing = getPillarFraming(code);
 
   return (
     <div className="space-y-10">
@@ -48,6 +50,11 @@ export default async function PillarDetailPage({
         <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
           {pillar.name}
         </h1>
+        {framing && (
+          <p className="mt-3 max-w-3xl text-base leading-relaxed text-ink-muted">
+            {framing}
+          </p>
+        )}
         <p className="mt-3 text-sm text-ink-muted">
           {pillar.priorities.length}{" "}
           {pillar.priorities.length === 1 ? "priority" : "priorities"}

--- a/lib/strategic-plan/pillar-framing.ts
+++ b/lib/strategic-plan/pillar-framing.ts
@@ -1,0 +1,23 @@
+// ============================================================
+// Pillar framing — stakeholder-readable orientation per pillar
+// ============================================================
+// One- or two-sentence plain-language framing for each strategic-plan
+// pillar, drawn from a synthesis of the pillar name and its constituent
+// priorities. The upstream submodule
+// (vendor/strategic-plan/docs/) does not currently carry per-pillar
+// framing, so these defaults are authored here and refined by IIDS over
+// time. Tracked under #106 — refine the wording as stakeholder
+// feedback comes in; the keys must stay aligned with the catalog.
+// ============================================================
+
+export const PILLAR_FRAMING: Record<string, string> = {
+  A: "Centers the undergraduate experience — instruction, achievement, and well-being. Priorities span high-impact teaching, first-year support, AI literacy across disciplines, and campus belonging.",
+  B: "Embeds applied, hands-on learning into every UI degree path. Priorities expand research opportunities, workforce and community partnerships, and the systems that make 100% participation achievable.",
+  C: "Extends UI's reach beyond the residential cohort. Priorities span online learners, targeted regional investment, transfer pathways, and continuing education for in-demand careers.",
+  D: "Concentrates research investment in high-impact areas and connects UI's research enterprise to Idaho. Priorities cover focus areas, infrastructure, industry partnerships, agency collaboration, and the state's healthcare-worker shortage.",
+  E: "Modernizes UI's data, processes, and workforce so the institution can deliver on the other four pillars. Priorities cover the data warehouse, AI-driven process automation, faculty and staff support, and a culture of efficient execution.",
+};
+
+export function getPillarFraming(code: string): string | undefined {
+  return PILLAR_FRAMING[code];
+}


### PR DESCRIPTION
## Summary

Adds plain-language framing for each pillar — one or two sentences explaining what the pillar covers — so stakeholders skimming the Strategic Plan Alignment Explorer get oriented before diving into the priority list.

- **`lib/strategic-plan/pillar-framing.ts`** — typed `Record<string, string>` keyed by pillar code (`A`–`E`), plus a `getPillarFraming()` helper.
- **`/standards/strategic-plan`** (pillar index) — each card carries the framing beneath the pillar name, above the priority count.
- **`/standards/strategic-plan/pillars/[code]`** (pillar detail) — framing renders as the page subhead beneath the H1, before the priority list.

Mobile layout (375px) verified locally — cards stack cleanly, framing remains readable, sub-nav scrolls.

Closes #106. Final slice of [#100](https://github.com/ui-insight/AISPEG/issues/100), alongside #103, #105, #101, #104, and #102.

## HITL handoff

Three items in #106's acceptance criteria are deferred and need your call:

1. **Stakeholder copy approval** — the framings I authored are defensible defaults synthesized from each pillar's name and constituent priorities, but they're not stakeholder-approved language. Treat them as a starting point. Edit `lib/strategic-plan/pillar-framing.ts` to refine; one file, one source of truth.
2. **Glossary tooltips** — no strategic-plan glossary module exists yet. The priority text reads cleanly to a stakeholder audience without jargon callouts, so I deferred adding glossary infrastructure. If specific terms warrant tooltipping (e.g. "experiential learning", "transfer pathway"), file a follow-up.
3. **`/critique` deep-dive** — that's a user-invoked skill, not autonomously runnable. This PR's framing addition is the substantive structural change such a pass would have prompted; run `/critique` on `/standards/strategic-plan` after this lands and file follow-ups for any P0/P1 findings.

## Default framings shipped

| Pillar | Framing |
|---|---|
| A | Centers the undergraduate experience — instruction, achievement, and well-being. Priorities span high-impact teaching, first-year support, AI literacy across disciplines, and campus belonging. |
| B | Embeds applied, hands-on learning into every UI degree path. Priorities expand research opportunities, workforce and community partnerships, and the systems that make 100% participation achievable. |
| C | Extends UI's reach beyond the residential cohort. Priorities span online learners, targeted regional investment, transfer pathways, and continuing education for in-demand careers. |
| D | Concentrates research investment in high-impact areas and connects UI's research enterprise to Idaho. Priorities cover focus areas, infrastructure, industry partnerships, agency collaboration, and the state's healthcare-worker shortage. |
| E | Modernizes UI's data, processes, and workforce so the institution can deliver on the other four pillars. Priorities cover the data warehouse, AI-driven process automation, faculty and staff support, and a culture of efficient execution. |

## Test plan

- [ ] `npm run build` clean; all pillar/priority pages prerender as SSG
- [ ] `npm run lint` clean
- [ ] `/standards/strategic-plan` shows framing on each pillar card
- [ ] `/standards/strategic-plan/pillars/A` (and others) show framing in the page header
- [ ] Mobile layout (375px) verified — readable, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)