### PR TITLE
Landing /critique arc closer: drop dead utility, faux-links, add 'as of'

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,11 @@ export default async function Home() {
     .filter((i): i is NonNullable<typeof i> => i !== undefined);
   const standards = standardsSummary();
   const reportCount = artifacts.length;
+  const buildDate = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 
   return (
     <div className="space-y-10">
@@ -79,6 +84,9 @@ export default async function Home() {
             ))}
           </p>
         )}
+        <p className="mt-2 text-xs text-ink-subtle">
+          As of {buildDate} (last deploy)
+        </p>
       </section>
 
       <section>
@@ -89,7 +97,7 @@ export default async function Home() {
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
             Projects
           </p>
-          <h2 className="mt-2 text-2xl font-semibold">
+          <h2 className="mt-2 text-2xl">
             {projectCount} AI projects across UI units
           </h2>
           <p className="mt-2 text-sm text-ink-muted">
@@ -133,9 +141,6 @@ export default async function Home() {
           <p className="mt-2 text-sm leading-relaxed text-ink-muted">
             Routes to a named IIDS owner with a 2-business-day SLA.
           </p>
-          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
-            Start &rarr;
-          </p>
         </Link>
 
         <Link
@@ -162,9 +167,6 @@ export default async function Home() {
             </span>{" "}
             published.
           </p>
-          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
-            View &rarr;
-          </p>
         </Link>
 
         <Link
@@ -181,9 +183,6 @@ export default async function Home() {
             <span className="font-semibold text-brand-black">{reportCount}</span>{" "}
             published. Latest:{" "}
             <span className="font-semibold text-brand-black">{mostRecent}</span>.
-          </p>
-          <p className="mt-3 text-sm font-medium text-brand-black group-hover:underline">
-            Browse &rarr;
           </p>
         </Link>
       </section>


### PR DESCRIPTION
## Summary

Three small landing fixes that close out the May 2026 \`/critique\` arc. All verified in the browser preview.

- **#146** — drop redundant \`font-semibold\` on the Projects-card H2. The \`@layer base main h2\` rule already enforces weight 900, so the utility was a no-op that misled the next file editor. Visual unchanged.
- **#147** (a11y) — drop the inner faux-link \`Start →\` / \`View →\` / \`Browse →\` from each of the three proof-point tiles. The whole card is the click target; the trailing line was tab-orphaned and added redundant text to screen-reader announcements. Eyebrow + heading already signal navigation.
- **#148** — add \`As of {buildDate} (last deploy)\` caption under the hero stat strip. Sets honest expectations about data recency without adding a card or badge.

Closes #146, #147, #148.

## Test plan

- [x] \`npm run build\` clean
- [x] Preview snapshot confirms each tile is announced as a single link with no trailing redundancy
- [x] Preview snapshot confirms \"As of May 3, 2026 (last deploy)\" renders under the stage breakdown
- [x] Preview snapshot confirms the Projects-card H2 visual is unchanged
- [ ] Reviewer skim for typography rhythm at 1280×800 and 360×800

🤖 Generated with [Claude Code](https://claude.com/claude-code)