### PR TITLE
Project detail: polish pass (curatorial closer)

### DIFF
--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -438,6 +438,18 @@ export default function ProjectDetail({
           </div>
         </section>
       )}
+
+      {/* Closer — bookends the page with the eyebrow at the top.
+          Signals the page is a curated artifact, not auto-generated. */}
+      <footer className="border-t border-hairline pt-6 text-xs text-brand-silver">
+        Coordinated by IIDS ·{" "}
+        <Link
+          href="/builder-guide"
+          className="font-medium text-brand-silver hover:text-brand-black"
+        >
+          Submit a correction &rarr;
+        </Link>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a small footer line bookending the eyebrow at the top: hairline above, brand-silver text, \`Coordinated by IIDS · Submit a correction →\` linking to /builder-guide. Closes the dead-space-after-Related issue from the /critique pass — short pages (e.g., MindRouter) used to trail off; they now end with a clear curatorial sign-off.

Closes #188. Refs epic #184.

## Test plan
- [x] \`npm run build\` clean.
- [x] Visual check on \`/portfolio/mindrouter\` (short page) and \`/portfolio/template-app\` (longer page) — closer renders correctly with hairline above, last child of the wrapper.
- [x] Page reads as complete (beginning + middle + end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)