### PR TITLE
Add UniVerso to the portfolio (UI Library home unit)

### DIFF
--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -407,6 +407,49 @@ export const projects: Project[] = [
   },
 
   // ============================================================
+  // UI Library
+  // ============================================================
+  {
+    slug: "universo",
+    name: "UniVerso",
+    tagline:
+      "AI-powered research discovery for the University of Idaho.",
+    description:
+      "Conversational research discovery platform: users search and discover UI research through natural-language queries, powered by vector search (ChromaDB) and LLM-generated overviews. Surfaces researchers, projects, and outputs across the university to internal and external audiences. Uniquely uses a MongoDB + ChromaDB stack rather than the Postgres + UDM line shared by the AI4RA-aligned projects.",
+    homeUnits: ["UI Library"],
+    operationalOwners: [
+      { name: "Devin Becker", title: "Associate Dean of the Library" },
+    ],
+    buildParticipants: ["IIDS"],
+    status: "piloting",
+    visibility: "Public",
+    ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    pilotCohort: { size: 10, scope: "UI Library and IIDS staff" },
+    repoUrl: "https://github.com/ui-iids/universo",
+    isPrivateRepo: true,
+    liveUrl: "https://universo.insight.uidaho.edu",
+    operationalFunction:
+      "Conversational interface for discovering UI research: search across researchers, projects, and outputs; AI-generated overviews summarise discovery results in context.",
+    operationalExcellenceOutcome:
+      "Lowers the barrier to discovering what UI researchers do — internally for cross-unit collaboration, externally for partners and prospective collaborators. Library-led complement to the ORED-led research-administration stack.",
+    tech: [
+      "FastAPI",
+      "Python 3.13",
+      "React 19",
+      "Vite",
+      "TypeScript",
+      "MongoDB",
+      "ChromaDB",
+      "LangChain",
+      "MindRouter",
+    ],
+    relatedSlugs: ["mindrouter"],
+    workCategories: ["research-admin"],
+    strategicPlanAlignment: ["D.2"],
+  },
+
+  // ============================================================
   // IIDS — Infrastructure
   // ============================================================
   {


### PR DESCRIPTION
## Summary

Adds **UniVerso** to the portfolio inventory. AI-powered research discovery platform built by IIDS for the UI Library — conversational search over UI research using vector search (ChromaDB) and LLM-generated overviews.

| Field | Value |
|---|---|
| Slug | `universo` |
| Home unit | UI Library |
| Operational owner | Devin Becker, Associate Dean of the Library |
| Build participants | IIDS (lead dev: Jarred Kvamme, RCDS) |
| Status | `piloting` |
| Pilot cohort | size 10, "UI Library and IIDS staff" |
| Visibility | Public |
| Live URL | https://universo.insight.uidaho.edu |
| Repo | [`ui-iids/universo`](https://github.com/ui-iids/universo) (private) |
| AI4RA relationship | None |
| Work category | `research-admin` |
| Strategic-plan alignment | `D.2` (research infrastructure) |

## Notable architectural divergence

This is the **first project in the portfolio sourced from the `ui-iids` GitHub org** rather than `ui-insight`, and the **first to use a MongoDB + ChromaDB stack** rather than the Postgres + UDM line shared by the AI4RA-aligned projects. The divergence is called out explicitly in the project description so reviewers don't read the inconsistency as drift.

## Effect on /portfolio

Stat strip jumps from **14 projects across 10 home units** to **15 across 11**.

## Test plan

- [x] `npm run build` passes
- [x] `npm run verify:portfolio` passes (15 projects, 0 errors, 0 warnings — including the `pilotCohort` requirement for `piloting` status)
- [x] UniVerso card renders under a new "UI Library" group with `Live / Piloting` chips, `D.2` code chip, owner Devin Becker, and a working live link (verified via DOM)
- [ ] Reviewer: confirm `iidsSponsor` should remain Barrie Robison (default) — could plausibly be Luke Sheneman if he's the actual sponsor. Easy follow-up if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)