### PR TITLE
Project Map slice 4: hover, click-through, deep links (#205)

### DIFF
--- a/app/dev/project-map/page.tsx
+++ b/app/dev/project-map/page.tsx
@@ -16,13 +16,15 @@ export default function ProjectMapDevPage() {
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Internal preview
         </p>
-        <h1 className="mt-2 text-2xl font-black">Project Map (slice 3 preview)</h1>
+        <h1 className="mt-2 text-2xl font-black">Project Map (slice 4 preview)</h1>
         <p className="mt-2 max-w-3xl text-sm text-ink-muted">
-          Pillar-colored priority arc with hierarchical edge bundling
-          via pillar centroids. Right-side links to work categories
-          stay neutral. Hover highlight + click-through arrive in
-          slice 4; the Tiles | Map toggle on /explore in slice 5, at
-          which point this route goes away.
+          Hover or tab to a node to highlight its connections; everything
+          else dims. Click navigates: project → /portfolio/&lt;slug&gt;,
+          priority → /standards/strategic-plan/priorities/&lt;code&gt;,
+          category → /explore#category-&lt;slug&gt;. URL hash carries
+          the focused node so links are shareable; Escape clears focus.
+          The Tiles | Map toggle on /explore lands in slice 5, at which
+          point this route goes away.
         </p>
       </header>
       <ProjectMap />

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -91,7 +91,10 @@ function CategoryTileCard({ tile }: { tile: CategoryTile }) {
   // it even before something is tagged) without offering a dead link.
   if (isEmpty) {
     return (
-      <div className="flex h-full flex-col rounded-xl border border-hairline bg-white p-5 opacity-70">
+      <div
+        id={`category-${tile.slug}`}
+        className="flex h-full scroll-mt-12 flex-col rounded-xl border border-hairline bg-white p-5 opacity-70"
+      >
         <h2 className="text-base font-semibold text-brand-black">
           {tile.label}
         </h2>
@@ -107,8 +110,9 @@ function CategoryTileCard({ tile }: { tile: CategoryTile }) {
 
   return (
     <Link
+      id={`category-${tile.slug}`}
       href={`/portfolio?category=${tile.slug}`}
-      className="group flex h-full flex-col rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+      className="group flex h-full scroll-mt-12 flex-col rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
     >
       <h2 className="text-base font-semibold text-brand-black">
         {tile.label}

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,3 +85,37 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
   color-scheme: dark;
 }
 
+/* Project Map — focus dimming.
+ * The map sets [data-focused] on the SVG root when a node is hovered,
+ * tabbed to, or restored from the URL hash. Connected nodes/edges get
+ * [data-focus="connected"]; the focused node itself gets
+ * [data-focus="self"]. Everything else dims so the highlighted bridge
+ * reads cleanly. Transitions keep it from flickering. */
+.project-map [data-node-key] circle,
+.project-map [data-node-key] text,
+.project-map [data-edge-key] {
+  transition: opacity 0.12s ease-out, stroke-opacity 0.12s ease-out, transform 0.12s ease-out;
+}
+.project-map[data-focused] [data-node-key] circle,
+.project-map[data-focused] [data-node-key] text {
+  opacity: 0.18;
+}
+.project-map[data-focused] [data-edge-key] {
+  stroke-opacity: 0.08;
+}
+.project-map[data-focused] [data-node-key][data-focus] circle,
+.project-map[data-focused] [data-node-key][data-focus] text {
+  opacity: 1;
+}
+.project-map[data-focused] [data-edge-key][data-focus="connected"] {
+  stroke-opacity: 1;
+}
+.project-map[data-focused] [data-node-key][data-focus="self"] circle {
+  transform-box: fill-box;
+  transform-origin: center;
+  transform: scale(1.6);
+}
+.project-map[data-focused] [data-node-key][data-focus="self"] text {
+  font-weight: 700;
+}
+

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -2,18 +2,20 @@
 
 // ============================================================
 // ProjectMap — interactive visualization of the priorities ↔ projects ↔
-// work-categories mesh. Slice 3 (this file): pillar coloring + hierarchical
-// edge bundling on the left arc. Slice 4 layers on interaction; slice 5
-// mounts the component under /explore behind a Tiles | Map toggle.
+// work-categories mesh. Slice 4 (this file): hover/focus highlight,
+// click navigation, hash deep links, keyboard accessibility. Slice 5
+// will mount this component under /explore behind a Tiles | Map toggle.
 //
-// Bundling: each left-side edge (project → priority) routes through its
-// pillar centroid before reaching the priority dot. d3-shape's
-// `curveBundle.beta(0.5)` smooths [project, centroid, priority] into a
-// trunked curve; many edges sharing a centroid produce the visible
-// pillar trunks. Right-side edges (project → category) stay 2-point
-// (essentially straight) — there's no intermediate grouping defined for
-// categories in v1.
+// Interaction model is intentionally NOT React-state-driven. Hover
+// thrash on a state that re-renders 80+ SVG elements is wasteful, so
+// focus is tracked in a ref and applied imperatively: applyFocus walks
+// the DOM and sets data-focus="self"|"connected" on the affected
+// nodes/edges, and the dimming is done by CSS rules in globals.css
+// keyed off `[data-focused]` on the SVG root.
 // ============================================================
+
+import { useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
 
 import { line as d3Line, curveBundle } from "d3-shape";
 
@@ -21,26 +23,26 @@ import {
   buildProjectMapGraph,
   type ProjectMapGraph,
 } from "@/lib/project-map-graph";
+import {
+  WORK_CATEGORY_LABELS,
+  type WorkCategory,
+} from "@/lib/work-categories";
 
 const VIEW_W = 1100;
 const VIEW_H = 900;
 const CX = VIEW_W / 2;
 const CY = VIEW_H / 2;
 const R = 380;
-const PILLAR_CENTROID_R = R * 0.55;     // trunk converges here before fanning
+const PILLAR_CENTROID_R = R * 0.55;
 const PROJECT_HALF_HEIGHT = 320;
 const ARC_LABEL_OFFSET = 8;
-const PILLAR_LABEL_OFFSET = 38;          // pillar code outside the arc labels
+const PILLAR_LABEL_OFFSET = 38;
 const PROJECT_LABEL_OFFSET = 10;
 const NODE_R = 4;
 const PROJECT_NODE_R = 5;
-const BUNDLE_BETA = 0.5;                 // 0 = pure spline, 1 = straight
+const BUNDLE_BETA = 0.5;
+const TOOLTIP_OFFSET = 14;
 
-// Pillar palette — see issue #204. ui-gold is reserved (per .impeccable.md)
-// so no pillar gets it. Keys must match Pillar.code in lib/strategic-plan.
-//
-// Tailwind v4 scans this file for class strings, so the literals here
-// are sufficient to generate the utilities.
 const PILLAR_FILL: Record<string, string> = {
   A: "fill-brand-huckleberry",
   B: "fill-brand-lupine",
@@ -78,15 +80,11 @@ interface Polar {
   angleDeg: number;
 }
 
-// Sweep the left arc top-down. SVG uses y-down, so sin>0 means below
-// center. θ=260° gives sin≈-0.98 (top), θ=100° gives sin≈+0.98
-// (bottom); cos≈-0.17 in both, so x is to the left of center.
 function leftArcAngle(i: number, n: number): number {
   if (n === 1) return 180;
   return 260 - (i / (n - 1)) * 160;
 }
 
-// Right arc: θ=-80° at top (sin≈-0.98), θ=+80° at bottom; cos≈+0.17.
 function rightArcAngle(i: number, n: number): number {
   if (n === 1) return 0;
   return -80 + (i / (n - 1)) * 160;
@@ -108,51 +106,183 @@ function projectY(i: number, n: number): number {
   );
 }
 
-// True for arc labels on the left half — text would render upside-down
-// without a 180° flip.
 function shouldFlipLabel(angleDeg: number): boolean {
   const wrapped = ((angleDeg % 360) + 360) % 360;
   return wrapped > 90 && wrapped < 270;
 }
 
+type NodeKind = "priority" | "project" | "category";
+interface FocusedNode {
+  kind: NodeKind;
+  id: string;
+}
+
+function nodeKey(kind: NodeKind, id: string): string {
+  return `${kind}-${id}`;
+}
+
+function leftEdgeKey(project: string, code: string): string {
+  return `L|${project}|${code}`;
+}
+
+function rightEdgeKey(project: string, slug: string): string {
+  return `R|${project}|${slug}`;
+}
+
+// Hash format: #project-<slug>, #priority-A.1, #category-<slug>.
+// Priority codes contain dots, which are valid in URL fragments and
+// don't need encoding. Slugs are lowercase with hyphens.
+function hashFor(node: FocusedNode | null): string {
+  if (!node) return "";
+  return `#${node.kind}-${node.id}`;
+}
+
+function nodeFromHash(hash: string): FocusedNode | null {
+  if (!hash || hash[0] !== "#") return null;
+  const m = hash.slice(1).match(/^(priority|project|category)-(.+)$/);
+  if (!m) return null;
+  const kind = m[1] as NodeKind;
+  return { kind, id: decodeURIComponent(m[2]) };
+}
+
+interface Adjacency {
+  // For each project: connected priorities, categories, edge keys.
+  byProject: Map<
+    string,
+    { priorities: Set<string>; categories: Set<string>; edgeKeys: Set<string> }
+  >;
+  // For each priority/category: connected projects + edge keys.
+  byPriority: Map<string, { projects: Set<string>; edgeKeys: Set<string> }>;
+  byCategory: Map<string, { projects: Set<string>; edgeKeys: Set<string> }>;
+}
+
+function buildAdjacency(graph: ProjectMapGraph): Adjacency {
+  const byProject: Adjacency["byProject"] = new Map();
+  const byPriority: Adjacency["byPriority"] = new Map();
+  const byCategory: Adjacency["byCategory"] = new Map();
+
+  const ensureProject = (slug: string) => {
+    let entry = byProject.get(slug);
+    if (!entry) {
+      entry = { priorities: new Set(), categories: new Set(), edgeKeys: new Set() };
+      byProject.set(slug, entry);
+    }
+    return entry;
+  };
+  const ensurePriority = (code: string) => {
+    let entry = byPriority.get(code);
+    if (!entry) {
+      entry = { projects: new Set(), edgeKeys: new Set() };
+      byPriority.set(code, entry);
+    }
+    return entry;
+  };
+  const ensureCategory = (slug: string) => {
+    let entry = byCategory.get(slug);
+    if (!entry) {
+      entry = { projects: new Set(), edgeKeys: new Set() };
+      byCategory.set(slug, entry);
+    }
+    return entry;
+  };
+
+  // Seed every node so isolated entries (no links) still have an
+  // adjacency record — keeps later lookups branch-free.
+  graph.projects.forEach((p) => ensureProject(p.slug));
+  graph.priorities.forEach((p) => ensurePriority(p.code));
+  graph.categories.forEach((c) => ensureCategory(c.slug));
+
+  for (const link of graph.links) {
+    if (link.side === "left") {
+      const ek = leftEdgeKey(link.project, link.target);
+      const pr = ensureProject(link.project);
+      const pri = ensurePriority(link.target);
+      pr.priorities.add(link.target);
+      pr.edgeKeys.add(ek);
+      pri.projects.add(link.project);
+      pri.edgeKeys.add(ek);
+    } else {
+      const ek = rightEdgeKey(link.project, link.target);
+      const pr = ensureProject(link.project);
+      const cat = ensureCategory(link.target);
+      pr.categories.add(link.target);
+      pr.edgeKeys.add(ek);
+      cat.projects.add(link.project);
+      cat.edgeKeys.add(ek);
+    }
+  }
+  return { byProject, byPriority, byCategory };
+}
+
+interface ConnectedSets {
+  projects: Set<string>;
+  priorities: Set<string>;
+  categories: Set<string>;
+  edgeKeys: Set<string>;
+}
+
+function connectedFor(node: FocusedNode, adj: Adjacency): ConnectedSets {
+  if (node.kind === "project") {
+    const e = adj.byProject.get(node.id);
+    return {
+      projects: new Set(),
+      priorities: e?.priorities ?? new Set(),
+      categories: e?.categories ?? new Set(),
+      edgeKeys: e?.edgeKeys ?? new Set(),
+    };
+  }
+  if (node.kind === "priority") {
+    const e = adj.byPriority.get(node.id);
+    return {
+      projects: e?.projects ?? new Set(),
+      priorities: new Set(),
+      categories: new Set(),
+      edgeKeys: e?.edgeKeys ?? new Set(),
+    };
+  }
+  const e = adj.byCategory.get(node.id);
+  return {
+    projects: e?.projects ?? new Set(),
+    priorities: new Set(),
+    categories: new Set(),
+    edgeKeys: e?.edgeKeys ?? new Set(),
+  };
+}
+
 export default function ProjectMap() {
   const graph: ProjectMapGraph = buildProjectMapGraph("public");
+  const router = useRouter();
+  const svgRef = useRef<SVGSVGElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const focusedRef = useRef<FocusedNode | null>(null);
 
-  // Per-priority angle + screen position.
+  const adjacency = useMemo(() => buildAdjacency(graph), [graph]);
+
+  // Position maps. Computed once per render — graph is server-derived
+  // and stable, so this is constant work.
   const priorityPos = new Map<string, Polar>();
   graph.priorities.forEach((p, i) => {
     priorityPos.set(p.code, polar(leftArcAngle(i, graph.priorities.length), R));
   });
 
-  // Pillar centroid: mean angle of the pillar's priorities, projected onto
-  // the trunk radius. All edges entering a pillar pass through this point,
-  // which is what produces the visible bundling.
-  const pillarCentroid = new Map<string, Polar>();
   const pillarMembers = new Map<string, string[]>();
   graph.priorities.forEach((p) => {
     const list = pillarMembers.get(p.pillar) ?? [];
     list.push(p.code);
     pillarMembers.set(p.pillar, list);
   });
-  for (const [pillar, codes] of pillarMembers) {
-    const angles = codes
-      .map((c) => priorityPos.get(c)?.angleDeg)
-      .filter((a): a is number => typeof a === "number");
-    const meanAngle = angles.reduce((a, b) => a + b, 0) / angles.length;
-    pillarCentroid.set(pillar, polar(meanAngle, PILLAR_CENTROID_R));
-  }
 
-  // Pillar code → label anchor (for the small group header outside the arc).
+  const pillarCentroid = new Map<string, Polar>();
   const pillarLabelPos = new Map<string, Polar>();
   for (const [pillar, codes] of pillarMembers) {
     const angles = codes
       .map((c) => priorityPos.get(c)?.angleDeg)
       .filter((a): a is number => typeof a === "number");
     const meanAngle = angles.reduce((a, b) => a + b, 0) / angles.length;
+    pillarCentroid.set(pillar, polar(meanAngle, PILLAR_CENTROID_R));
     pillarLabelPos.set(pillar, polar(meanAngle, R + PILLAR_LABEL_OFFSET));
   }
 
-  // Pillar lookup for any priority code (used by edge coloring).
   const pillarOf = new Map<string, string>();
   graph.priorities.forEach((p) => pillarOf.set(p.code, p.pillar));
 
@@ -172,15 +302,126 @@ export default function ProjectMap() {
     });
   });
 
+  // ---------------- Focus + tooltip imperative core ----------------
+
+  function applyFocus(node: FocusedNode | null) {
+    focusedRef.current = node;
+    const svg = svgRef.current;
+    if (!svg) return;
+    // Clear all existing focus markers.
+    svg
+      .querySelectorAll<HTMLElement>("[data-focus]")
+      .forEach((el) => el.removeAttribute("data-focus"));
+    if (!node) {
+      svg.removeAttribute("data-focused");
+      writeHash("");
+      return;
+    }
+    svg.setAttribute("data-focused", nodeKey(node.kind, node.id));
+    const selfEl = svg.querySelector(
+      `[data-node-key="${nodeKey(node.kind, node.id)}"]`,
+    );
+    if (selfEl) selfEl.setAttribute("data-focus", "self");
+    const sets = connectedFor(node, adjacency);
+    const mark = (selector: string) => {
+      svg.querySelectorAll(selector).forEach((el) => {
+        el.setAttribute("data-focus", "connected");
+      });
+    };
+    sets.projects.forEach((slug) =>
+      mark(`[data-node-key="${nodeKey("project", slug)}"]`),
+    );
+    sets.priorities.forEach((code) =>
+      mark(`[data-node-key="${nodeKey("priority", code)}"]`),
+    );
+    sets.categories.forEach((slug) =>
+      mark(`[data-node-key="${nodeKey("category", slug)}"]`),
+    );
+    sets.edgeKeys.forEach((key) => mark(`[data-edge-key="${key}"]`));
+    writeHash(hashFor(node));
+  }
+
+  function writeHash(newHash: string) {
+    if (typeof window === "undefined") return;
+    if (window.location.hash === newHash) return;
+    if (newHash) {
+      history.replaceState(null, "", newHash);
+    } else {
+      // Clear hash without leaving a trailing `#`.
+      history.replaceState(
+        null,
+        "",
+        window.location.pathname + window.location.search,
+      );
+    }
+  }
+
+  function showTooltip(text: string, clientX: number, clientY: number) {
+    const tt = tooltipRef.current;
+    if (!tt) return;
+    tt.textContent = text;
+    tt.style.transform = `translate(${clientX + TOOLTIP_OFFSET}px, ${clientY + TOOLTIP_OFFSET}px)`;
+    tt.style.opacity = "1";
+  }
+
+  function moveTooltip(clientX: number, clientY: number) {
+    const tt = tooltipRef.current;
+    if (!tt || tt.style.opacity === "0") return;
+    tt.style.transform = `translate(${clientX + TOOLTIP_OFFSET}px, ${clientY + TOOLTIP_OFFSET}px)`;
+  }
+
+  function hideTooltip() {
+    const tt = tooltipRef.current;
+    if (!tt) return;
+    tt.style.opacity = "0";
+  }
+
+  function navigate(node: FocusedNode) {
+    if (node.kind === "project") {
+      router.push(`/portfolio/${node.id}`);
+      return;
+    }
+    if (node.kind === "priority") {
+      router.push(`/standards/strategic-plan/priorities/${node.id}`);
+      return;
+    }
+    router.push(`/explore#category-${node.id}`);
+  }
+
+  // Initial focus from URL hash + global keyboard listener.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const initial = nodeFromHash(window.location.hash);
+    if (initial) applyFocus(initial);
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && focusedRef.current) {
+        applyFocus(null);
+        hideTooltip();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // applyFocus + hideTooltip are stable closures over refs/router;
+    // re-running on every render would clobber user focus. The graph
+    // is server-derived and doesn't change at runtime, so the empty
+    // dep array is correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---------------- Render ----------------
+
   return (
     <>
       <div className="hidden md:block">
         <svg
+          ref={svgRef}
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          className="h-auto w-full"
+          className="project-map h-auto w-full"
           role="img"
-          aria-label="Project Map — strategic priorities on the left grouped by pillar, projects in the middle, work categories on the right; bundled curves trunk through each pillar centroid before fanning to individual priorities."
+          aria-label="Project Map — strategic priorities on the left grouped by pillar, projects in the middle, work categories on the right; bundled curves link each project to its declared alignments. Hover or tab to a node to highlight its connections."
         >
+          {/* Edges */}
           <g fill="none" strokeWidth={0.7}>
             {graph.links.map((link, idx) => {
               const proj = projectPos.get(link.project);
@@ -194,14 +435,22 @@ export default function ProjectMap() {
                   ? pillarCentroid.get(pillar)
                   : undefined;
                 const points: Array<[number, number]> = centroid
-                  ? [[proj.x, proj.y], [centroid.x, centroid.y], [target.x, target.y]]
-                  : [[proj.x, proj.y], [target.x, target.y]];
+                  ? [
+                      [proj.x, proj.y],
+                      [centroid.x, centroid.y],
+                      [target.x, target.y],
+                    ]
+                  : [
+                      [proj.x, proj.y],
+                      [target.x, target.y],
+                    ];
                 const d = bundleLine(points) ?? "";
                 const stroke =
                   (pillar && PILLAR_STROKE[pillar]) || FALLBACK_STROKE;
                 return (
                   <path
                     key={`L|${link.project}|${link.target}|${idx}`}
+                    data-edge-key={leftEdgeKey(link.project, link.target)}
                     d={d}
                     className={stroke}
                   />
@@ -218,6 +467,7 @@ export default function ProjectMap() {
               return (
                 <path
                   key={`R|${link.project}|${link.target}|${idx}`}
+                  data-edge-key={rightEdgeKey(link.project, link.target)}
                   d={d}
                   className="stroke-brand-silver/40"
                 />
@@ -225,6 +475,7 @@ export default function ProjectMap() {
             })}
           </g>
 
+          {/* Priorities */}
           <g>
             {graph.priorities.map((p) => {
               const pos = priorityPos.get(p.code);
@@ -234,8 +485,37 @@ export default function ProjectMap() {
               const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
               const fill = PILLAR_FILL[p.pillar] || FALLBACK_FILL;
               const text = PILLAR_TEXT[p.pillar] || FALLBACK_TEXT;
+              const node: FocusedNode = { kind: "priority", id: p.code };
               return (
-                <g key={p.code}>
+                <g
+                  key={p.code}
+                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  data-node-key={nodeKey("priority", p.code)}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Priority ${p.code}: ${p.text}`}
+                  onMouseEnter={(e) => {
+                    applyFocus(node);
+                    showTooltip(
+                      `${p.code} — ${p.text}`,
+                      e.clientX,
+                      e.clientY,
+                    );
+                  }}
+                  onMouseMove={(e) => moveTooltip(e.clientX, e.clientY)}
+                  onMouseLeave={() => {
+                    applyFocus(null);
+                    hideTooltip();
+                  }}
+                  onFocus={() => applyFocus(node)}
+                  onClick={() => navigate(node)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      navigate(node);
+                    }
+                  }}
+                >
                   <circle cx={pos.x} cy={pos.y} r={NODE_R} className={fill} />
                   <text
                     x={label.x}
@@ -252,7 +532,8 @@ export default function ProjectMap() {
             })}
           </g>
 
-          <g>
+          {/* Pillar group headers — purely decorative, not interactive */}
+          <g aria-hidden="true">
             {Array.from(pillarMembers.keys()).map((pillar) => {
               const pos = pillarLabelPos.get(pillar);
               if (!pos) return null;
@@ -275,6 +556,59 @@ export default function ProjectMap() {
             })}
           </g>
 
+          {/* Projects */}
+          <g>
+            {graph.projects.map((p) => {
+              const pos = projectPos.get(p.slug);
+              if (!pos) return null;
+              const node: FocusedNode = { kind: "project", id: p.slug };
+              const tooltip = p.tagline ? `${p.name} — ${p.tagline}` : p.name;
+              return (
+                <g
+                  key={p.slug}
+                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  data-node-key={nodeKey("project", p.slug)}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Project ${p.name}${p.tagline ? `: ${p.tagline}` : ""}`}
+                  onMouseEnter={(e) => {
+                    applyFocus(node);
+                    showTooltip(tooltip, e.clientX, e.clientY);
+                  }}
+                  onMouseMove={(e) => moveTooltip(e.clientX, e.clientY)}
+                  onMouseLeave={() => {
+                    applyFocus(null);
+                    hideTooltip();
+                  }}
+                  onFocus={() => applyFocus(node)}
+                  onClick={() => navigate(node)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      navigate(node);
+                    }
+                  }}
+                >
+                  <circle
+                    cx={pos.x}
+                    cy={pos.y}
+                    r={PROJECT_NODE_R}
+                    className="fill-brand-black"
+                  />
+                  <text
+                    x={pos.x + PROJECT_LABEL_OFFSET}
+                    y={pos.y}
+                    dy="0.32em"
+                    className="fill-brand-black text-[10px] font-medium"
+                  >
+                    {p.name}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+
+          {/* Categories */}
           <g>
             {graph.categories.map((c) => {
               const pos = categoryPos.get(c.slug);
@@ -282,8 +616,37 @@ export default function ProjectMap() {
               const flip = shouldFlipLabel(pos.angleDeg);
               const label = polar(pos.angleDeg, R + ARC_LABEL_OFFSET);
               const rotation = flip ? pos.angleDeg + 180 : pos.angleDeg;
+              const node: FocusedNode = { kind: "category", id: c.slug };
+              const meta = WORK_CATEGORY_LABELS[c.slug as WorkCategory];
+              const tooltip = meta
+                ? `${meta.label} — ${meta.description}`
+                : c.label;
               return (
-                <g key={c.slug}>
+                <g
+                  key={c.slug}
+                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  data-node-key={nodeKey("category", c.slug)}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Work category: ${c.label}`}
+                  onMouseEnter={(e) => {
+                    applyFocus(node);
+                    showTooltip(tooltip, e.clientX, e.clientY);
+                  }}
+                  onMouseMove={(e) => moveTooltip(e.clientX, e.clientY)}
+                  onMouseLeave={() => {
+                    applyFocus(null);
+                    hideTooltip();
+                  }}
+                  onFocus={() => applyFocus(node)}
+                  onClick={() => navigate(node)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      navigate(node);
+                    }
+                  }}
+                >
                   <circle
                     cx={pos.x}
                     cy={pos.y}
@@ -304,37 +667,24 @@ export default function ProjectMap() {
               );
             })}
           </g>
-
-          <g>
-            {graph.projects.map((p) => {
-              const pos = projectPos.get(p.slug);
-              if (!pos) return null;
-              return (
-                <g key={p.slug}>
-                  <circle
-                    cx={pos.x}
-                    cy={pos.y}
-                    r={PROJECT_NODE_R}
-                    className="fill-brand-black"
-                  />
-                  <text
-                    x={pos.x + PROJECT_LABEL_OFFSET}
-                    y={pos.y}
-                    dy="0.32em"
-                    className="fill-brand-black text-[10px] font-medium"
-                  >
-                    {p.name}
-                  </text>
-                </g>
-              );
-            })}
-          </g>
         </svg>
       </div>
       <p className="block text-sm text-ink-muted md:hidden">
         Interactive map best viewed on a wider screen — switch to Tiles to
         browse on this device.
       </p>
+      {/*
+        Tooltip lives outside the SVG so it can use viewport coordinates
+        and isn't bound by the SVG's painter-order. Updated imperatively
+        on mouse events; React never re-renders it.
+      */}
+      <div
+        ref={tooltipRef}
+        role="tooltip"
+        aria-hidden="true"
+        className="pointer-events-none fixed left-0 top-0 z-50 max-w-xs rounded border border-hairline bg-white px-2.5 py-1.5 text-xs text-brand-black shadow-md transition-opacity duration-150"
+        style={{ opacity: 0 }}
+      />
     </>
   );
 }


### PR DESCRIPTION
Slice 4 of epic [#201](https://github.com/ui-insight/AISPEG/issues/201). Closes [#205](https://github.com/ui-insight/AISPEG/issues/205).

## What

Makes the Project Map interactive: hover/keyboard focus highlights connections, clicks navigate to the matching detail page, URL hash carries the focused node so links are shareable, and Escape clears.

## Architecture

Per the issue's perf hint, focus is **not** React state. The component renders once at mount and never again on interaction. `applyFocus(node)` walks the DOM and sets `data-focus="self"` on the focused node + `data-focus="connected"` on each connected node and edge; CSS in [`app/globals.css`](app/globals.css) does the dimming off `[data-focused]` on the SVG root. No re-render thrash on every pointer move.

Adjacency is computed once via `useMemo` (`{ byProject, byPriority, byCategory }` → connected edges and opposite-axis nodes). Tooltip is a single `fixed`-positioned `<div>` outside the SVG, repositioned via ref on `onMouseMove` — never re-rendered.

## Interactions

| Trigger | Effect |
|---|---|
| Hover or `Tab` to a node | Highlight self + connected nodes/edges, dim unrelated, show tooltip with full text |
| `mouseleave` | Clear focus + hide tooltip |
| Click or `Enter`/`Space` on project | `router.push(\`/portfolio/<slug>\`)` |
| Click or `Enter`/`Space` on priority | `router.push(\`/standards/strategic-plan/priorities/<code>\`)` |
| Click or `Enter`/`Space` on category | `router.push(\`/explore#category-<slug>\`)` |
| `Escape` (global) | Clear focus |
| Page load with `#priority-D.2` etc. | Apply that focus on mount |

## Hash format

- `#project-<slug>` for projects
- `#priority-<code>` for priorities (codes contain `.`, valid in fragments — no encoding needed)
- `#category-<slug>` for work categories

`history.replaceState` updates the hash during a session so we don't bloat browser history.

## Sibling change: /explore tile anchors

Category click-throughs land on `/explore#category-<slug>`. The matching tile now carries `id="category-<slug>"` plus `scroll-mt-12` so the browser anchor-scroll lands cleanly under the page header. This makes the deep link work end-to-end now, before slice 5 mounts the map on /explore.

## Decisions

- **`role="button"` + `tabIndex={0}` on each node `<g>`** rather than wrapping in SVG `<a>`. Using router.push gives client-side nav; SVG `<a>` would do a full document navigation.
- **`useEffect` with empty deps for hash + global keydown.** Re-running on every render would clobber focus mid-hover. Disabled `react-hooks/exhaustive-deps` for that one block with a comment explaining why (the effect closes over refs and a stable router; the graph is server-derived and immutable at runtime).
- **Tooltip as a fixed-positioned div outside SVG.** SVG `<text>` per pointer move would re-render every pixel of movement; ref-updated CSS transform doesn't.
- **No `onBlur` clears focus.** Blur-clear conflicts with mouseleave-clear when the user tabs away then mouses back. Escape and mouseleave are sufficient clear paths.
- **Pillar headers are `aria-hidden="true"`.** They're decorative group anchors, not interactive nodes — keeping them out of the tab order matches what a screen reader user would want.

## Verification

Captured live in the preview server at `/dev/project-map`:

- 43 focusable nodes (20 priority + 8 category + 15 project), 44 keyed edges.
- Tab → first node gets focus → SVG root gains `data-focused`. Computed opacity: self / connected nodes = `1`, unrelated nodes = `0.18`. Connected edges `stroke-opacity: 1`, dimmed edges `stroke-opacity: 0.08`.
- Mouseover sample: tooltip reads `"A.1 — Provide a high-impact education with a focus on delivering the best value in the West"`, opacity `1`.
- Click on `priority-A.2` → pathname becomes `/standards/strategic-plan/priorities/A.2`.
- Click on `project-stratplan` → `/portfolio/stratplan`.
- Click on `category-documents` → `/explore#category-documents`, anchor element present.
- Reload at `/dev/project-map#priority-D.2` → SVG mounts with `data-focused="priority-D.2"`, 6 connected projects + 6 connected edges highlighted (D.2 has the heaviest alignment in the current inventory).
- `Escape` clears state, hides tooltip, clears hash.
- `npm run build` clean.

## Test plan

- [x] `npm run build` passes
- [x] Hover/focus highlight works for all three node types
- [x] Tooltip shows full text and follows cursor
- [x] Click navigation lands at the right pathname for project, priority, and category
- [x] `Tab` reaches every node; `Enter` / `Space` activates; `Escape` clears
- [x] Hash deep link applies on initial mount
- [x] /explore tile anchors line up with category click-throughs
- [ ] Visual approval in a real browser (the imperative DOM updates are easy to test programmatically, but feel-check the hover transitions before merging)

## Out of scope (next slice)

- `/explore` Tiles | Map toggle + dynamic import; removal of `/dev/project-map` ([#206](https://github.com/ui-insight/AISPEG/issues/206))

🤖 Generated with [Claude Code](https://claude.com/claude-code)