### PR TITLE
Refresh docs to match post-Sprint-5 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,10 @@ rule conflicts with something else in this document, the rule wins.
     purpose — see `REFACTOR.md`. Recover from git history only if a
     salvage need is explicitly raised.
 13. **NEVER edit auto-generated files.** `lib/governance/catalog.ts`,
-    `lib/governance/vocabularies.ts`, and `lib/portfolio-meta.ts` are
-    overwritten by their build scripts. Edit the source (the
-    `vendor/data-governance/` JSONs or the `refresh-commit-dates`
+    `lib/governance/vocabularies.ts`, `lib/strategic-plan/catalog.ts`,
+    and `lib/portfolio-meta.ts` are overwritten by their build
+    scripts. Edit the source (the `vendor/data-governance/` JSONs, the
+    `vendor/strategic-plan/` JSON, or the `refresh-commit-dates`
     script) and regenerate.
 
 ### Deployment
@@ -102,6 +103,24 @@ sprint sequencing.
   (PR #93). The About page predated the sprint and is live at `/about`.
   Remaining `app/docs/*` drift is tracked as
   [#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98).
+- **Sprint 5** — *complete (May 2026)*. Data governance integration:
+  `vendor/data-governance/` submodule, `lib/governance/*` typed
+  modules, `/standards/data-model` explorer, drift CI, `iids-portfolio`
+  domain registered (PR #172).
+- **Post-Sprint-5 / May 2026** — Lifecycle taxonomy shipped end-to-end
+  per [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md): schema
+  + Migration 007 (PR #169), verifier + commit-date derivation
+  (PR #170), public-stage chips + two-tier filter (PR #171).
+  Strategic Plan Alignment Explorer shipped per
+  [ADR 0002](./docs/adr/0002-strategic-plan-alignment-explorer.md):
+  vendor catalog + pillars routes (PR #175), priority detail (#179),
+  alignment field on portfolio entries (#180), drift CI (#181),
+  reverse-direction (#182), stakeholder framing (#183), Migration 008.
+  Intervention → Project rename across code, types, and docs
+  (PRs #194-196). /portfolio polish: stat-strip lede, filter demotion,
+  rename "The Work" → "Projects" (PRs #207-218). UniVerso added as
+  the first ui-iids portfolio entry (#221). Strategic-plan alignment
+  declared for all 15 portfolio projects (#220).
 
 ## Information architecture
 
@@ -163,32 +182,45 @@ Headings weight 900; body 400; emphasis 600–700. No display serif pairing.
 
 ```
 app/                       # Next.js App Router
-  page.tsx                 # Landing — four-card steering page
+  page.tsx                 # Landing — steering page
   layout.tsx               # Root layout, sidebar, metadata
+  about/                   # About — strategic frame, AI4RA partnership, IIDS operator note
   portfolio/               # Projects
   explore/                 # Explore — "by problem" axis, category-tile entry
   builder-guide/           # Submit a Project (assessment quiz)
+  intake/[token]/          # Submitter-visible status page (Sprint 3a)
   reports/                 # Reports surface
-  standards/               # Standards (sub-nav: ledger + data-model explorer)
-  standards/data-model/    # Data Governance Explorer (UDM catalog + extensions)
+  presentations/           # Legacy redirect → /reports (kept to preserve inbound links)
+  standards/               # Standards (sub-nav: ledger + data-model + strategic-plan)
+    data-model/            # Data Governance Explorer (UDM catalog + extensions)
+    strategic-plan/        # Strategic Plan Alignment Explorer (pillars + priorities)
   ai4ra-ecosystem/         # AI4RA partnership deep-dive (linked from /about)
+  internal/                # Auth-gated views (Basic auth) — same data, sharper detail
   admin/                   # Registry + submissions admin
   api/                     # Next.js API routes
   docs/                    # Technical + user documentation
 
 components/                # Reusable components
   Sidebar.tsx              # Sidebar navigation
+  StandardsSubNav.tsx      # Sub-nav under /standards
   PortfolioCard.tsx        # Project card
+  PortfolioFilters.tsx     # Two-tier public-stage / operational-status filter
+  ProjectDetail.tsx        # Project detail page composition
   IssueCard.tsx            # GitHub issue card
   DocPage.tsx              # Docs layout primitives
+  (plus governance + data-model explorer components)
 
 lib/                       # Domain logic
   portfolio.ts             # Project inventory (typed; seed source for the applications table)
+  portfolio-verification.ts # ADR 0001 verifier — `npm run verify:portfolio`
+  portfolio-meta.ts        # AUTO-GENERATED — derived lastCommitDate per repo (do not edit)
+  lifecycle-display.ts     # Display helpers for public-stage / operational status chips
   work.ts                  # Postgres-backed query module for /portfolio (reads applications + blockers)
-  work-categories.ts       # "By problem" taxonomy — typed slugs + audience-facing labels (drives /explore + the /portfolio category facet)
+  work-categories.ts       # "By problem" taxonomy — typed slugs + audience-facing labels
   standards-watch.ts       # Standards ledger
   artifacts.ts             # Unified Reports timeline — briefs, activity reports, external talks
   builder-guide-data.ts    # Assessment quiz + scoring + tiers
+  intake-config.ts         # Named human + SLA + status labels for Submit-a-Project
   similarity.ts            # Submission ↔ registry overlap engine
   github.ts                # GitHub Issues API
   mindrouter.ts            # MindRouter LLM client
@@ -196,16 +228,34 @@ lib/                       # Domain logic
   governance/              # Data Governance Explorer typed modules
     types.ts               # Shared interfaces (Project, Table, Column, Vocabulary*)
     canonical-udm-tables.ts # Hand-curated canonical-vs-extension tagging (v1)
+    cross-project-fk.ts    # Cross-project foreign-key declarations
+    glossary.ts            # Term glossary surfaced in chip tooltips
+    project-framing.ts     # Per-project framing copy
+    vocabulary-usage.ts    # Reverse index — which projects use which vocab
     catalog.ts             # AUTO-GENERATED — projects + tables (do not edit)
     vocabularies.ts        # AUTO-GENERATED — controlled vocabularies (do not edit)
+  strategic-plan/          # Strategic Plan Alignment Explorer typed modules
+    types.ts               # Pillar / Priority interfaces
+    pillar-framing.ts      # Stakeholder-facing framing per pillar
+    project-alignment.ts   # Reverse lookup — projects advancing each priority
+    catalog.ts             # AUTO-GENERATED — pillars + priorities (do not edit)
 
-db/migrations/             # SQL migrations (001 → 006)
+db/migrations/             # SQL migrations (001 → 008; 007 = lifecycle, 008 = strategic-plan-alignment)
 
 scripts/                   # Node scripts run via tsx
-  build-governance-catalog.ts # Reads vendor/data-governance/ → emits lib/governance/{catalog,vocabularies}.ts
+  build-governance-catalog.ts     # vendor/data-governance/ → lib/governance/{catalog,vocabularies}.ts
+  build-strategic-plan-catalog.ts # vendor/strategic-plan/ → lib/strategic-plan/catalog.ts
+  governance-freshness.ts         # Submodule freshness PR comment
+  governance-pr-summary.ts        # Catalog-diff PR comment
+  strategic-plan-freshness.ts     # Strategic-plan submodule freshness PR comment
+  migrate.ts                      # Postgres migration runner
+  seed-portfolio.ts               # lib/portfolio.ts → applications table
+  verify-portfolio.ts             # ADR 0001 status-rule enforcer
+  refresh-commit-dates.ts         # GitHub API → lib/portfolio-meta.ts (weekly Action)
 
-vendor/                    # Vendored dependencies
-  data-governance/         # Git submodule → ui-insight/data-governance
+vendor/                    # Vendored dependencies (git submodules)
+  data-governance/         # ui-insight/data-governance — UDM + controlled vocabs
+  strategic-plan/          # UI Strategic Plan pillars + priorities
 ```
 
 ## Conventions
@@ -232,7 +282,8 @@ normative version of any of these lives in **Agent Rules** above).
 
 | To add… | Edit | Notes |
 |---|---|---|
-| A project | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Set `status` honestly per the verification rules in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — `npm run verify:portfolio` polices it. Tag with `workCategories` from `lib/work-categories.ts`. After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
+| A project | `lib/portfolio.ts` | Use existing entries as templates. Set `visibility` honestly. Set `status` honestly per the verification rules in [ADR 0001](docs/adr/0001-product-lifecycle-taxonomy.md) — `npm run verify:portfolio` polices it. Tag with `workCategories` from `lib/work-categories.ts`. Declare `strategicPlanAlignment` against priority codes from `lib/strategic-plan/catalog.ts` (see [ADR 0002](docs/adr/0002-strategic-plan-alignment-explorer.md)). After editing, re-run `scripts/seed-portfolio.ts` against dev to refresh the `applications` table. |
+| Strategic-plan alignment on a project | `lib/portfolio.ts` (the `strategicPlanAlignment` field on the entry) | Reference priority codes (e.g. `"A.1"`, `"D.3"`) defined in `lib/strategic-plan/catalog.ts`. The drift CI workflow validates references against the upstream `vendor/strategic-plan/` snapshot. Per [ADR 0002](docs/adr/0002-strategic-plan-alignment-explorer.md). |
 | A work category | `lib/work-categories.ts` (constant + label record) + tag relevant projects | Audience-facing labels (a Dean's vocabulary). Header comment in the file documents add/rename/retire/promote mechanics. tsc enforces consistency across consumers. |
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
 | A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |
@@ -246,11 +297,23 @@ and update `lib/db.ts` only if the connection pool needs new behavior.
 ## Development commands
 
 ```bash
-npm run dev                # Dev server on :3000 (auto-runs build:governance first)
-npm run build              # Production build (auto-runs build:governance first)
-npm run build:governance   # Regenerate lib/governance/{catalog,vocabularies}.ts
-                           # from vendor/data-governance/ submodule
-npm run lint               # ESLint
+npm run dev                    # Dev server on :3000 (predev runs build:governance + build:strategic-plan)
+npm run build                  # Production build (prebuild runs build:governance + build:strategic-plan)
+npm run build:governance       # Regenerate lib/governance/{catalog,vocabularies}.ts
+                               # from vendor/data-governance/ submodule
+npm run build:strategic-plan   # Regenerate lib/strategic-plan/catalog.ts
+                               # from vendor/strategic-plan/ submodule
+npm run lint                   # ESLint
+
+# Portfolio data + ADR 0001 enforcement
+npm run migrate                # Apply pending SQL migrations against $DATABASE_URL
+npm run seed:portfolio         # lib/portfolio.ts → applications table (dev DB)
+npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this)
+npm run refresh:commit-dates   # Hit GitHub API → regenerate lib/portfolio-meta.ts
+
+# Submodule freshness (used by PR-summary workflows)
+npm run governance:freshness        # Renders submodule-staleness comment
+npm run strategic-plan:freshness    # Same, for the strategic-plan submodule
 ```
 
 `npm run build` is the primary verification step. Run it before committing.
@@ -292,7 +355,9 @@ npm run governance:freshness        # needs PINNED_SHA + PINNED_COMMIT_DATE_ISO
 canonical AI4RA Unified Data Model catalog and controlled-vocabulary
 registry. The `prebuild` and `predev` hooks regenerate
 `lib/governance/catalog.ts` and `lib/governance/vocabularies.ts` from
-this submodule, so the typed catalog modules stay in sync.
+this submodule (and `lib/strategic-plan/catalog.ts` from the
+`vendor/strategic-plan/` submodule), so the typed catalog modules stay
+in sync.
 
 When the upstream catalog changes, refresh the submodule:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,25 +39,26 @@ The site runs at <http://localhost:3000>.
 
 > **Tip for agentic tools**: at the start of a session, point your agent at
 > [`CLAUDE.md`](./CLAUDE.md) and [`REFACTOR.md`](./REFACTOR.md). Together
-> they cover project structure, conventions, the four-surface IA, the
+> they cover project structure, conventions, the five-surface IA, the
 > friction-ledger model, and the sprint sequencing.
 
 ---
 
 ## How the site works
 
-### Four primary surfaces
+### Five primary surfaces
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| Projects | `/portfolio` | `lib/portfolio.ts` |
-| Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz) + Postgres `submissions` (responses) |
+| Projects | `/portfolio` | Postgres `applications` (read via `lib/work.ts`); `lib/portfolio.ts` is the typed seed source. Two-tier filter (public stage → operational status) per [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md). |
+| Explore | `/explore` | `lib/work-categories.ts` (taxonomy) + `lib/portfolio.ts` (counts) — by-problem axis. |
+| Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz) + Postgres `submissions` (responses); status page at `/intake/[token]`. |
 | Reports | `/reports` | `lib/artifacts.ts` (unified timeline) + per-report routes |
-| Standards | `/standards` | `lib/standards-watch.ts` |
+| Standards | `/standards` | `lib/standards-watch.ts`; sub-nav surfaces `/standards/data-model` and `/standards/strategic-plan`. |
 
-Plus `/ai4ra-ecosystem`, `/docs/*`, `/admin/*`. See
-[`CLAUDE.md`](./CLAUDE.md) for the full route inventory and what's been
-archived.
+Plus `/ai4ra-ecosystem`, `/about`, `/internal` (auth-gated),
+`/docs/*`, `/admin/*`. See [`CLAUDE.md`](./CLAUDE.md) for the full
+route inventory and what's been archived.
 
 ### Typed data modules over JSON blobs
 
@@ -123,11 +124,16 @@ array. The shape is defined in the same file. Required fields include
     { name: "Pat Owner", title: "Director of Something" },
   ],
   buildParticipants: ["IIDS"],
-  status: "Piloting",        // see "Status transitions" below
+  status: "piloting",        // ADR 0001 operational state — see below
   visibility: "Public",      // see "Visibility tier" below
   ai4raRelationship: "None", // see "AI4RA relationship" below
   tags: ["diffusion"],       // optional; see "Tag vocabulary" below
-  // ...optional fields: funding, externalDeployments, links, etc.
+  workCategories: ["..."],   // typed category slugs from lib/work-categories.ts
+  iidsSponsor: "Name",       // ADR 0001 — required to claim approved+
+  // ...plus the ADR 0001 status-specific fields (pilotCohort,
+  //    productionScope, supportContact, sunsetDate, replacedBy, etc.)
+  //    and optional: funding, externalDeployments, links,
+  //    strategicPlanAlignment (priority codes per ADR 0002).
 },
 ```
 
@@ -161,21 +167,33 @@ existence of the work is itself sensitive.
 
 #### Status transitions
 
-| Status | Meaning | When to set it |
-|---|---|---|
-| `Planned` | Committed-to but not started | Ownership and home unit assigned, scope discussed, no code yet |
-| `Prototype` | Built but not in operational use | Functional artifact exists; not yet validated by a real user in real work |
-| `Piloting` | In limited operational use | A bounded group of real users is using it for real work; learning phase |
-| `Production` | Routine institutional use | The operational owner depends on it for day-to-day work and would push back if it went away |
-| `Tracked` | Not built by IIDS | In the inventory because IIDS coordinates around it; partner-unit-led |
-| `Archived` | Decommissioned | Excluded from active counts; retained for historical record |
+The status taxonomy is defined and enforced by
+[ADR 0001 — Product Lifecycle Taxonomy](./docs/adr/0001-product-lifecycle-taxonomy.md).
+The lifecycle has two layers:
 
-**The bar for `Piloting` → `Production`**: the operational owner would
-escalate if the tool stopped working tomorrow.
+- **Operational ladder** (9 states + `tracked` meta): `idea`,
+  `approved`, `building`, `prototype`, `piloting`, `production`,
+  `maintained`, `sunsetting`, `archived`, plus `tracked` for
+  partner-unit-led work IIDS coordinates around.
+- **Public stage rollup** (5 buckets) — `exploring`, `building`,
+  `live`, `retired`, `tracked` — derived automatically from the
+  operational state. Stakeholders see the public stage; IIDS sees the
+  operational state as a secondary chip.
 
-**The bar for `Tracked`**: IIDS is aware of the work, the home unit
+Each operational state has a **measurable verification rule** (e.g.
+`production` requires either a public `liveUrl` reachable beyond the
+pilot or a public `repoUrl` where the repo itself is the deliverable,
+plus `productionScope` and `supportContact`). `npm run verify:portfolio`
+enforces the rules in CI; run it locally before pushing.
+
+For the full rule table, the schema fields each state requires, and
+the rationale, read [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md)
+in full before changing a project's `status`.
+
+**The bar for `tracked`**: IIDS is aware of the work, the home unit
 owns it, IIDS may have advised but did not build. Always pair with
-`buildParticipants` that does *not* list IIDS.
+`buildParticipants` that does *not* list IIDS, and set
+`trackingOnly: true`.
 
 #### `homeUnits` vs `buildParticipants`
 
@@ -214,12 +232,13 @@ known active values:
   case: a non-IIDS UI unit is co-building, not just consuming. Renders
   the *"Capability diffusion"* chip on `/portfolio`.
 
-That's it for the active tag vocabulary today. Once the *"By problem"*
-exploration axis ships (epic [#154](https://github.com/ui-insight/AISPEG/issues/154)),
-category tagging migrates to a typed `workCategories` field;
-`tags` retains its current ad-hoc usage for situational flags only.
-**Don't invent new ad-hoc tags** — flag a need in [#154](https://github.com/ui-insight/AISPEG/issues/154)
-or open a new issue.
+Category tagging now lives in a typed `workCategories` field on each
+project (sourced from `lib/work-categories.ts`); the by-problem
+explore axis ([epic #154](https://github.com/ui-insight/AISPEG/issues/154))
+shipped via PRs #158-163. `tags` retains its ad-hoc usage for
+situational flags only. **Don't invent new ad-hoc tags** — promote
+the concept into `workCategories` (with a header-comment-driven
+add/rename/retire flow) or open a new issue.
 
 #### Freshness expectations
 
@@ -271,9 +290,8 @@ artifact:
 
 ### Adding a new top-level route
 
-The IA is intentionally narrow (4 primary surfaces today, 5 once the
-*"By problem"* explore axis ships per [#154](https://github.com/ui-insight/AISPEG/issues/154)).
-Adding a new top-level route should be a deliberate choice — discuss in
+The IA is intentionally narrow (5 primary surfaces). Adding a new
+top-level route should be a deliberate choice — discuss in
 `REFACTOR.md` or open an issue first.
 
 If approved:
@@ -342,9 +360,9 @@ Give your agent the strategic context first. A good opening:
 > Read `REFACTOR.md` and `CLAUDE.md` to understand the project. This is a
 > Next.js 16 site that's the coordination nexus for the University of
 > Idaho's institutional AI initiative, operated by IIDS. We're mid-refactor
-> from a legacy AISPEG-collaboration framing. The IA is four surfaces:
-> Projects, Submit a Project, Reports, Standards. Run `npm run build` to
-> verify changes.
+> from a legacy AISPEG-collaboration framing. The IA is five surfaces:
+> Projects, Explore, Submit a Project, Reports, Standards. Run
+> `npm run build` to verify changes.
 
 ### Effective prompt patterns
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The site shows what's being built, what's stalled, and where to engage.
 | **Projects** | `/portfolio` | Portfolio of AI projects across UI units. Each entry names a home unit and operational owner. |
 | **Submit a Project** | `/builder-guide` | A 9-step assessment that scopes an AI idea, classifies it into one of four tiers, and connects the submitter to a named owner at IIDS. |
 | **Reports** | `/reports` | Activity reports, briefs, and time-stamped public artifacts. |
-| **Standards** | `/standards` | Public ledger of the institutional software-development and user-experience standards IIDS has formally requested from OIT. The `/standards/data-model` sub-section is an interactive explorer for the AI4RA Unified Data Model and the per-project extensions across the IIDS portfolio. |
+| **Explore** | `/explore` | "By problem" entry point — category tiles built from `lib/work-categories.ts`, complementary to `/portfolio`'s by-home-unit grouping. |
+| **Standards** | `/standards` | Public ledger of the institutional software-development and user-experience standards IIDS has formally requested from OIT. Sub-sections: `/standards/data-model` (Data Governance Explorer for the AI4RA Unified Data Model) and `/standards/strategic-plan` (Strategic Plan Alignment Explorer — pillars, priorities, and the projects advancing each one). |
 
 Plus `/docs` (technical and user documentation) and `/admin/*` (registry +
 submissions admin during the ClickUp transition). Several legacy routes
@@ -93,7 +94,7 @@ lib/                         # Domain logic and data
   mindrouter.ts              # MindRouter LLM client
   db.ts                      # Postgres connection pool
 
-db/migrations/               # SQL migrations (001 → 004)
+db/migrations/               # SQL migrations (001 → 008)
 ```
 
 ## Refactor in progress
@@ -118,6 +119,16 @@ the full plan, sprint sequencing, and decisions:
   (PR #93). The About page predated the sprint and is live at `/about`.
   Remaining `app/docs/*` drift is tracked as
   [#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98).
+- **Sprint 5** — *complete (May 2026)*. Data governance integration:
+  `vendor/data-governance/` submodule + drift CI + `iids-portfolio`
+  domain registration (PR #172).
+- **Post-Sprint-5 / May 2026** — Lifecycle taxonomy shipped end-to-end
+  ([ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md)) with
+  Migration 007, the `verify:portfolio` CI gate, and two-tier filter
+  UI. Strategic Plan Alignment Explorer shipped
+  ([ADR 0002](./docs/adr/0002-strategic-plan-alignment-explorer.md))
+  with Migration 008, bidirectional alignment, and drift CI. See
+  [`REFACTOR.md`](./REFACTOR.md) for the full timeline.
 
 ## Working on the codebase
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -327,7 +327,7 @@ similarity-aware review. Status updates flow from manual edits to
 **Output:** old AISPEG-collaborator-era content is fully retired or salvaged.
 Codebase reflects the new architecture without legacy cruft.
 
-### Sprint 5 — Data governance integration
+### Sprint 5 — Data governance integration *(complete, May 2026)*
 
 - Vendored `ui-insight/data-governance` as a git submodule at
   `vendor/data-governance/` and added a `prebuild`/`predev` step
@@ -341,6 +341,95 @@ Codebase reflects the new architecture without legacy cruft.
   `app/standards/data-model/**`, or `scripts/build-governance-catalog.*`.
   Drift output streams into the Actions Step Summary panel; the job fails
   on non-zero exit so registry drift cannot land silently.
+- Registered the AISPEG site as the `iids-portfolio` domain inside
+  `vendor/data-governance/` (PR #172) so the portfolio's typed enums
+  (`ProjectStatus`, `PublicStage`, `Visibility`, `AI4RARelationship`,
+  `WorkCategory`) are catalog-tracked alongside the research-admin
+  vocabularies.
+
+### Post-Sprint-5 — May 2026
+
+The work below was not pre-planned in the May 2026 refactor — it
+emerged once Sprint 5 made the catalog-tracked taxonomy idiom
+practical. Captured here so the timeline stays honest.
+
+#### Lifecycle taxonomy ([ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md))
+
+The legacy 6-state status union (`Planned | Prototype | Piloting |
+Production | Tracked | Archived`) failed three real-world ways: it
+collapsed "idea" with "approved-to-build", conflated active
+development with idle demo state, and hid maintenance-mode vs.
+sunsetting under a single `Production`. ADR 0001 replaced it with a
+**two-layer taxonomy** — a 9-state operational ladder plus a 5-bucket
+public-stage rollup — and locked **measurable verification rules** in
+`lib/portfolio-verification.ts` (run via `npm run verify:portfolio`,
+enforced in CI).
+
+Shipped across:
+
+- ADR 0001 (PR #164) — locked the design.
+- Schema + Migration 007 (PR #169) — extended the `Project` interface
+  and re-classified the existing portfolio rows.
+- Verifier + commit-date derivation (PR #170) — `verify:portfolio`,
+  `refresh:commit-dates`, weekly GitHub Action.
+- UI (PR #171) — public-stage chips on cards, two-tier filter on
+  `/portfolio`, public stage on the landing stat strip and `/explore`.
+- Polish (PRs #185, #218) — adopted the lifecycle palette on project
+  detail pages and suppressed the operational chip when its label
+  duplicates the public stage.
+
+#### Strategic Plan Alignment Explorer ([ADR 0002](./docs/adr/0002-strategic-plan-alignment-explorer.md))
+
+Each portfolio project now declares which UI Strategic Plan
+priorities it advances. The explorer at `/standards/strategic-plan`
+renders pillars and priorities; each priority page reverses the
+direction and lists the projects advancing it. Vendored as a git
+submodule (`vendor/strategic-plan/`), built into a typed catalog
+(`lib/strategic-plan/catalog.ts`) by `scripts/build-strategic-plan-catalog.ts`.
+
+Shipped across:
+
+- Tracer slice — vendor catalog + pillars routes (PR #175).
+- Priority detail page (PR #179).
+- Alignment field on portfolio entries + chips on cards (PR #180).
+- Drift CI + submodule-freshness advisory (PR #181).
+- Reverse direction — projects advancing each priority (PR #182).
+- Stakeholder framing per pillar (PR #183).
+- Migration 008 mirrored alignment into Postgres.
+- Backfill (PR #220) — declared alignment for all 14 portfolio
+  projects then in the inventory.
+
+#### Intervention → Project rename (PRs #194-196)
+
+User research surfaced that "Intervention" was IIDS-internal
+vocabulary that read poorly to stakeholders. Renamed across types,
+identifiers, file names, and documentation to "Project". The
+data-governance submodule bumped in lockstep (`InterventionStatus` →
+`ProjectStatus`). One-shot rename, no compat shims.
+
+#### /portfolio IA polish (PRs #207-218)
+
+Pass to make `/portfolio` more scannable for stakeholders:
+
+- "The Work" → "Projects" rename across user-facing surfaces (#207).
+- Quantitative stat-strip lede replacing the prose header (#208).
+- Filter demotion — Home Unit and Category collapsed by default,
+  Sort moved to a `<select>` (#209).
+- Tiered chip vocabulary on cards with inline glossary in tooltips
+  (#210).
+- Color tokens + AI4RA pointer differentiation (#211).
+- Visibility correction — only OpenERA is embargoed; everything else
+  was over-tagged (#219).
+
+#### Inventory growth
+
+- UniVerso added (PR #221) as the first `ui-iids` (RCDS) entry in the
+  portfolio. Brings the inventory to 15 projects.
+
+The site no longer reads as mid-refactor on the user-facing surfaces.
+The remaining open work is `app/docs/*` drift cleanup
+([#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98))
+and the Sprint 3b ClickUp wiring (deferred to Colin).
 
 ## v1 cut
 

--- a/docs/adr/0002-strategic-plan-alignment-explorer.md
+++ b/docs/adr/0002-strategic-plan-alignment-explorer.md
@@ -1,0 +1,103 @@
+# ADR 0002 — Strategic Plan Alignment Explorer
+
+**Status:** Accepted
+**Date:** 2026-05-03
+**Deciders:** Barrie Robison (with @ProfessorPolymorphic)
+**Related:** [#100](https://github.com/ui-insight/AISPEG/issues/100) (epic), [ADR 0001](./0001-product-lifecycle-taxonomy.md) (lifecycle taxonomy — same catalog-tracked-vocabulary idiom), PRs #175, #179, #180, #181, #182, #183, #220
+
+## Context
+
+The IIDS portfolio site exists to make institutional AI work legible to UI stakeholders — Provost, Deans, partner units. Those stakeholders ask a recurring question that the site could not answer: **"How does this work advance the University Strategic Plan?"**
+
+The Strategic Plan has a stable structure (5 pillars, ~25 priorities, each priority a one-sentence commitment) and a stable canonical reference URL. It is the document Deans and the Provost cite when justifying resourcing decisions. Anything the institution claims to be doing should ladder up to it.
+
+Three constraints shape the response:
+
+1. **The Strategic Plan is upstream of this repo.** It changes on its own cadence, owned by Strategic Enrollment Management, not IIDS. The site cannot be the source of truth for pillar/priority text.
+2. **The portfolio is the source of truth for what IIDS is doing.** Each project's alignment claim is editorial — IIDS asserts it, and the assertion should be reviewable and version-controlled.
+3. **Stakeholders need bidirectional lookup.** A Dean reading a project asks "what plan priority does this advance?" A Provost reading the plan asks "what's actually happening on D.2?" Both directions should be one click.
+
+## Decision
+
+Build a **Strategic Plan Alignment Explorer** at `/standards/strategic-plan` that surfaces bidirectional alignment between portfolio projects and Strategic Plan priorities, using the same vendored-submodule + typed-catalog idiom Sprint 5 established for data governance.
+
+### Data architecture
+
+| Layer | Source | Why |
+|---|---|---|
+| Pillar / priority text | `vendor/strategic-plan/` git submodule | Upstream-owned. Pinned by SHA so the site's render is deterministic. |
+| Typed catalog | `lib/strategic-plan/catalog.ts` (auto-generated) | `scripts/build-strategic-plan-catalog.ts` regenerates on `prebuild`/`predev`. Hand edits are forbidden (rule 13 in CLAUDE.md). |
+| Alignment claim | `strategicPlanAlignment?: string[]` on each `Project` in `lib/portfolio.ts` | Editorial; references priority codes (e.g. `"D.2"`, `"E.4"`). One commit = one claim, full audit trail. |
+| Postgres mirror | Migration 008 — `strategic_plan_alignment text[]` on `applications` | Lets `lib/work.ts` (the runtime read path) join the alignment without re-reading `lib/portfolio.ts`. Seeded by `npm run seed:portfolio`. |
+
+### Surfaces
+
+- **`/standards/strategic-plan`** — pillars overview (catalog-driven).
+- **`/standards/strategic-plan/pillars/[code]`** — one pillar's priorities.
+- **`/standards/strategic-plan/priorities/[code]`** — one priority + the projects advancing it (reverse lookup via `lib/strategic-plan/project-alignment.ts`).
+- **Project cards on `/portfolio`** — render alignment chips so the forward direction is one click from the portfolio entry.
+
+### Drift CI
+
+Two GitHub Actions workflows mirror the governance pattern:
+
+- **`strategic-plan-drift.yml`** (blocking) — on PRs touching `vendor/strategic-plan/**`, `lib/strategic-plan/**`, `app/standards/strategic-plan/**`, or the build script. Validates that every `strategicPlanAlignment` priority code in `lib/portfolio.ts` resolves against the vendored catalog; fails the build if a project references a priority that no longer exists upstream.
+- **`strategic-plan-pr-summary.yml`** (advisory) — submodule-freshness comment via `npm run strategic-plan:freshness`, same pattern as the governance freshness comment.
+
+## Sub-decisions resolved
+
+### 1. Lives under `/standards`, not as its own top-level surface
+
+The IA is intentionally narrow (5 sidebar entries). A new top-level entry for Strategic Plan would imply parity with Projects, Explore, Submit, Reports, Standards — which it doesn't have; the explorer is a lens on the portfolio, not a parallel surface. Living under `/standards` (alongside the Data Governance Explorer) frames it correctly: *standards we hold ourselves to*, including the institutional plan.
+
+### 2. Alignment is a `string[]` of priority codes, not a structured object
+
+Each entry could carry a confidence level, an author, a justification paragraph. We chose the leanest possible shape — an array of priority codes — because:
+
+- The git log already records who added the claim, when, and what changed (audit trail for free).
+- A justification paragraph belongs on the project's own narrative, not duplicated per-claim.
+- Anything richer is data IIDS would have to maintain; the cost of authorship discipline outpaces the value to stakeholders.
+
+If a future need arises (e.g. ranking projects within a priority), promote the type then. YAGNI today.
+
+### 3. Reverse lookup reads from `lib/portfolio.ts` directly, not Postgres
+
+`lib/strategic-plan/project-alignment.ts` filters `projects` from `lib/portfolio.ts` rather than querying the `applications` table. Two reasons:
+
+- The strategic-plan pages are statically renderable — no DB coupling on the read path keeps the build cacheable and the production cold-start fast.
+- It applies the same public-vs-internal visibility filter the portfolio does (`Internal-only` excluded; `Partial` included), without re-implementing it in SQL.
+
+When ClickUp wiring lands and `lib/portfolio.ts` retires as the runtime read path, swap this module to read via `lib/work.ts`. The interface (`AlignedProject`) is stable; the data source moves.
+
+## Consequences
+
+**Positive:**
+
+- Stakeholders get a one-click answer to "what plan priority does this advance?" in both directions.
+- The Strategic Plan stays upstream and version-controlled; the site never claims to own it.
+- Drift CI prevents a renamed/removed upstream priority from silently breaking project claims.
+- Reuses the Sprint 5 idiom (vendored submodule → typed catalog → drift workflow) — no new infrastructure, just one more instance.
+
+**Negative:**
+
+- A second submodule to keep current. The `strategic-plan:freshness` advisory mitigates by surfacing staleness on every PR, but it's still a periodic chore.
+- Editorial claims in `lib/portfolio.ts` add a field for authors to fill out; backfill (PR #220) handled the existing 14 entries but new projects must declare alignment to be useful in the explorer.
+
+**Neutral:**
+
+- Lives under `/standards`, which means it shares sub-nav real estate with Data Model. Adding a third sub-section in the future is fine; adding a tenth would be a problem — but the IA can absorb it for now.
+
+## Implementation sequencing
+
+Six PRs, in order. Each shipped independently.
+
+1. **Tracer slice** ([#175](https://github.com/ui-insight/AISPEG/pull/175)) — vendor submodule, build script, pillars overview route. Proved the idiom worked end-to-end before building out detail.
+2. **Priority detail page** ([#179](https://github.com/ui-insight/AISPEG/pull/179)) — `/standards/strategic-plan/priorities/[code]`.
+3. **Alignment field + chips on cards** ([#180](https://github.com/ui-insight/AISPEG/pull/180)) — added `strategicPlanAlignment` to `Project`, rendered chips on `/portfolio` cards.
+4. **Drift CI + freshness advisory** ([#181](https://github.com/ui-insight/AISPEG/pull/181)) — blocking drift workflow + advisory freshness comment.
+5. **Reverse direction** ([#182](https://github.com/ui-insight/AISPEG/pull/182)) — `getProjectsForPriority` and the projects-advancing-this-priority list on the priority detail page.
+6. **Stakeholder framing per pillar** ([#183](https://github.com/ui-insight/AISPEG/pull/183)) — `lib/strategic-plan/pillar-framing.ts` with audience-facing copy on each pillar.
+
+Followed by the data audit:
+
+7. **Backfill** ([#220](https://github.com/ui-insight/AISPEG/pull/220)) — declared alignment for all 14 portfolio projects then in inventory. Migration 008 mirrors the field into `applications`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,3 +79,4 @@ ADRs are **append-only**. To change a decision:
 | # | Title | Status | Date |
 |---|---|---|---|
 | [0001](./0001-product-lifecycle-taxonomy.md) | Product Lifecycle Taxonomy | Accepted | 2026-05-03 |
+| [0002](./0002-strategic-plan-alignment-explorer.md) | Strategic Plan Alignment Explorer | Accepted | 2026-05-03 |


### PR DESCRIPTION
## Summary

Audit found significant drift across `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, and `REFACTOR.md` after the lifecycle taxonomy, Strategic Plan Alignment Explorer, and Intervention → Project rename shipped. This sweep aligns the docs with what actually exists in the codebase and adds **ADR 0002** for the Strategic Plan Explorer to match the ADR 0001 precedent.

### What changed

- **`CLAUDE.md`** — refreshed project-structure tree (was missing `lib/strategic-plan/`, `lib/lifecycle-display.ts`, several governance modules, `/about`, `/intake`, `/internal`, and 8 of 9 scripts); bumped migrations `006 → 008`; added strategic-plan alignment row to the *Adding content* table; rule 13 now covers `lib/strategic-plan/catalog.ts`; dev-commands block now lists `migrate`, `seed:portfolio`, `verify:portfolio`, `refresh:commit-dates`, and the freshness scripts; added Sprint 5 and Post-Sprint-5 entries to refactor status.
- **`README.md`** — added Explore row + Standards sub-sections; bumped migration range; appended Sprint 5 and Post-Sprint-5.
- **`CONTRIBUTING.md`** — *"four primary surfaces"* → *"five primary surfaces"* with Explore; **replaced the legacy 6-state status table that directly contradicted ADR 0001** with a pointer to ADR 0001 + the two-layer summary; closed out the work-categories #154 epic note.
- **`REFACTOR.md`** — marked Sprint 5 complete and added a Post-Sprint-5 section covering the lifecycle taxonomy ship, Strategic Plan Alignment Explorer, Intervention → Project rename, `/portfolio` polish, and the UniVerso addition.
- **`docs/adr/0002-strategic-plan-alignment-explorer.md`** — new ADR documenting the bidirectional alignment design, the vendored-submodule + typed-catalog idiom (mirrors Sprint 5), three sub-decisions (sub-nav placement, lean `string[]` shape, reverse lookup reads from `lib/portfolio.ts`), and the 6-PR sequencing from #175 through #220.
- **`docs/adr/README.md`** — index updated.

No code changes; documentation only.

## Test plan

- [x] `npm run build` — clean (no errors, no warnings)
- [ ] Reviewer skim: ADR 0002 reads as a faithful retroactive capture of the Strategic Plan Explorer design
- [ ] Reviewer skim: post-Sprint-5 section in `REFACTOR.md` matches what actually shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)