### PR TITLE
Project Map slice 3: pillar coloring + edge bundling (#204)

### DIFF
--- a/app/dev/project-map/page.tsx
+++ b/app/dev/project-map/page.tsx
@@ -16,10 +16,11 @@ export default function ProjectMapDevPage() {
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Internal preview
         </p>
-        <h1 className="mt-2 text-2xl font-black">Project Map (slice 2 scaffold)</h1>
+        <h1 className="mt-2 text-2xl font-black">Project Map (slice 3 preview)</h1>
         <p className="mt-2 max-w-3xl text-sm text-ink-muted">
-          Static layout with straight-line links. Hierarchical edge
-          bundling + pillar coloring land in slice 3; interaction in
+          Pillar-colored priority arc with hierarchical edge bundling
+          via pillar centroids. Right-side links to work categories
+          stay neutral. Hover highlight + click-through arrive in
           slice 4; the Tiles | Map toggle on /explore in slice 5, at
           which point this route goes away.
         </p>

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -2,17 +2,20 @@
 
 // ============================================================
 // ProjectMap — interactive visualization of the priorities ↔ projects ↔
-// work-categories mesh. Slice 2 of epic #201: static layout, straight
-// links, responsive hide. Slice 3 layers on hierarchical edge bundling
-// + pillar coloring; slice 4 adds interaction; slice 5 mounts under
-// /explore behind a Tiles | Map toggle.
+// work-categories mesh. Slice 3 (this file): pillar coloring + hierarchical
+// edge bundling on the left arc. Slice 4 layers on interaction; slice 5
+// mounts the component under /explore behind a Tiles | Map toggle.
 //
-// The component is a pure declarative SVG: layout math runs on each
-// render off the typed graph from lib/project-map-graph. No d3
-// dependency yet — slice 3 brings d3-shape's `lineRadial` +
-// `curveBundle` for the curves and d3-selection for any imperative
-// touch-ups.
+// Bundling: each left-side edge (project → priority) routes through its
+// pillar centroid before reaching the priority dot. d3-shape's
+// `curveBundle.beta(0.5)` smooths [project, centroid, priority] into a
+// trunked curve; many edges sharing a centroid produce the visible
+// pillar trunks. Right-side edges (project → category) stay 2-point
+// (essentially straight) — there's no intermediate grouping defined for
+// categories in v1.
 // ============================================================
+
+import { line as d3Line, curveBundle } from "d3-shape";
 
 import {
   buildProjectMapGraph,
@@ -24,11 +27,50 @@ const VIEW_H = 900;
 const CX = VIEW_W / 2;
 const CY = VIEW_H / 2;
 const R = 380;
+const PILLAR_CENTROID_R = R * 0.55;     // trunk converges here before fanning
 const PROJECT_HALF_HEIGHT = 320;
 const ARC_LABEL_OFFSET = 8;
+const PILLAR_LABEL_OFFSET = 38;          // pillar code outside the arc labels
 const PROJECT_LABEL_OFFSET = 10;
 const NODE_R = 4;
 const PROJECT_NODE_R = 5;
+const BUNDLE_BETA = 0.5;                 // 0 = pure spline, 1 = straight
+
+// Pillar palette — see issue #204. ui-gold is reserved (per .impeccable.md)
+// so no pillar gets it. Keys must match Pillar.code in lib/strategic-plan.
+//
+// Tailwind v4 scans this file for class strings, so the literals here
+// are sufficient to generate the utilities.
+const PILLAR_FILL: Record<string, string> = {
+  A: "fill-brand-huckleberry",
+  B: "fill-brand-lupine",
+  C: "fill-brand-clearwater",
+  D: "fill-brand-silver",
+  E: "fill-ui-charcoal",
+};
+const PILLAR_TEXT: Record<string, string> = {
+  A: "fill-brand-huckleberry",
+  B: "fill-brand-lupine",
+  C: "fill-brand-clearwater",
+  D: "fill-brand-silver",
+  E: "fill-ui-charcoal",
+};
+const PILLAR_STROKE: Record<string, string> = {
+  A: "stroke-brand-huckleberry/40",
+  B: "stroke-brand-lupine/40",
+  C: "stroke-brand-clearwater/40",
+  D: "stroke-brand-silver/40",
+  E: "stroke-ui-charcoal/30",
+};
+
+const FALLBACK_FILL = "fill-brand-silver";
+const FALLBACK_TEXT = "fill-ink-muted";
+const FALLBACK_STROKE = "stroke-brand-silver/40";
+
+const bundleLine = d3Line<[number, number]>()
+  .x((d) => d[0])
+  .y((d) => d[1])
+  .curve(curveBundle.beta(BUNDLE_BETA));
 
 interface Polar {
   x: number;
@@ -76,10 +118,43 @@ function shouldFlipLabel(angleDeg: number): boolean {
 export default function ProjectMap() {
   const graph: ProjectMapGraph = buildProjectMapGraph("public");
 
+  // Per-priority angle + screen position.
   const priorityPos = new Map<string, Polar>();
   graph.priorities.forEach((p, i) => {
     priorityPos.set(p.code, polar(leftArcAngle(i, graph.priorities.length), R));
   });
+
+  // Pillar centroid: mean angle of the pillar's priorities, projected onto
+  // the trunk radius. All edges entering a pillar pass through this point,
+  // which is what produces the visible bundling.
+  const pillarCentroid = new Map<string, Polar>();
+  const pillarMembers = new Map<string, string[]>();
+  graph.priorities.forEach((p) => {
+    const list = pillarMembers.get(p.pillar) ?? [];
+    list.push(p.code);
+    pillarMembers.set(p.pillar, list);
+  });
+  for (const [pillar, codes] of pillarMembers) {
+    const angles = codes
+      .map((c) => priorityPos.get(c)?.angleDeg)
+      .filter((a): a is number => typeof a === "number");
+    const meanAngle = angles.reduce((a, b) => a + b, 0) / angles.length;
+    pillarCentroid.set(pillar, polar(meanAngle, PILLAR_CENTROID_R));
+  }
+
+  // Pillar code → label anchor (for the small group header outside the arc).
+  const pillarLabelPos = new Map<string, Polar>();
+  for (const [pillar, codes] of pillarMembers) {
+    const angles = codes
+      .map((c) => priorityPos.get(c)?.angleDeg)
+      .filter((a): a is number => typeof a === "number");
+    const meanAngle = angles.reduce((a, b) => a + b, 0) / angles.length;
+    pillarLabelPos.set(pillar, polar(meanAngle, R + PILLAR_LABEL_OFFSET));
+  }
+
+  // Pillar lookup for any priority code (used by edge coloring).
+  const pillarOf = new Map<string, string>();
+  graph.priorities.forEach((p) => pillarOf.set(p.code, p.pillar));
 
   const categoryPos = new Map<string, Polar>();
   graph.categories.forEach((c, i) => {
@@ -104,28 +179,47 @@ export default function ProjectMap() {
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="h-auto w-full"
           role="img"
-          aria-label="Project Map — strategic priorities on the left, projects in the middle, work categories on the right, with lines linking each project to its declared alignments."
+          aria-label="Project Map — strategic priorities on the left grouped by pillar, projects in the middle, work categories on the right; bundled curves trunk through each pillar centroid before fanning to individual priorities."
         >
-          <g
-            stroke="currentColor"
-            strokeWidth={0.6}
-            fill="none"
-            className="text-brand-silver/40"
-          >
+          <g fill="none" strokeWidth={0.7}>
             {graph.links.map((link, idx) => {
               const proj = projectPos.get(link.project);
-              const target =
-                link.side === "left"
-                  ? priorityPos.get(link.target)
-                  : categoryPos.get(link.target);
-              if (!proj || !target) return null;
+              if (!proj) return null;
+
+              if (link.side === "left") {
+                const target = priorityPos.get(link.target);
+                if (!target) return null;
+                const pillar = pillarOf.get(link.target);
+                const centroid = pillar
+                  ? pillarCentroid.get(pillar)
+                  : undefined;
+                const points: Array<[number, number]> = centroid
+                  ? [[proj.x, proj.y], [centroid.x, centroid.y], [target.x, target.y]]
+                  : [[proj.x, proj.y], [target.x, target.y]];
+                const d = bundleLine(points) ?? "";
+                const stroke =
+                  (pillar && PILLAR_STROKE[pillar]) || FALLBACK_STROKE;
+                return (
+                  <path
+                    key={`L|${link.project}|${link.target}|${idx}`}
+                    d={d}
+                    className={stroke}
+                  />
+                );
+              }
+
+              const target = categoryPos.get(link.target);
+              if (!target) return null;
+              const points: Array<[number, number]> = [
+                [proj.x, proj.y],
+                [target.x, target.y],
+              ];
+              const d = bundleLine(points) ?? "";
               return (
-                <line
-                  key={`${link.project}|${link.side}|${link.target}|${idx}`}
-                  x1={proj.x}
-                  y1={proj.y}
-                  x2={target.x}
-                  y2={target.y}
+                <path
+                  key={`R|${link.project}|${link.target}|${idx}`}
+                  d={d}
+                  className="stroke-brand-silver/40"
                 />
               );
             })}
@@ -138,25 +232,45 @@ export default function ProjectMap() {
               const flip = shouldFlipLabel(pos.angleDeg);
               const label = polar(pos.angleDeg, R + ARC_LABEL_OFFSET);
               const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
+              const fill = PILLAR_FILL[p.pillar] || FALLBACK_FILL;
+              const text = PILLAR_TEXT[p.pillar] || FALLBACK_TEXT;
               return (
                 <g key={p.code}>
-                  <circle
-                    cx={pos.x}
-                    cy={pos.y}
-                    r={NODE_R}
-                    className="fill-brand-huckleberry"
-                  />
+                  <circle cx={pos.x} cy={pos.y} r={NODE_R} className={fill} />
                   <text
                     x={label.x}
                     y={label.y}
                     transform={`rotate(${rotation}, ${label.x}, ${label.y})`}
                     textAnchor={flip ? "end" : "start"}
                     dy="0.32em"
-                    className="fill-ink-muted text-[9px]"
+                    className={`text-[9px] ${text}`}
                   >
                     {p.code}
                   </text>
                 </g>
+              );
+            })}
+          </g>
+
+          <g>
+            {Array.from(pillarMembers.keys()).map((pillar) => {
+              const pos = pillarLabelPos.get(pillar);
+              if (!pos) return null;
+              const flip = shouldFlipLabel(pos.angleDeg);
+              const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
+              const text = PILLAR_TEXT[pillar] || FALLBACK_TEXT;
+              return (
+                <text
+                  key={`pillar-${pillar}`}
+                  x={pos.x}
+                  y={pos.y}
+                  transform={`rotate(${rotation}, ${pos.x}, ${pos.y})`}
+                  textAnchor={flip ? "end" : "start"}
+                  dy="0.32em"
+                  className={`text-[14px] font-black ${text}`}
+                >
+                  {pillar}
+                </text>
               );
             })}
           </g>
@@ -174,7 +288,7 @@ export default function ProjectMap() {
                     cx={pos.x}
                     cy={pos.y}
                     r={NODE_R}
-                    className="fill-brand-clearwater"
+                    className="fill-ink-muted"
                   />
                   <text
                     x={label.x}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aispeg",
       "version": "1.0.0",
       "dependencies": {
+        "d3-shape": "^3.2.0",
         "next": "^16.1.6",
         "pg": "^8.20.0",
         "react": "^19.2.4",
@@ -15,6 +16,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.0",
+        "@types/d3-shape": "^3.1.8",
         "@types/node": "^25.3.0",
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
@@ -2004,6 +2006,23 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3139,6 +3158,27 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "refresh:commit-dates": "tsx scripts/refresh-commit-dates.ts"
   },
   "dependencies": {
+    "d3-shape": "^3.2.0",
     "next": "^16.1.6",
     "pg": "^8.20.0",
     "react": "^19.2.4",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.0",
+    "@types/d3-shape": "^3.1.8",
     "@types/node": "^25.3.0",
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
Slice 3 of epic [#201](https://github.com/ui-insight/AISPEG/issues/201). Closes [#204](https://github.com/ui-insight/AISPEG/issues/204).

## What

Replaces the slice-2 straight links with hierarchical edge bundling on the left arc and adds pillar coloring across the priority side of the visualization.

### Bundling

Each project → priority edge is built as a 3-point control polygon `[project, pillarCentroid, priority]` and smoothed with [`d3-shape`](https://github.com/d3/d3-shape)'s `curveBundle.beta(0.5)`. The pillar centroid sits at the mean angle of that pillar's priorities, projected onto a smaller radius (`0.55 × R`). Many edges sharing the same centroid produce the visible pillar trunks before fanning out to individual priorities.

Right-side links (project → category) stay 2-point — there's no intermediate grouping defined for categories in v1.

### Pillar palette

| Pillar | Token | Hex |
|---|---|---|
| A — Ignite Student Success | `brand-huckleberry` | `#261882` |
| B — Drive 100% Experiential Learning | `brand-lupine` | `#5E48FF` |
| C — Adapt the Educational Model | `brand-clearwater` | `#008080` |
| D — Harness Research Innovation and Partnership | `brand-silver` | `#808080` |
| E — Optimize Operational Excellence | `ui-charcoal` | `#191919` |

`ui-gold` stays reserved per [`.impeccable.md`](.impeccable.md) — no pillar gets it.

Color is applied to: priority dots, priority labels, edge strokes (at `/30`–`/40` opacity), and a bold pillar code header (`A`, `B`, ...) anchored outside the priority labels at the cluster's mean angle. Project nodes and category nodes stay neutral so the left arc owns the color identity.

## Decisions

- **No pillar arc band.** The issue offered the band as one option among "color swatch / colored label / arc band — pick what reads." I went with colored dot + colored label + a bold pillar code outside the arc. Conveys "five groups" cleanly without the SVG arc-path math, and one fewer layer to keep visually subtle.
- **Category dots demoted from clearwater to `ink-muted`.** They were `fill-brand-clearwater` in slice 2; that color now belongs to pillar C. The issue is explicit that category nodes stay neutral, so I picked `ink-muted` (`#595959`) — distinct from project black, distinct from the silver of pillar D.
- **`d3-shape` only**, no umbrella package. `d3-array` from the issue's listed deps isn't actually used (the centroid computation is one `Array.reduce`); `d3-path` comes in transitively via `d3-shape`. Total bundle adds ~10kb gz to the eventual `/explore` chunk (loaded only when the map mounts in slice 5).
- **`bundleLine` is module-scoped**, not per-render. Constructing the d3 line generator once.
- **`Tailwind` literals are written as full strings in a `Record`** so v4's content scanner picks them up at build time. Verified by inspecting computed `fill` / `stroke` values in the running preview.

## Verification

Captured from the running preview at desktop width:

- 44 paths total: 25 left (bundled, with `C` cubic-bezier segments through the centroid) + 19 right (straight, single `L` command).
- All five pillar colors resolve to the prescribed `rgb(...)` values; category dots resolve to `rgb(89, 89, 89)`; project dots stay `rgb(25, 25, 25)`.
- 48 text labels: 20 priority codes + 8 category labels + 15 project names + 5 pillar headers.
- Mobile fallback still active below `md`.
- `npm run build` clean.

## Test plan

- [x] `npm run build` passes
- [x] Left arc reads as five pillar groups at desktop widths
- [x] Bundled curves visibly trunk through pillar centroids before fanning to individual priorities
- [x] Right-side links remain neutral straight lines
- [x] Brand tokens only — no raw hex
- [ ] Visual approval that the pillar coloring is "subtle, not garish" (especially pillars D and E, which are the lowest-saturation hues)

## Out of scope (next slices)

- Hover highlight, click-through, hash deep links — slice 4 ([#205](https://github.com/ui-insight/AISPEG/issues/205))
- `/explore` Tiles | Map toggle + dynamic import — slice 5 ([#206](https://github.com/ui-insight/AISPEG/issues/206))

🤖 Generated with [Claude Code](https://claude.com/claude-code)