### PR TITLE
Rename "The Work" → "Projects" across user-facing surfaces

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -158,7 +158,7 @@ verbatim. Two valid forms:
 - `/` → eyebrow *"Institutional AI Initiative"* + H1 *"AI work at the
   University of Idaho"* (Form B; "Home" is generic so the initiative
   name is the anchor).
-- `/portfolio` → eyebrow *"The Work"* + H1 *"AI Projects for
+- `/portfolio` → eyebrow *"Projects"* + H1 *"AI Projects for
   Operational Excellence"* (Form B).
 - `/standards` → eyebrow *"Standards"* (in `app/standards/layout.tsx`)
   + H1 *"Software-development and user-experience standards"* (Form B).
@@ -203,7 +203,7 @@ treatment to other pages as a default.
 **Test for "is this a domain-accent eyebrow?":** the label changes
 based on which item the user is viewing, and the color carries
 meaning beyond decoration. If both are true, clearwater is fine. If
-the eyebrow is fixed (e.g., *"The Work"* on every visit to
+the eyebrow is fixed (e.g., *"Projects"* on every visit to
 `/portfolio`), it's a wayfinding eyebrow — use brand-silver.
 
 ## Work Categories Taxonomy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Five primary surfaces in the sidebar, plus an About link in the footer:
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| The Work | `/portfolio` | Postgres `applications` table (read via `lib/work.ts`); `lib/portfolio.ts` is the TS shadow + seed source for `scripts/seed-portfolio.ts`. Filter UI is two-tier: public stage (rollup) → operational status (drill-in), per [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md). |
+| Projects | `/portfolio` | Postgres `applications` table (read via `lib/work.ts`); `lib/portfolio.ts` is the TS shadow + seed source for `scripts/seed-portfolio.ts`. Filter UI is two-tier: public stage (rollup) → operational status (drill-in), per [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md). |
 | Explore | `/explore` | `lib/work-categories.ts` (taxonomy) + `lib/portfolio.ts` (counts and representative names) — by-problem axis, complementary to `/portfolio`'s by-home-unit grouping |
 | Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz definition); Postgres `submissions` (responses) |
 | Reports | `/reports` | `lib/artifacts.ts` — unified timeline of briefs, activity reports, and external presentations |
@@ -165,7 +165,7 @@ Headings weight 900; body 400; emphasis 600–700. No display serif pairing.
 app/                       # Next.js App Router
   page.tsx                 # Landing — four-card steering page
   layout.tsx               # Root layout, sidebar, metadata
-  portfolio/               # The Work
+  portfolio/               # Projects
   explore/                 # Explore — "by problem" axis, category-tile entry
   builder-guide/           # Submit a Project (assessment quiz)
   reports/                 # Reports surface

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ The site runs at <http://localhost:3000>.
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| The Work | `/portfolio` | `lib/portfolio.ts` |
+| Projects | `/portfolio` | `lib/portfolio.ts` |
 | Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz) + Postgres `submissions` (responses) |
 | Reports | `/reports` | `lib/artifacts.ts` (unified timeline) + per-report routes |
 | Standards | `/standards` | `lib/standards-watch.ts` |
@@ -281,7 +281,7 @@ If approved:
 1. Create `app/<route>/page.tsx`.
 2. Add the entry to `primaryItems` (or `footerItems`) in
    `components/Sidebar.tsx`. Existing icons (each used by exactly one
-   entry): `house` (Home), `grid` (The Work), `compass` (Submit a
+   entry): `house` (Home), `grid` (Projects), `compass` (Submit a
    Project), `shield` (Standards), `document` (Reports), `book` (About).
    **Each sidebar entry uses a distinct icon** — adding a new entry
    means adding a new glyph to `NavIcon`, not reusing an existing one.
@@ -343,7 +343,7 @@ Give your agent the strategic context first. A good opening:
 > Next.js 16 site that's the coordination nexus for the University of
 > Idaho's institutional AI initiative, operated by IIDS. We're mid-refactor
 > from a legacy AISPEG-collaboration framing. The IA is four surfaces:
-> The Work, Submit a Project, Reports, Standards. Run `npm run build` to
+> Projects, Submit a Project, Reports, Standards. Run `npm run build` to
 > verify changes.
 
 ### Effective prompt patterns

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The site shows what's being built, what's stalled, and where to engage.
 
 | Surface | Route | Job |
 |---|---|---|
-| **The Work** | `/portfolio` | Portfolio of AI projects across UI units. Each entry names a home unit and operational owner. |
+| **Projects** | `/portfolio` | Portfolio of AI projects across UI units. Each entry names a home unit and operational owner. |
 | **Submit a Project** | `/builder-guide` | A 9-step assessment that scopes an AI idea, classifies it into one of four tiers, and connects the submitter to a named owner at IIDS. |
 | **Reports** | `/reports` | Activity reports, briefs, and time-stamped public artifacts. |
 | **Standards** | `/standards` | Public ledger of the institutional software-development and user-experience standards IIDS has formally requested from OIT. The `/standards/data-model` sub-section is an interactive explorer for the AI4RA Unified Data Model and the per-project extensions across the IIDS portfolio. |
@@ -69,7 +69,7 @@ For full local-database setup, see [`/docs/deployment`](./app/docs/deployment/pa
 app/                         # Next.js App Router
   page.tsx                   # Landing — steering page
   layout.tsx                 # Root layout + metadata
-  portfolio/                 # The Work — AI projects inventory
+  portfolio/                 # Projects — AI projects inventory
   builder-guide/             # Submit a Project — 9-step assessment
   reports/                   # Reports surface
   standards/                 # Standards ledger

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -59,7 +59,7 @@ export default function AboutPage() {
             className="group block rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
           >
             <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-              The Work
+              Projects
             </p>
             <h3 className="mt-2 text-base font-semibold text-ui-charcoal">
               Portfolio of AI projects
@@ -135,7 +135,7 @@ export default function AboutPage() {
             </h3>
             <p className="mt-1 text-sm text-gray-600 leading-relaxed">
               Deans, the Provost&rsquo;s office, ORED leadership,
-              partner-unit leadership. The Work and Reports surfaces are
+              partner-unit leadership. The Projects and Reports surfaces are
               designed for scanning &mdash; owner names and home-unit
               groupings let a stakeholder find their unit&rsquo;s slice
               without reading everything.
@@ -176,7 +176,7 @@ export default function AboutPage() {
                 href="/portfolio"
                 className="text-brand-black hover:underline"
               >
-                The Work
+                Projects
               </Link>{" "}
               to find related ongoing efforts before starting something
               new.

--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -197,7 +197,7 @@ auth_level             5%     Exact match
 app/
   layout.tsx              # Root layout with Sidebar
   page.tsx                # Landing — four-card steering page
-  portfolio/              # The Work — projects inventory
+  portfolio/              # Projects inventory
   builder-guide/          # Submit-a-Project assessment
   reports/                # Reports surface
   standards/              # Standards ledger

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -64,7 +64,7 @@ export default function ExplorePage() {
           counts the projects tagged with that kind of work and links
           straight into a filtered view of{" "}
           <Link href="/portfolio" className="font-medium text-brand-black hover:underline">
-            The Work
+            Projects
           </Link>
           .
         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,7 +87,7 @@ export default async function Home() {
           className="group block rounded-xl border border-hairline bg-white p-8 transition-shadow hover:shadow-md"
         >
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            The Work
+            Projects
           </p>
           <h2 className="mt-2 text-2xl font-semibold">
             {projectCount} AI projects across UI units

--- a/app/portfolio/error.tsx
+++ b/app/portfolio/error.tsx
@@ -17,7 +17,7 @@ export default function PortfolioError({
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-clearwater">
-        The Work — temporarily unavailable
+        Projects — temporarily unavailable
       </p>
 
       <h1 className="mt-3 text-3xl font-black tracking-tight text-brand-black md:text-4xl">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -170,7 +170,7 @@ export default async function PortfolioPage({
       {/* Header */}
       <div>
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-          The Work
+          Projects
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
           AI Projects for Operational Excellence

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -147,7 +147,7 @@ export default function ProjectDetail({
       {/* Breadcrumb */}
       <nav className="text-sm text-gray-500">
         <Link href={basePath} className="hover:text-brand-black">
-          {audience === "internal" ? "Internal portfolio" : "Portfolio"}
+          {audience === "internal" ? "Internal projects" : "Projects"}
         </Link>
         {app.homeUnits[0] && (
           <>
@@ -162,7 +162,7 @@ export default function ProjectDetail({
       {/* Beat 1 — What is this? Hero band, no card shell. */}
       <header>
         <SectionEyebrow>
-          The Work{app.homeUnits[0] ? ` · ${app.homeUnits[0]}` : ""}
+          Projects{app.homeUnits[0] ? ` · ${app.homeUnits[0]}` : ""}
         </SectionEyebrow>
         <h1 className="mt-2 text-4xl font-black leading-tight tracking-tight text-brand-black md:text-5xl">
           {app.name}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 
 const primaryItems = [
   { href: "/", label: "Home", icon: "house" },
-  { href: "/portfolio", label: "The Work", icon: "grid" },
+  { href: "/portfolio", label: "Projects", icon: "grid" },
   { href: "/explore", label: "Explore", icon: "search" },
   { href: "/builder-guide", label: "Submit a Project", icon: "compass" },
   { href: "/standards", label: "Standards", icon: "shield" },


### PR DESCRIPTION
## Summary

- Sidebar label, page eyebrows, breadcrumbs, and inline link text renamed from **"The Work"** to **"Projects"** on `/`, `/portfolio`, `/portfolio/[slug]`, `/about`, `/explore`, and the portfolio error page.
- Design-context example in `.impeccable.md` updated; IA tables in `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, and `app/docs/architecture` updated so the documented IA matches the live label.
- Sprint 2 ("The Work rebuild") references in `CLAUDE.md` and `README.md` left as-is — frozen historical labels, matching the `REFACTOR.md` treatment.

The sidebar→eyebrow→H1 thread (`.impeccable.md` rule) now reads: eyebrow *"Projects"* + H1 *"AI Projects for Operational Excellence"*. The eyebrow now anchors the H1's noun rather than introducing a new one.

Closes #207. First slice of #212 (`/portfolio` IA + density rework).

## Test plan

- [x] `npm run build` passes with no errors or warnings
- [x] `/portfolio` renders with `Projects` in the sidebar and `PROJECTS` eyebrow
- [x] `/portfolio/[slug]` renders with `Projects / Home Unit / Name` breadcrumb and `Projects · Home Unit` eyebrow
- [x] No console errors on either page
- [ ] Reviewer: spot-check `/`, `/about`, `/explore` for the four-card / inline-link rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)