### PR TITLE
Project Map slice 2: component scaffold + static layout (#203)

### DIFF
--- a/app/dev/project-map/page.tsx
+++ b/app/dev/project-map/page.tsx
@@ -1,0 +1,30 @@
+// Temporary preview route for the Project Map scaffold (epic #201,
+// slice 2). Removed in slice 5 (#206) once the component is mounted
+// behind the Tiles | Map toggle on /explore.
+
+import ProjectMap from "@/components/ProjectMap";
+
+export const metadata = {
+  title: "Project Map (preview)",
+  robots: { index: false, follow: false },
+};
+
+export default function ProjectMapDevPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Internal preview
+        </p>
+        <h1 className="mt-2 text-2xl font-black">Project Map (slice 2 scaffold)</h1>
+        <p className="mt-2 max-w-3xl text-sm text-ink-muted">
+          Static layout with straight-line links. Hierarchical edge
+          bundling + pillar coloring land in slice 3; interaction in
+          slice 4; the Tiles | Map toggle on /explore in slice 5, at
+          which point this route goes away.
+        </p>
+      </header>
+      <ProjectMap />
+    </div>
+  );
+}

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+// ============================================================
+// ProjectMap — interactive visualization of the priorities ↔ projects ↔
+// work-categories mesh. Slice 2 of epic #201: static layout, straight
+// links, responsive hide. Slice 3 layers on hierarchical edge bundling
+// + pillar coloring; slice 4 adds interaction; slice 5 mounts under
+// /explore behind a Tiles | Map toggle.
+//
+// The component is a pure declarative SVG: layout math runs on each
+// render off the typed graph from lib/project-map-graph. No d3
+// dependency yet — slice 3 brings d3-shape's `lineRadial` +
+// `curveBundle` for the curves and d3-selection for any imperative
+// touch-ups.
+// ============================================================
+
+import {
+  buildProjectMapGraph,
+  type ProjectMapGraph,
+} from "@/lib/project-map-graph";
+
+const VIEW_W = 1100;
+const VIEW_H = 900;
+const CX = VIEW_W / 2;
+const CY = VIEW_H / 2;
+const R = 380;
+const PROJECT_HALF_HEIGHT = 320;
+const ARC_LABEL_OFFSET = 8;
+const PROJECT_LABEL_OFFSET = 10;
+const NODE_R = 4;
+const PROJECT_NODE_R = 5;
+
+interface Polar {
+  x: number;
+  y: number;
+  angleDeg: number;
+}
+
+// Sweep the left arc top-down. SVG uses y-down, so sin>0 means below
+// center. θ=260° gives sin≈-0.98 (top), θ=100° gives sin≈+0.98
+// (bottom); cos≈-0.17 in both, so x is to the left of center.
+function leftArcAngle(i: number, n: number): number {
+  if (n === 1) return 180;
+  return 260 - (i / (n - 1)) * 160;
+}
+
+// Right arc: θ=-80° at top (sin≈-0.98), θ=+80° at bottom; cos≈+0.17.
+function rightArcAngle(i: number, n: number): number {
+  if (n === 1) return 0;
+  return -80 + (i / (n - 1)) * 160;
+}
+
+function polar(angleDeg: number, radius: number): Polar {
+  const t = (angleDeg * Math.PI) / 180;
+  return {
+    x: CX + radius * Math.cos(t),
+    y: CY + radius * Math.sin(t),
+    angleDeg,
+  };
+}
+
+function projectY(i: number, n: number): number {
+  if (n === 1) return CY;
+  return (
+    CY - PROJECT_HALF_HEIGHT + (i / (n - 1)) * (2 * PROJECT_HALF_HEIGHT)
+  );
+}
+
+// True for arc labels on the left half — text would render upside-down
+// without a 180° flip.
+function shouldFlipLabel(angleDeg: number): boolean {
+  const wrapped = ((angleDeg % 360) + 360) % 360;
+  return wrapped > 90 && wrapped < 270;
+}
+
+export default function ProjectMap() {
+  const graph: ProjectMapGraph = buildProjectMapGraph("public");
+
+  const priorityPos = new Map<string, Polar>();
+  graph.priorities.forEach((p, i) => {
+    priorityPos.set(p.code, polar(leftArcAngle(i, graph.priorities.length), R));
+  });
+
+  const categoryPos = new Map<string, Polar>();
+  graph.categories.forEach((c, i) => {
+    categoryPos.set(
+      c.slug,
+      polar(rightArcAngle(i, graph.categories.length), R),
+    );
+  });
+
+  const projectPos = new Map<string, { x: number; y: number }>();
+  graph.projects.forEach((p, i) => {
+    projectPos.set(p.slug, {
+      x: CX,
+      y: projectY(i, graph.projects.length),
+    });
+  });
+
+  return (
+    <>
+      <div className="hidden md:block">
+        <svg
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          className="h-auto w-full"
+          role="img"
+          aria-label="Project Map — strategic priorities on the left, projects in the middle, work categories on the right, with lines linking each project to its declared alignments."
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth={0.6}
+            fill="none"
+            className="text-brand-silver/40"
+          >
+            {graph.links.map((link, idx) => {
+              const proj = projectPos.get(link.project);
+              const target =
+                link.side === "left"
+                  ? priorityPos.get(link.target)
+                  : categoryPos.get(link.target);
+              if (!proj || !target) return null;
+              return (
+                <line
+                  key={`${link.project}|${link.side}|${link.target}|${idx}`}
+                  x1={proj.x}
+                  y1={proj.y}
+                  x2={target.x}
+                  y2={target.y}
+                />
+              );
+            })}
+          </g>
+
+          <g>
+            {graph.priorities.map((p) => {
+              const pos = priorityPos.get(p.code);
+              if (!pos) return null;
+              const flip = shouldFlipLabel(pos.angleDeg);
+              const label = polar(pos.angleDeg, R + ARC_LABEL_OFFSET);
+              const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
+              return (
+                <g key={p.code}>
+                  <circle
+                    cx={pos.x}
+                    cy={pos.y}
+                    r={NODE_R}
+                    className="fill-brand-huckleberry"
+                  />
+                  <text
+                    x={label.x}
+                    y={label.y}
+                    transform={`rotate(${rotation}, ${label.x}, ${label.y})`}
+                    textAnchor={flip ? "end" : "start"}
+                    dy="0.32em"
+                    className="fill-ink-muted text-[9px]"
+                  >
+                    {p.code}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+
+          <g>
+            {graph.categories.map((c) => {
+              const pos = categoryPos.get(c.slug);
+              if (!pos) return null;
+              const flip = shouldFlipLabel(pos.angleDeg);
+              const label = polar(pos.angleDeg, R + ARC_LABEL_OFFSET);
+              const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
+              return (
+                <g key={c.slug}>
+                  <circle
+                    cx={pos.x}
+                    cy={pos.y}
+                    r={NODE_R}
+                    className="fill-brand-clearwater"
+                  />
+                  <text
+                    x={label.x}
+                    y={label.y}
+                    transform={`rotate(${rotation}, ${label.x}, ${label.y})`}
+                    textAnchor={flip ? "end" : "start"}
+                    dy="0.32em"
+                    className="fill-ink-muted text-[10px]"
+                  >
+                    {c.label}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+
+          <g>
+            {graph.projects.map((p) => {
+              const pos = projectPos.get(p.slug);
+              if (!pos) return null;
+              return (
+                <g key={p.slug}>
+                  <circle
+                    cx={pos.x}
+                    cy={pos.y}
+                    r={PROJECT_NODE_R}
+                    className="fill-brand-black"
+                  />
+                  <text
+                    x={pos.x + PROJECT_LABEL_OFFSET}
+                    y={pos.y}
+                    dy="0.32em"
+                    className="fill-brand-black text-[10px] font-medium"
+                  >
+                    {p.name}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      <p className="block text-sm text-ink-muted md:hidden">
+        Interactive map best viewed on a wider screen — switch to Tiles to
+        browse on this device.
+      </p>
+    </>
+  );
+}


### PR DESCRIPTION
Slice 2 of epic [#201](https://github.com/ui-insight/AISPEG/issues/201). Closes [#203](https://github.com/ui-insight/AISPEG/issues/203).

## What

- New [`components/ProjectMap.tsx`](components/ProjectMap.tsx) — `\"use client\"` SVG renderer for the priorities x projects x categories mesh. Pure declarative output of the typed graph from slice 1; no DOM mutation, no event handlers yet.
- New [`app/dev/project-map/page.tsx`](app/dev/project-map/page.tsx) — temporary `noindex` preview route for visual iteration while slices 3-4 land. Removed in slice 5 when the component mounts under `/explore`.

## Layout

ViewBox `1100 x 900`, absolute coordinates centered on the midpoint (per the IIDS PI-net pattern; easier to reason about than viewBox math).

- **Left arc** — 20 priority codes (`A.1` ... `E.4`) swept top-down across screen-coord angles `260deg -> 100deg` on a circle of radius `380`. Labels rotated to read outward radially; labels on the left half flip `180deg` so they stay right-side-up.
- **Center column** — 15 project nodes evenly spaced along the vertical diameter. Names render right-of-node.
- **Right arc** — 8 work-category labels swept top-down across `-80deg -> +80deg` on the same radius.
- **Links** — 44 `<line>` elements (25 strategic-plan + 19 work-categories), brand-silver/40 stroke. Bundled curves arrive in slice 3.
- **Responsive** — `hidden md:block` on the SVG; a short note in its place below `md`.

## Decisions

- **No d3 dependencies in this slice.** The issue lists `d3-selection / d3-shape / d3-array` in slice-2 scope, but the static layout uses pure trig and React's declarative rendering — no shape primitives needed yet. Adding unused deps is dead weight; they land with `lineRadial` + `curveBundle` in slice 3 where they earn their keep.
- **Priority labels are codes only**, not full priority text. With 20 priorities at ~9deg of arc each, the full text would overlap badly. Hover-to-reveal full text is a slice-4 concern.
- **Project labels are full names.** Per `.impeccable.md` rule 1 (\"every claim names a human/unit\"), names are load-bearing. The longest (`OIT Data Modernization (Huron)`) brushes the right-arc nodes near the top/bottom of the column — slice 3's bundling visually de-noises that region.
- **Brand tokens only** — `fill-brand-huckleberry` (priorities), `fill-brand-clearwater` (categories), `fill-brand-black` (projects), `text-brand-silver/40` for links, `text-ink-muted` for arc labels. No raw hex.

## Verification

- `npm run build` clean. `/dev/project-map` prerenders as static.
- DOM check at desktop width: 43 circles (20 + 8 + 15), 44 lines, 43 text labels, all key elements present (`A.1`, `E.4`, `UniVerso`, `OIT Data Modernization (Huron)`, `Working with documents`, `AI infrastructure`).
- Mobile (375px): SVG width = 0 (`hidden md:block` active), fallback note visible.
- No console errors.

## Test plan

- [x] `npm run build` passes
- [x] Map renders at `md+` widths with all 43 nodes and 44 links
- [x] Every project node has at least one visible link to a priority and/or a category (visual sanity check)
- [x] Mobile viewport hides the SVG and shows the fallback note
- [x] Brand tokens only — no raw hex
- [ ] Visual approval that the static layout \"feels right\" before slice 3 layers on bundling

## Out of scope (deferred to later slices)

- Hierarchical edge bundling + pillar coloring on the left arc (slice 3, [#204](https://github.com/ui-insight/AISPEG/issues/204))
- Hover highlight, click-through, hash deep links (slice 4, [#205](https://github.com/ui-insight/AISPEG/issues/205))
- `/explore` Tiles | Map toggle and dynamic import; removal of `/dev/project-map` (slice 5, [#206](https://github.com/ui-insight/AISPEG/issues/206))

🤖 Generated with [Claude Code](https://claude.com/claude-code)