### PR TITLE
Rename Intervention → Project across documentation

### DIFF
--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -42,7 +42,7 @@ Think like a design director. Evaluate:
 **Emotional Journey**:
 - What emotion does this interface evoke? Is that intentional?
 - **Peak-end rule**: Is the most intense moment positive? Does the experience end well?
-- **Emotional valleys**: Check for anxiety spikes at high-stakes moments (payment, delete, commit). Are there design interventions (progress indicators, reassurance copy, undo options)?
+- **Emotional valleys**: Check for anxiety spikes at high-stakes moments (payment, delete, commit). Are there design projects (progress indicators, reassurance copy, undo options)?
 
 **Nielsen's Heuristics** (consult [heuristics-scoring](reference/heuristics-scoring.md)):
 Score each of the 10 heuristics 0-4. This scoring will be presented in the report.

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -112,7 +112,7 @@ invent a parallel aesthetic.
 - **Projector visibility:** deck body text ≥ 28pt equivalent. Use Public
   Sans 600+ for projector legibility. Avoid thin strokes.
 - **Color-blind:** status chips carry a label, not color alone (already
-  true in the Intervention schema). Pride Gold on white has good contrast
+  true in the Project schema). Pride Gold on white has good contrast
   (check AA), but for small text pair gold with brand-black ink rather than
   as text color on white.
 
@@ -158,7 +158,7 @@ verbatim. Two valid forms:
 - `/` → eyebrow *"Institutional AI Initiative"* + H1 *"AI work at the
   University of Idaho"* (Form B; "Home" is generic so the initiative
   name is the anchor).
-- `/portfolio` → eyebrow *"The Work"* + H1 *"AI Interventions for
+- `/portfolio` → eyebrow *"The Work"* + H1 *"AI Projects for
   Operational Excellence"* (Form B).
 - `/standards` → eyebrow *"Standards"* (in `app/standards/layout.tsx`)
   + H1 *"Software-development and user-experience standards"* (Form B).
@@ -220,10 +220,10 @@ the typed module is the source of truth.
 
 | Operation | What changes | Cost |
 |---|---|---|
-| Add a category | Constant + label record + tag interventions | ~5 min; tsc verifies the label record stays exhaustive |
-| Rename a category | Slug edit in two places | tsc surfaces every callsite (intervention tags + UI consumers) |
-| Retire a category | Remove from constant | tsc finds every still-tagged intervention; untag in one pass |
-| Promote to first-class field | Lift matching interventions into a new shape | Mechanical — grep the slug |
+| Add a category | Constant + label record + tag projects | ~5 min; tsc verifies the label record stays exhaustive |
+| Rename a category | Slug edit in two places | tsc surfaces every callsite (project tags + UI consumers) |
+| Retire a category | Remove from constant | tsc finds every still-tagged project; untag in one pass |
+| Promote to first-class field | Lift matching projects into a new shape | Mechanical — grep the slug |
 
 **Visual treatment:** chips are neutral (`surface-alt` background +
 `hairline` border + `brand-black` text). No per-category color coding —
@@ -259,7 +259,7 @@ is the operational status.
   same reason: ten distinct colors would cross the decoration line.
 
 **`tracked` suppresses the operational chip.** Externally-owned
-interventions don't follow the IIDS operational ladder, so the primary
+projects don't follow the IIDS operational ladder, so the primary
 stage chip carries the whole signal — a second neutral chip would imply
 a granularity that doesn't exist for them.
 
@@ -267,7 +267,7 @@ a granularity that doesn't exist for them.
 operational granularity isn't useful at landing-density. Format:
 
 ```
-14 interventions across 10 home units
+14 projects across 10 home units
 6 building · 6 live · 2 tracked
 ```
 

--- a/AGENTIC_CODING_HANDOUT.md
+++ b/AGENTIC_CODING_HANDOUT.md
@@ -75,7 +75,7 @@ The session will likely move through four stages:
 - `app/` — pages (Next.js App Router; four primary surfaces:
   `/portfolio`, `/builder-guide`, `/reports`, `/standards`)
 - `components/` — reusable UI pieces
-- `lib/portfolio.ts` — interventions inventory (typed)
+- `lib/portfolio.ts` — projects inventory (typed)
 - `lib/standards-watch.ts` — standards ledger
 - `lib/builder-guide-data.ts` — assessment quiz, scoring, tiers
 - `lib/github.ts` — fetches GitHub issue data
@@ -124,7 +124,7 @@ This keeps the tools complementary instead of redundant.
 
 Strong starter tasks in this repo include:
 
-- add or refine an intervention entry in `lib/portfolio.ts`
+- add or refine a project entry in `lib/portfolio.ts`
 - add a new entry to `lib/standards-watch.ts` when a new standard is
   formally requested from OIT
 - fix a small typography or layout detail on a page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Interactive website for the University of Idaho's institutional AI
 initiative, coordinated by **IIDS** (Institute for Interdisciplinary Data
 Sciences, which runs MindRouter and DGX Stack). The site maintains a
-growing inventory of AI interventions across UI units — some built by
+growing inventory of AI projects across UI units — some built by
 IIDS, others led by partner units, plus tools from the AI4RA partnership
 (UI + Southern Utah University NSF GRANTED, producing OpenERA, Vandalizer,
 MindRouter, ProcessMapping) that UI deploys institutionally. Built with
@@ -178,12 +178,12 @@ app/                       # Next.js App Router
 
 components/                # Reusable components
   Sidebar.tsx              # Sidebar navigation
-  PortfolioCard.tsx        # Intervention card
+  PortfolioCard.tsx        # Project card
   IssueCard.tsx            # GitHub issue card
   DocPage.tsx              # Docs layout primitives
 
 lib/                       # Domain logic
-  portfolio.ts             # Intervention inventory (typed; seed source for the applications table)
+  portfolio.ts             # Project inventory (typed; seed source for the applications table)
   work.ts                  # Postgres-backed query module for /portfolio (reads applications + blockers)
   work-categories.ts       # "By problem" taxonomy — typed slugs + audience-facing labels (drives /explore + the /portfolio category facet)
   standards-watch.ts       # Standards ledger
@@ -222,7 +222,7 @@ normative version of any of these lives in **Agent Rules** above).
   the builder-guide wizard, `components/PortfolioFilters.tsx`).
 - **Routes drop in by file convention.** New `app/<route>/page.tsx`
   picks up the layout automatically.
-- **Intervention entries are load-bearing UI.** When adding to
+- **Project entries are load-bearing UI.** When adding to
   `lib/portfolio.ts`, fill all required fields — the shape is in
   the same file. `homeUnits`, `operationalOwners`, and
   `buildParticipants` render directly to the public site, so name
@@ -232,8 +232,8 @@ normative version of any of these lives in **Agent Rules** above).
 
 | To add… | Edit | Notes |
 |---|---|---|
-| An intervention | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Set `status` honestly per the verification rules in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — `npm run verify:portfolio` polices it. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
-| A work category | `lib/work-categories.ts` (constant + label record) + tag relevant interventions | Audience-facing labels (a Dean's vocabulary). Header comment in the file documents add/rename/retire/promote mechanics. tsc enforces consistency across consumers. |
+| A project | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Set `status` honestly per the verification rules in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — `npm run verify:portfolio` polices it. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
+| A work category | `lib/work-categories.ts` (constant + label record) + tag relevant projects | Audience-facing labels (a Dean's vocabulary). Header comment in the file documents add/rename/retire/promote mechanics. tsc enforces consistency across consumers. |
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
 | A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |
 | A canonical UDM table tag | `lib/governance/canonical-udm-tables.ts` | Hand-curated v1 list. The data-governance catalog JSONs do not yet carry canonical/extension classification — once they do, this module retires. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ archived.
 Most structured data lives in typed TypeScript modules so the build
 catches schema drift:
 
-- `lib/portfolio.ts` — interventions inventory (seed source; runtime via Postgres)
+- `lib/portfolio.ts` — projects inventory (seed source; runtime via Postgres)
 - `lib/standards-watch.ts` — standards ledger
 - `lib/builder-guide-data.ts` — quiz, scoring, tiers
 - `lib/artifacts.ts` — unified Reports timeline (briefs, activity reports, external talks)
@@ -104,9 +104,9 @@ hand-maintained in `lib/portfolio.ts`.
 
 ## Common tasks
 
-### Adding an intervention to the portfolio
+### Adding a project to the portfolio
 
-Open `lib/portfolio.ts` and append a new entry to the `interventions`
+Open `lib/portfolio.ts` and append a new entry to the `projects`
 array. The shape is defined in the same file. Required fields include
 `slug`, `name`, `tagline`, `description`, `homeUnits`,
 `operationalOwners`, `buildParticipants`, `status`, `visibility`, and
@@ -114,8 +114,8 @@ array. The shape is defined in the same file. Required fields include
 
 ```ts
 {
-  slug: "my-new-intervention",
-  name: "My New Intervention",
+  slug: "my-new-project",
+  name: "My New Project",
   tagline: "One-line elevator pitch.",
   description: "Longer description shown on the detail page.",
   homeUnits: ["Office of the Provost"],
@@ -148,7 +148,7 @@ the editorial decisions that shape what shows up where.
   brief.
 - **`Partial`** — UI deployment exists but specific operational details
   (pilot scope, participant identities, configuration) are embargoed.
-  The intervention shows on `/portfolio` with a *"deployment details
+  The project shows on `/portfolio` with a *"deployment details
   embargoed"* notice. Use when the underlying work is sensitive, in
   negotiation, or pending public communications.
 - **`Internal-only`** — not visible on public `/portfolio` at all; only
@@ -180,8 +180,8 @@ owns it, IIDS may have advised but did not build. Always pair with
 #### `homeUnits` vs `buildParticipants`
 
 - **`homeUnits`** — the UI organizational unit(s) whose operations the
-  intervention serves. *Whose work depends on this.* Always at least
-  one entry. Multiple entries when an intervention serves more than
+  project serves. *Whose work depends on this.* Always at least
+  one entry. Multiple entries when a project serves more than
   one unit (rare).
 - **`buildParticipants`** — who actually built (or builds) the thing.
   Almost always includes `"IIDS"` for IIDS-built work; lists
@@ -210,7 +210,7 @@ owns it, IIDS may have advised but did not build. Always pair with
 `tags` is currently a free `string[]` used for situational flags. The
 known active values:
 
-- **`"diffusion"`** — the intervention is a *capability diffusion*
+- **`"diffusion"`** — the project is a *capability diffusion*
   case: a non-IIDS UI unit is co-building, not just consuming. Renders
   the *"Capability diffusion"* chip on `/portfolio`.
 
@@ -225,7 +225,7 @@ or open a new issue.
 
 The portfolio is only useful if it's current. The rules:
 
-- **At commit time** — when an intervention's *status*, *operational
+- **At commit time** — when a project's *status*, *operational
   owner*, *home unit*, or *scope* changes in real life, update
   `lib/portfolio.ts` in the same week. The git log is the audit
   trail.
@@ -349,7 +349,7 @@ Give your agent the strategic context first. A good opening:
 ### Effective prompt patterns
 
 **Adding content:**
-> "Add a new intervention to `lib/portfolio.ts`: [name], owned by [unit],
+> "Add a new project to `lib/portfolio.ts`: [name], owned by [unit],
 > built by IIDS. Use the existing entry shape. Visibility: Public."
 
 **Modifying a page:**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The site shows what's being built, what's stalled, and where to engage.
 
 | Surface | Route | Job |
 |---|---|---|
-| **The Work** | `/portfolio` | Portfolio of AI interventions across UI units. Each entry names a home unit and operational owner. |
+| **The Work** | `/portfolio` | Portfolio of AI projects across UI units. Each entry names a home unit and operational owner. |
 | **Submit a Project** | `/builder-guide` | A 9-step assessment that scopes an AI idea, classifies it into one of four tiers, and connects the submitter to a named owner at IIDS. |
 | **Reports** | `/reports` | Activity reports, briefs, and time-stamped public artifacts. |
 | **Standards** | `/standards` | Public ledger of the institutional software-development and user-experience standards IIDS has formally requested from OIT. The `/standards/data-model` sub-section is an interactive explorer for the AI4RA Unified Data Model and the per-project extensions across the IIDS portfolio. |
@@ -69,7 +69,7 @@ For full local-database setup, see [`/docs/deployment`](./app/docs/deployment/pa
 app/                         # Next.js App Router
   page.tsx                   # Landing — steering page
   layout.tsx                 # Root layout + metadata
-  portfolio/                 # The Work — AI interventions inventory
+  portfolio/                 # The Work — AI projects inventory
   builder-guide/             # Submit a Project — 9-step assessment
   reports/                   # Reports surface
   standards/                 # Standards ledger
@@ -85,7 +85,7 @@ components/                  # Reusable React components
   Sidebar.tsx, PortfolioCard.tsx, IssueCard.tsx, DocPage.tsx, ...
 
 lib/                         # Domain logic and data
-  portfolio.ts               # Inventory of AI interventions (typed)
+  portfolio.ts               # Inventory of AI projects (typed)
   standards-watch.ts         # Standards ledger entries
   builder-guide-data.ts      # Assessment quiz, scoring, tiers
   similarity.ts              # Submission ↔ registry overlap engine

--- a/app/admin/registry/new/page.tsx
+++ b/app/admin/registry/new/page.tsx
@@ -124,7 +124,7 @@ export default function NewRegistryEntryPage() {
           Register new application
         </h1>
         <p className="mt-1 text-sm text-gray-500">
-          Manually register an project. The detail page will let you fill
+          Manually register a project. The detail page will let you fill
           in the rest (full description, blockers, classification, etc.). For
           submissions that came through Submit-a-Project, use the
           &ldquo;Promote to registry&rdquo; button on the submission detail

--- a/docs/adr/0001-product-lifecycle-taxonomy.md
+++ b/docs/adr/0001-product-lifecycle-taxonomy.md
@@ -3,18 +3,18 @@
 **Status:** Accepted
 **Date:** 2026-05-03
 **Deciders:** Barrie Robison (with @ProfessorPolymorphic), Luke Sheneman (governance scope)
-**Supersedes:** the ad-hoc `InterventionStatus` union in [`lib/portfolio.ts`](../../lib/portfolio.ts) (`Planned | Prototype | Piloting | Production | Tracked | Archived`)
+**Supersedes:** the ad-hoc `ProjectStatus` union in [`lib/portfolio.ts`](../../lib/portfolio.ts) (`Planned | Prototype | Piloting | Production | Tracked | Archived`)
 **Related:** [#159](https://github.com/ui-insight/AISPEG/issues/159) (governance scope), [#154](https://github.com/ui-insight/AISPEG/issues/154) (work-categories epic — same pattern)
 
 ## Context
 
-The AISPEG portfolio catalogs AI interventions across UI units. Status accuracy is load-bearing: a stakeholder reading `/portfolio` makes resourcing decisions partly on what they see. The current six-state union (`Planned | Prototype | Piloting | Production | Tracked | Archived`) has three concrete failure modes:
+The AISPEG portfolio catalogs AI projects across UI units. Status accuracy is load-bearing: a stakeholder reading `/portfolio` makes resourcing decisions partly on what they see. The current six-state union (`Planned | Prototype | Piloting | Production | Tracked | Archived`) has three concrete failure modes:
 
 1. **No distinction between "idea" and "approved-to-build."** `Planned` covers both, so a stakeholder can't tell whether something has an owner or is aspirational.
 2. **`Prototype` conflates active development with idle demo state.** A project being built today and a project that was prototyped six months ago and abandoned read identically.
 3. **`Production` collapses three different operational realities** — actively maintained, in maintenance-only mode, and being sunset.
 
-Beyond the gaps, the labels are **not measurable**. Nothing in code verifies that a `Production` intervention actually has a `liveUrl` accessible institution-wide, or that a `Piloting` one has an actual cohort. Status drifts because nothing forces it to stay honest.
+Beyond the gaps, the labels are **not measurable**. Nothing in code verifies that a `Production` project actually has a `liveUrl` accessible institution-wide, or that a `Piloting` one has an actual cohort. Status drifts because nothing forces it to stay honest.
 
 ## Decision
 
@@ -33,7 +33,7 @@ The day-to-day status IIDS tracks. Each state has a verification rule that can b
 | `piloting` | Piloting | `liveUrl` accessible to a **named cohort**. `pilotCohort` populated with `size > 0` and a bounded `scope` (single unit OR named individuals OR an explicit "limited beta" descriptor). |
 | `production` | Production | A **publicly-accessible artifact** exists beyond the original pilot cohort: either (a) a `liveUrl` reachable beyond the pilot, or (b) a public `repoUrl` (`isPrivateRepo: false` or unset) where the repo itself is the consumable deliverable — the path that covers infrastructure, scaffolds, and self-hostable appliances. `productionScope` is `"home-unit"` (entire home unit's users), `"institution-wide"`, or `"external"` (institutional + outside-UI deployments). `supportContact` populated. |
 | `maintained` | Maintained | Inherits production's accessibility rule (liveUrl OR public repo). **No commits to `main` in the last 90 days.** No open feature issues — only `bug`-, `security`-, or `chore`-labeled issues. |
-| `sunsetting` | Sunsetting | `sunsetDate` set (ISO date, future or recent past). `replacedBy` populated — either a successor intervention `slug` or the literal string `manual-process`. |
+| `sunsetting` | Sunsetting | `sunsetDate` set (ISO date, future or recent past). `replacedBy` populated — either a successor project `slug` or the literal string `manual-process`. |
 | `archived` | Archived | `liveUrl` returns 404, is null, or domain is dead (or, for repo-as-artifact deliverables, `repoUrl` is archived/deleted). Service stopped. Record kept for institutional memory. |
 | `tracked` *(meta)* | Tracked | Not built by IIDS. `trackingOnly: true`. Bypasses the operational ladder; the public stage is its own bucket. |
 
@@ -61,7 +61,7 @@ This **resolves [#159](https://github.com/ui-insight/AISPEG/issues/159) in the a
 
 ### 2. `Tracked` gets its own public stage
 
-Three options were considered: own stage, roll into whatever the external owner reports, or flat secondary tag with no public stage. We chose **own stage**. Rationale: a stakeholder reading the registry needs to know whether IIDS is responsible for an intervention or is merely tracking it. Hiding that under a `Live`/`Building` rollup obscures the load-bearing distinction.
+Three options were considered: own stage, roll into whatever the external owner reports, or flat secondary tag with no public stage. We chose **own stage**. Rationale: a stakeholder reading the registry needs to know whether IIDS is responsible for a project or is merely tracking it. Hiding that under a `Live`/`Building` rollup obscures the load-bearing distinction.
 
 ### 3. `featureComplete` flag, not pure commit-cadence
 
@@ -71,9 +71,9 @@ Pure commit-cadence has false positives — a healthy maintained project with sp
 
 The first draft of the rules required a `liveUrl` for `production`. That broke for two real cases in the portfolio: `template-app` is a scaffold consumed by cloning, and `dgx-stack` is a self-hostable appliance — neither is a hosted webapp, and both are honestly in production use. The semantic the rule is reaching for is "**is there a publicly-accessible artifact someone outside the build team can use right now?**" For hosted apps, that's `liveUrl`. For infrastructure, scaffolds, and self-hostable deliverables, the public repo *is* the consumable artifact. Either satisfies the rule. The verifier checks that `repoUrl` is set and `isPrivateRepo` is not true — a private repo with no liveUrl fails, as it should.
 
-## Schema additions to `Intervention`
+## Schema additions to `Project`
 
-To make the rules checkable, the `Intervention` interface in [`lib/portfolio.ts`](../../lib/portfolio.ts) gains:
+To make the rules checkable, the `Project` interface in [`lib/portfolio.ts`](../../lib/portfolio.ts) gains:
 
 | Field | Type | Why | Authored or derived |
 |---|---|---|---|
@@ -97,16 +97,16 @@ Implementation lands as `lib/portfolio-verification.ts` exporting:
 ```ts
 export interface VerificationProblem {
   slug: string;
-  claimedStatus: InterventionStatus;
+  claimedStatus: ProjectStatus;
   problem: string;
   rule: string;
 }
 
-export function verifyIntervention(i: Intervention): VerificationProblem[];
-export function verifyAll(interventions: Intervention[]): VerificationProblem[];
+export function verifyProject(i: Project): VerificationProblem[];
+export function verifyAll(projects: Project[]): VerificationProblem[];
 ```
 
-Plus an npm script `npm run verify:portfolio` that fails non-zero if any intervention has problems. CI runs it on every PR. The rules in this ADR are the spec; the file is the executable.
+Plus an npm script `npm run verify:portfolio` that fails non-zero if any project has problems. CI runs it on every PR. The rules in this ADR are the spec; the file is the executable.
 
 `lastCommitDate` derivation: `scripts/refresh-commit-dates.ts` hits the GitHub API for each `repoUrl`, writes results to an auto-generated `lib/portfolio-meta.ts` (gitignored from manual edits, regenerated like `lib/governance/catalog.ts`). A weekly GitHub Action keeps it fresh.
 
@@ -116,7 +116,7 @@ The `vendor/data-governance` submodule grows a new domain. Initial vocabularies 
 
 | Group | Cardinality | Source of truth |
 |---|---|---|
-| `InterventionStatus` | 10 values (including `tracked`) | `lib/portfolio.ts` |
+| `ProjectStatus` | 10 values (including `tracked`) | `lib/portfolio.ts` |
 | `PublicStage` | 5 values | `lib/portfolio.ts` (derived) |
 | `ProductionScope` | 3 values | `lib/portfolio.ts` |
 | `Visibility` | 3 values | `lib/portfolio.ts` (existing) |
@@ -125,11 +125,11 @@ The `vendor/data-governance` submodule grows a new domain. Initial vocabularies 
 
 Each value carries `code`, `label`, `displayOrder`, `description`, and (new) a `verificationRule` description string. The implementation of the rule lives in `lib/portfolio-verification.ts`; the catalog records what the rule *is*, not how it's checked.
 
-## Migration of the existing 15 interventions
+## Migration of the existing 15 projects
 
 Status currently claimed → likely re-classification under the new rules. Final assignments happen during the schema PR's data audit; this is a starting point for that conversation.
 
-| Intervention | Current | Likely new | Notes |
+| Project | Current | Likely new | Notes |
 |---|---|---|---|
 | `stratplan` | Production | `production` (Live) | Verify `productionScope` + `supportContact` |
 | `audit-dashboard` | Prototype | `building` (Building) | Active dev; check commit cadence |
@@ -156,20 +156,20 @@ Status currently claimed → likely re-classification under the new rules. Final
 - Resolves [#159](https://github.com/ui-insight/AISPEG/issues/159) for the broader site-IA enums (`Visibility`, `AI4RARelationship`, etc. — all picked up under the same domain).
 
 **Negative:**
-- Adds eight authored fields to `Intervention`. Authors carry more discipline.
+- Adds eight authored fields to `Project`. Authors carry more discipline.
 - Requires a derivation script (`refresh-commit-dates.ts`) and a CI step.
-- The 15 existing interventions need a re-classification audit; some statuses will move.
+- The 15 existing projects need a re-classification audit; some statuses will move.
 - Couples the AISPEG site's iteration to upstream `vendor/data-governance` for taxonomy edits — the same coupling that already applies to research-admin domain vocabularies. Tradeoff accepted.
 
 **Neutral:**
-- The `Tracked` meta-state breaks the ladder pattern slightly, but this is honest — externally-owned interventions don't follow the same lifecycle and should be visibly separated.
+- The `Tracked` meta-state breaks the ladder pattern slightly, but this is honest — externally-owned projects don't follow the same lifecycle and should be visibly separated.
 
 ## Implementation sequencing
 
 Five PRs, in order. Each ships independently.
 
 1. **This ADR** *(merged)* — locks the design.
-2. **Schema PR** — extend `Intervention`, Migration 007 mirrors columns into `applications`, re-classify the 15 existing rows, update `scripts/seed-portfolio.ts`. CI green requires the verification check passes (which won't exist yet — this PR creates the data shape, not the verifier).
+2. **Schema PR** — extend `Project`, Migration 007 mirrors columns into `applications`, re-classify the 15 existing rows, update `scripts/seed-portfolio.ts`. CI green requires the verification check passes (which won't exist yet — this PR creates the data shape, not the verifier).
 3. **Verification PR** — `lib/portfolio-verification.ts` + `npm run verify:portfolio` + `scripts/refresh-commit-dates.ts` + a weekly GitHub Action for derivation. CI now polices status accuracy.
 4. **UI PR** — `PublicStage` chip on portfolio cards (primary), operational status chip (secondary). Status filter on `/portfolio` reorganized: top-level by public stage, drill-in by operational. `/explore` and the landing pick up the new public-stage signals. `.impeccable.md` updated.
 5. **Governance PR** — add the `iids-portfolio` domain to `vendor/data-governance`, regenerate `lib/governance/*.ts`, drift workflow now polices these vocabularies too. Closes [#159](https://github.com/ui-insight/AISPEG/issues/159).

--- a/lib/portfolio-verification.ts
+++ b/lib/portfolio-verification.ts
@@ -6,7 +6,7 @@
 //
 // Each operational status has a measurable rule; this module checks each
 // claim against its rule and returns a list of problems. CI runs
-// `npm run verify:portfolio` to fail the build when an project's
+// `npm run verify:portfolio` to fail the build when a project's
 // claimed status is inconsistent with its data.
 //
 // `lastCommitDate` for each repoUrl-bearing project is derived

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -593,7 +593,7 @@ export const HOME_UNIT_GROUP_ORDER = [
 export function groupByHomeUnit(
   items: Project[]
 ): { unit: string; items: Project[] }[] {
-  // An project is listed under its FIRST home unit for grouping.
+  // A project is listed under its FIRST home unit for grouping.
   const groups = new Map<string, Project[]>();
   for (const i of items) {
     const primary = i.homeUnits[0] || "Unclassified";


### PR DESCRIPTION
Slice 4 (final) of [#189](https://github.com/ui-insight/AISPEG/issues/189). Closes #193, closes #189.

## Summary

- Sed sweep across all documentation files: `Intervention` → `Project`, `interventions` → `projects`, `intervention` → `project`.
- Article-agreement follow-up: `"an project"` → `"a project"` across `.md`, `.ts`, `.tsx` files.

## Files swept

| File | Purpose |
|---|---|
| `README.md` | Project overview |
| `CLAUDE.md` | Agent rules + conventions |
| `CONTRIBUTING.md` | Contribution guide |
| `AGENTIC_CODING_HANDOUT.md` | Agentic-coding handout |
| `.impeccable.md` | Design context |
| `.agents/skills/critique/SKILL.md` | Critique skill bundle |
| `docs/adr/0001-product-lifecycle-taxonomy.md` | Lifecycle ADR |

Also touched (carry-over from earlier slices that the article-fix pass caught): `app/admin/registry/new/page.tsx`, `lib/portfolio.ts`, `lib/portfolio-verification.ts` — all comment-only changes fixing "an project" → "a project" in code comments.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run verify:portfolio` — passes ("14 projects, 0 errors").
- [x] `grep -ri "intervention"` across `.md`, `.ts`, `.tsx` — zero matches outside `vendor/` and build artifacts.
- [x] Spot-read of CLAUDE.md, .impeccable.md, ADR 0001 for prose coherence post-rename.

## Notable preservation

The ADR 0001 "Supersedes" line refers to the type as it exists today (`ProjectStatus`). Git history preserves the historical `InterventionStatus` audit trail; the ADR doesn't need to duplicate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)