### PR TITLE
Project Map slice 1: graph data adapter (#202)

### DIFF
--- a/lib/project-map-graph.ts
+++ b/lib/project-map-graph.ts
@@ -1,0 +1,111 @@
+// ============================================================
+// Project Map — graph data adapter
+// ============================================================
+// Server-side adapter that converts the typed portfolio +
+// strategic-plan + work-categories modules into a graph shape ready
+// for the bundled-network renderer on /explore (Map view).
+//
+// The renderer is dumb: this module is responsible for visibility
+// filtering, stable ordering, and producing every node + link the
+// view will draw. Empty seats (a priority with zero alignments, a
+// project with zero categories) are part of the signal — they render.
+//
+// See issue #202 (and epic #201) for the contract.
+// ============================================================
+
+import {
+  computePublicStage,
+  getPubliclyVisible,
+  type PublicStage,
+} from "./portfolio";
+import { pillars, priorities } from "./strategic-plan/catalog";
+import {
+  WORK_CATEGORIES,
+  WORK_CATEGORY_LABELS,
+  type WorkCategory,
+} from "./work-categories";
+
+export interface ProjectMapPriority {
+  code: string;        // "A.1"
+  text: string;        // priority text from catalog
+  pillar: string;      // "A"
+  pillarName: string;  // pillar.name from catalog
+}
+
+export interface ProjectMapProject {
+  slug: string;
+  name: string;
+  tagline: string | null;
+  homeUnits: string[];
+  publicStage: PublicStage;
+}
+
+export interface ProjectMapCategory {
+  slug: WorkCategory;
+  label: string;
+}
+
+export interface ProjectMapLink {
+  project: string;            // project slug
+  side: "left" | "right";     // priority side or category side
+  target: string;             // priority code or category slug
+}
+
+export interface ProjectMapGraph {
+  priorities: ProjectMapPriority[];
+  projects: ProjectMapProject[];
+  categories: ProjectMapCategory[];
+  links: ProjectMapLink[];
+}
+
+// `audience` is reserved for a future "internal" variant that surfaces
+// Internal-only entries under /internal. v1 is public-only.
+export function buildProjectMapGraph(
+  _audience: "public",
+): ProjectMapGraph {
+  const pillarNameByCode = new Map(pillars.map((p) => [p.code, p.name]));
+
+  const mapPriorities: ProjectMapPriority[] = [...priorities]
+    .sort((a, b) => a.code.localeCompare(b.code))
+    .map((p) => ({
+      code: p.code,
+      text: p.text,
+      pillar: p.pillar,
+      pillarName: pillarNameByCode.get(p.pillar) ?? p.pillar,
+    }));
+
+  const sourceProjects = getPubliclyVisible();
+
+  const mapProjects: ProjectMapProject[] = [...sourceProjects]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((p) => ({
+      slug: p.slug,
+      name: p.name,
+      tagline: p.tagline || null,
+      homeUnits: p.homeUnits,
+      publicStage: computePublicStage(p.status),
+    }));
+
+  // WORK_CATEGORIES is the declared display order — use it directly.
+  const mapCategories: ProjectMapCategory[] = WORK_CATEGORIES.map((slug) => ({
+    slug,
+    label: WORK_CATEGORY_LABELS[slug].label,
+  }));
+
+  const links: ProjectMapLink[] = [];
+  for (const project of sourceProjects) {
+    for (const code of project.strategicPlanAlignment ?? []) {
+      links.push({ project: project.slug, side: "left", target: code });
+    }
+    for (const slug of project.workCategories ?? []) {
+      links.push({ project: project.slug, side: "right", target: slug });
+    }
+  }
+
+  return {
+    priorities: mapPriorities,
+    projects: mapProjects,
+    categories: mapCategories,
+    links,
+  };
+}


### PR DESCRIPTION
First slice of the Project Map epic ([#201](https://github.com/ui-insight/AISPEG/issues/201)). Closes [#202](https://github.com/ui-insight/AISPEG/issues/202).

## What

Adds `lib/project-map-graph.ts` — a pure server-side adapter that converts the typed portfolio + strategic-plan + work-categories modules into the tripartite graph shape the bundled-network renderer (slice 2) will consume.

## Shape

```ts
buildProjectMapGraph("public") -> {
  priorities: { code, text, pillar, pillarName }[]
  projects:   { slug, name, tagline, homeUnits, publicStage }[]
  categories: { slug, label }[]
  links:      { project, side: "left" | "right", target }[]
}
```

## Decisions

- **Visibility filter** delegates to the existing `getPubliclyVisible()` helper — Internal-only out, Public + Partial in. (Issue text said "Embargoed"; the actual `Visibility` enum names that value `Partial`.)
- **Stable orderings** — priorities sorted by code (`A.1` → `E.4`), projects alphabetical by name, categories in declared `WORK_CATEGORIES` order.
- **Empty seats render** — a priority or project with zero alignments stays in the graph. The gap is part of the signal.
- **No defensive filtering on link targets** — `verify-portfolio` already polices alignment codes against the strategic-plan catalog; trusting that invariant per the project's "no validation for scenarios that can't happen" rule.
- **`audience` parameter reserved** — `_audience: "public"` is the only legal value in v1; an `"internal"` variant is deferred per the epic's scope cut.

## Verification

- `npm run build` clean.
- Pure module — no React, no DOM, no client code.
- Adapter snapshot from current data:
  - 20 priorities (all 5 pillars represented)
  - 15 projects after visibility filter
  - 8 work categories
  - 44 links (25 strategic-plan + 19 work-categories)
  - 0 orphan link targets

## Test plan

- [x] `npm run build` passes
- [x] Counts match expected ranges (epic predicted ~22 / 14 / ~10–12; actual 20 / 15 / 8 — UniVerso landed since the epic was filed)
- [x] Every link's `target` resolves to a node on the corresponding side

🤖 Generated with [Claude Code](https://claude.com/claude-code)