### PR TITLE
Suppress operational chip when its label collides with the public stage

### DIFF
--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -70,12 +70,16 @@ export default function PortfolioCard({
   const liveHost = app.liveUrl ? hostnameOf(app.liveUrl) : null;
 
   const stage = publicStageFromStatus(app.status);
-  // The operational chip is suppressed for `tracked` — the ladder
-  // doesn't apply to externally-owned projects, so the primary
-  // stage chip carries the whole signal. (See ADR 0001.)
-  const showOperationalChip =
-    isProjectStatus(app.status) && app.status !== "tracked";
   const operationalStatus = isProjectStatus(app.status) ? app.status : null;
+  // Suppress the operational chip whenever its label collides with the
+  // public-stage label (e.g. `building` operational rolling up into the
+  // `Building` stage; `tracked` rolling up into the `Tracked` stage).
+  // The primary stage chip already carries that signal, and a duplicate
+  // chip below reads as redundant noise. The check generalises the prior
+  // `tracked` special case. (See ADR 0001.)
+  const showOperationalChip =
+    operationalStatus !== null &&
+    OPERATIONAL_LABEL[operationalStatus] !== PUBLIC_STAGE_LABEL[stage];
 
   const isAi4ra =
     app.ai4raRelationship === "Core" ||


### PR DESCRIPTION
## Summary

Projects whose operational status is the literal value `building` (or `tracked`) were rendering two chips with the same label — `Building / Building`, `Tracked / Tracked` — because the operational name happens to collide with its rollup stage name. Two chips, same word, no information added.

Generalises the prior `app.status !== "tracked"` special case into a label-equality check: suppress the secondary operational chip whenever `OPERATIONAL_LABEL[status] === PUBLIC_STAGE_LABEL[stage]`. The primary stage chip already carries that signal.

## Behaviour

| Stage / Status | Before | After |
|---|---|---|
| `building` / `building` | Building / Building | **Building** |
| `tracked` / `tracked` | Tracked (was already special-cased) | **Tracked** |
| `building` / `prototype` | Building / Prototype | Building / Prototype |
| `live` / `piloting` | Live / Piloting | Live / Piloting |
| `live` / `production` | Live / Production | Live / Production |
| `live` / `maintained` | Live / Maintained | Live / Maintained |
| `retired` / `sunsetting` | Retired / Sunsetting | Retired / Sunsetting |
| `retired` / `archived` | Retired / Archived | Retired / Archived |
| `exploring` / `idea` | Exploring / Idea | Exploring / Idea |
| `exploring` / `approved` | Exploring / Approved | Exploring / Approved |

The check also simplifies the prior `tracked` special case — we no longer need to enumerate it explicitly.

Follow-up to #212. Discovered post-deploy on `aispeg-dev`.

## Test plan

- [x] `npm run build` passes
- [x] All 14 cards render correct chip pairs in dev (verified via DOM):
  - 6 cards collapse to a single `Building` chip
  - 5 cards show `Live / Production`
  - 1 card shows `Live / Piloting`
  - 2 cards show `Tracked` alone
- [ ] Reviewer: hover the stage chip on a `Building`-only card and confirm the tooltip ("Building — actively being built or prototyped by IIDS.") still gives the full context

🤖 Generated with [Claude Code](https://claude.com/claude-code)