### PR TITLE
Project detail: typography pass (Public Sans 900 + larger tagline)

### DIFF
--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -164,11 +164,11 @@ export default function ProjectDetail({
         <SectionEyebrow>
           The Work{app.homeUnits[0] ? ` · ${app.homeUnits[0]}` : ""}
         </SectionEyebrow>
-        <h1 className="mt-2 text-3xl font-bold text-ui-charcoal">
+        <h1 className="mt-2 text-4xl font-black leading-tight tracking-tight text-brand-black md:text-5xl">
           {app.name}
         </h1>
         {app.tagline && (
-          <p className="mt-3 text-lg leading-relaxed text-ink-muted">
+          <p className="mt-4 text-xl leading-relaxed text-ink-muted">
             {app.tagline}
           </p>
         )}
@@ -176,12 +176,12 @@ export default function ProjectDetail({
           {ownerNames.length > 0 ? (
             <>
               Operationally owned by{" "}
-              <em className="font-medium italic text-brand-black">
+              <em className="font-semibold italic text-brand-black">
                 {ownerNames.join(", ")}
               </em>
             </>
           ) : app.trackingOnly ? (
-            <em className="font-medium italic text-brand-black">
+            <em className="font-semibold italic text-brand-black">
               Awaiting contact with unit
             </em>
           ) : null}


### PR DESCRIPTION
## Summary
- H1: `text-3xl font-bold text-ui-charcoal` → `text-4xl md:text-5xl font-black tracking-tight text-brand-black`. Same weight as `/portfolio` and `/standards` (font-black), size bumped because this is the editorial lede of a feature page.
- Tagline: `text-lg` → `text-xl`. Reads as a true subtitle under the heavier H1.
- Owner-line italic emphasis: weight 500 → 600, per slice spec — names carry the principle-#1 weight.

Closes #187. Refs epic #184.

## Test plan
- [x] `npm run build` clean.
- [x] DOM check: H1 `48px` `weight 900`, tagline `20px`, owner-line `<em>` `weight 600 italic`.
- [x] Visual check on `/portfolio/openera` — H1 reads as institutional headline, owner-line emphasizes Sarah Martonick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)