### PR TITLE
Declare strategic-plan alignment for all 14 portfolio projects

### DIFF
--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -158,6 +158,7 @@ export const projects: Project[] = [
       "Makes strategic execution visible. Surfaces under-served priorities, cross-unit synergies, and misalignment. Supports investment prioritization conversations.",
     tech: ["React 19", "TypeScript", "Tailwind v4", "FastAPI", "PostgreSQL"],
     workCategories: ["executive-analytics"],
+    strategicPlanAlignment: ["E.4"],
   },
 
   // ============================================================
@@ -187,6 +188,7 @@ export const projects: Project[] = [
     tech: ["React 19", "FastAPI", "PostgreSQL 16", "MindRouter", "Qwen3"],
     relatedSlugs: ["mindrouter", "dgx-stack", "template-app"],
     workCategories: ["documents", "reconciliation"],
+    strategicPlanAlignment: ["E.2", "E.4"],
   },
 
   // ============================================================
@@ -219,6 +221,7 @@ export const projects: Project[] = [
     tech: ["React 19", "FastAPI", "SQLAlchemy 2.0", "MindRouter"],
     relatedSlugs: ["mindrouter"],
     workCategories: ["documents", "process"],
+    strategicPlanAlignment: ["E.2"],
   },
 
   // ============================================================
@@ -254,6 +257,7 @@ export const projects: Project[] = [
     tech: ["React 19", "Python 3.11+", "FastAPI", "Docker"],
     relatedSlugs: ["mindrouter", "dgx-stack", "processmapping"],
     workCategories: ["documents", "research-admin"],
+    strategicPlanAlignment: ["D.2", "E.2"],
   },
   {
     slug: "processmapping",
@@ -279,6 +283,7 @@ export const projects: Project[] = [
     tech: ["React 19", "TypeScript", "Vite", "FastAPI", "Python 3.11+"],
     relatedSlugs: ["vandalizer"],
     workCategories: ["process", "research-admin"],
+    strategicPlanAlignment: ["D.2", "E.2", "E.4"],
   },
 
   // ============================================================
@@ -311,6 +316,7 @@ export const projects: Project[] = [
     tech: ["React", "TypeScript", "Tailwind CSS", "FastAPI", "SQLAlchemy 2.0", "PostgreSQL 16"],
     relatedSlugs: ["vandalizer", "processmapping"],
     workCategories: ["research-admin"],
+    strategicPlanAlignment: ["D.2", "E.2"],
   },
 
   // ============================================================
@@ -339,6 +345,7 @@ export const projects: Project[] = [
     operationalExcellenceOutcome:
       "Systematic EO response posture. Reduces scramble when new EOs drop. Living view of EO-driven obligations for leadership.",
     workCategories: ["documents", "process"],
+    strategicPlanAlignment: ["E.4"],
   },
 
   // ============================================================
@@ -368,6 +375,7 @@ export const projects: Project[] = [
     tags: ["diffusion"],
     relatedSlugs: ["template-app"],
     workCategories: ["coordination"],
+    strategicPlanAlignment: ["B.3"],
   },
 
   // ============================================================
@@ -395,6 +403,7 @@ export const projects: Project[] = [
       "Cohort visibility for program leaders. Data-driven program improvement. Stronger NSF CAREER-grant pipeline.",
     tech: ["React", "TypeScript", "Vite", "FastAPI"],
     workCategories: ["executive-analytics"],
+    strategicPlanAlignment: ["D.2", "E.3"],
   },
 
   // ============================================================
@@ -426,6 +435,7 @@ export const projects: Project[] = [
     tech: ["Python 3.11+", "Docker", "Ollama", "vLLM", "Azure AD SSO"],
     relatedSlugs: ["dgx-stack", "audit-dashboard", "vandalizer", "ucm-daily-register"],
     workCategories: ["ai-infrastructure"],
+    strategicPlanAlignment: ["A.3", "E.2"],
   },
   {
     slug: "dgx-stack",
@@ -452,6 +462,7 @@ export const projects: Project[] = [
     tech: ["Docker", "vLLM", "NVIDIA Container Toolkit", "CUDA 13"],
     relatedSlugs: ["mindrouter", "audit-dashboard", "vandalizer"],
     workCategories: ["ai-infrastructure"],
+    strategicPlanAlignment: ["D.2", "E.2"],
   },
   {
     slug: "template-app",
@@ -484,6 +495,7 @@ export const projects: Project[] = [
       "nexus",
     ],
     workCategories: ["ai-infrastructure"],
+    strategicPlanAlignment: ["E.2", "E.4"],
   },
 
   // ============================================================
@@ -507,6 +519,7 @@ export const projects: Project[] = [
     operationalExcellenceOutcome:
       "Foundation for institutional reporting, analytics, and interoperability across enterprise systems.",
     trackingOnly: true,
+    strategicPlanAlignment: ["E.1"],
   },
   {
     slug: "nexus",
@@ -533,6 +546,7 @@ export const projects: Project[] = [
       "Standardizes where institutional application modules live. Shared security posture, audit trail, and operational footprint across UI units. Reduces per-app hosting overhead and fragmentation.",
     relatedSlugs: ["template-app"],
     workCategories: ["ai-infrastructure"],
+    strategicPlanAlignment: ["E.1", "E.4"],
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes the open arc from the **Strategic Plan Alignment Explorer** epic (#100). The explorer infrastructure shipped in May 2026 with empty alignment data, deliberately deferring assignments to a later round of human judgment. This change populates that round.

## Alignments

Hybrid pass: I drafted from each project's tagline, description, and operational outcome; @ProfessorPolymorphic confirmed the obvious matches and the judgment calls (ExecOrd → E.4; Nexus → E.1+E.4; MindRouter gains A.3 because students access it).

| Project | Codes |
|---|---|
| Strategic Plan Dashboard | `E.4` |
| Audit Dashboard | `E.2`, `E.4` |
| UCM Daily Register | `E.2` |
| Vandalizer | `D.2`, `E.2` |
| ProcessMapping | `D.2`, `E.2`, `E.4` |
| OpenERA | `D.2`, `E.2` |
| ExecOrd | `E.4` |
| SEM Experiential Learning | `B.3` |
| RFD CAREER Dashboard | `D.2`, `E.3` |
| MindRouter | `A.3`, `E.2` |
| DGX Stack | `D.2`, `E.2` |
| TEMPLATE-app | `E.2`, `E.4` |
| OIT Data Modernization | `E.1` |
| Nexus | `E.1`, `E.4` |

## Coverage by priority (8 of 19 priorities now active)

| Code | Text | Projects |
|---|---|---|
| A.3 | Teach students how to apply AI in their disciplines | 1 |
| B.3 | Build the systems to deliver 100% experiential learning | 1 |
| D.2 | Invest in research infrastructure and support | 5 |
| E.1 | Create a data warehouse | 2 |
| E.2 | Simplify and automate processes through AI | **8** |
| E.3 | Attract, retain, reward, and support the best faculty and staff | 1 |
| E.4 | Build a culture of efficient collaboration and execution around projects | 6 |

The institutional case the original epic argued for is now load-bearing — every priority detail page that has alignments lights up with project counts, and every project card threads back to the priorities it advances.

## Test plan

- [x] `npm run build` passes
- [x] `npm run verify:portfolio` passes (14 projects, 0 errors, 0 warnings — verifier checks every code against `lib/strategic-plan/catalog.ts`)
- [x] All 14 cards on `/portfolio` render the expected clearwater code chips (verified via DOM)
- [x] `/standards/strategic-plan/priorities/E.2` shows "8 IIDS projects have declared alignment" with the right list
- [ ] Reviewer: spot-check 2-3 priority detail pages — `/standards/strategic-plan/priorities/B.3` (1 project: SEM Experiential), `D.2` (5 projects), `E.4` (6 projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)