### PR TITLE
Project Map UX pass per /critique

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -11,8 +11,21 @@ import {
   WORK_CATEGORY_LABELS,
   type WorkCategory,
 } from "@/lib/work-categories";
+import { buildProjectMapGraph } from "@/lib/project-map-graph";
 import ExploreViewToggle from "@/components/ExploreViewToggle";
 import ProjectMapView from "@/components/ProjectMapView";
+
+// Pillar code → Tailwind utility for the legend swatch. Mirrors the
+// palette in components/ProjectMap.tsx; if you change one, change both.
+// Keeping the mapping local rather than re-exporting from the client
+// component avoids pulling the d3-shape bundle into this server file.
+const PILLAR_BG: Record<string, string> = {
+  A: "bg-pillar-a",
+  B: "bg-pillar-b",
+  C: "bg-pillar-c",
+  D: "bg-pillar-d",
+  E: "bg-pillar-e",
+};
 
 export const metadata = {
   title: "Explore | UI AI Initiative",
@@ -72,7 +85,7 @@ export default async function ExplorePage({
             ? "The whole mesh: priorities, projects, and work categories"
             : "Browse projects by the kind of work they help with"}
         </h1>
-        <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+        <p className="mt-4 max-w-prose text-base leading-relaxed text-ink-muted">
           {view === "map" ? (
             <>
               Every project, every strategic priority it advances, and
@@ -116,16 +129,150 @@ function TilesSection({ tiles }: { tiles: CategoryTile[] }) {
   );
 }
 
+interface PillarSummary {
+  code: string;
+  name: string;
+  priorityCount: number;
+  uncoveredPriorityCount: number;
+  projectCount: number;
+}
+
+function buildPillarSummary(): PillarSummary[] {
+  // Reuse the typed graph adapter the map renders from so the legend
+  // and the chart can never disagree about which priorities exist or
+  // which projects align to them.
+  const graph = buildProjectMapGraph("public");
+
+  // Map: pillar code -> { name, set of priority codes, set of uncovered priority codes, set of project slugs }
+  const byPillar = new Map<
+    string,
+    { name: string; priorities: Set<string>; uncovered: Set<string>; projects: Set<string> }
+  >();
+  graph.priorities.forEach((p) => {
+    if (!byPillar.has(p.pillar)) {
+      byPillar.set(p.pillar, {
+        name: p.pillarName,
+        priorities: new Set(),
+        uncovered: new Set(),
+        projects: new Set(),
+      });
+    }
+    byPillar.get(p.pillar)!.priorities.add(p.code);
+  });
+
+  const priorityToPillar = new Map<string, string>();
+  graph.priorities.forEach((p) => priorityToPillar.set(p.code, p.pillar));
+
+  const linkedPriorities = new Set<string>();
+  for (const link of graph.links) {
+    if (link.side !== "left") continue;
+    linkedPriorities.add(link.target);
+    const pillar = priorityToPillar.get(link.target);
+    if (!pillar) continue;
+    byPillar.get(pillar)?.projects.add(link.project);
+  }
+
+  // Compute uncovered priorities per pillar (priorities with zero project links).
+  byPillar.forEach((entry) => {
+    entry.priorities.forEach((code) => {
+      if (!linkedPriorities.has(code)) entry.uncovered.add(code);
+    });
+  });
+
+  // Sort by pillar code so the legend reads in the canonical order.
+  return Array.from(byPillar.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([code, entry]) => ({
+      code,
+      name: entry.name,
+      priorityCount: entry.priorities.size,
+      uncoveredPriorityCount: entry.uncovered.size,
+      projectCount: entry.projects.size,
+    }));
+}
+
 function MapSection() {
+  const summary = buildPillarSummary();
+  const totalUncovered = summary.reduce(
+    (acc, s) => acc + s.uncoveredPriorityCount,
+    0,
+  );
+
   return (
-    <section aria-label="Project Map" className="space-y-4">
+    <section aria-label="Project Map" className="space-y-6">
+      <PillarLegend summary={summary} totalUncovered={totalUncovered} />
       <ProjectMapView />
-      <p className="max-w-3xl text-sm text-ink-muted">
-        Each line connects a project to a strategic priority it advances or
-        a kind of work it supports. Hover any node to follow its
-        connections — click to drill in.
+      <p className="max-w-prose text-sm text-ink-muted">
+        Each curve links a project to a strategic priority it advances or a
+        work category it supports. Hover or tab to a node to highlight its
+        connections; click to open its detail page. Press{" "}
+        <kbd className="rounded border border-hairline bg-surface-alt px-1.5 py-0.5 text-[11px] font-medium text-brand-black">
+          Esc
+        </kbd>{" "}
+        to clear focus.
       </p>
     </section>
+  );
+}
+
+function PillarLegend({
+  summary,
+  totalUncovered,
+}: {
+  summary: PillarSummary[];
+  totalUncovered: number;
+}) {
+  return (
+    <div className="space-y-3">
+      <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {summary.map((s) => (
+          <li
+            key={s.code}
+            className="flex items-baseline gap-3 border-l-4 pl-3"
+            style={{ borderColor: `var(--color-pillar-${s.code.toLowerCase()})` }}
+          >
+            <span
+              aria-hidden="true"
+              className={`inline-block h-2.5 w-2.5 shrink-0 translate-y-px rounded-full ${PILLAR_BG[s.code] ?? "bg-ink-muted"}`}
+            />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-brand-black">
+                <span className="tabular-nums">{s.code}.</span> {s.name}
+              </p>
+              <p className="text-xs text-ink-muted">
+                <span className="font-semibold tabular-nums text-brand-black">
+                  {s.projectCount}
+                </span>{" "}
+                project{s.projectCount === 1 ? "" : "s"} ·{" "}
+                <span className="tabular-nums">{s.priorityCount}</span>{" "}
+                priorit{s.priorityCount === 1 ? "y" : "ies"}
+                {s.uncoveredPriorityCount > 0 && (
+                  <>
+                    {" "}
+                    ·{" "}
+                    <span className="text-brand-black">
+                      <span className="font-semibold tabular-nums">
+                        {s.uncoveredPriorityCount}
+                      </span>{" "}
+                      uncovered
+                    </span>
+                  </>
+                )}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {totalUncovered > 0 && (
+        <p className="text-sm text-ink-muted">
+          <span className="font-semibold text-brand-black tabular-nums">
+            {totalUncovered}
+          </span>{" "}
+          {totalUncovered === 1 ? "priority has" : "priorities have"} no
+          aligned projects yet — they show on the arc as gaps.
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,21 @@
   --color-card: #FFFFFF;
   --color-card-dark: #191919;
 
+  /* Categorical palette for the Project Map's pillar grouping.
+   * Brand restraint applies to chrome — sidebars, headings, focus, links.
+   * The chart is a data instrument; its categorical-color channel must
+   * earn its place by maximizing perceptual distance between groups.
+   * This is a 5-color subset of the Okabe-Ito colorblind-safe scheme,
+   * chosen for max separation on white. We avoid orange/yellow because
+   * they collide with Pride Gold (which is reserved for focus state).
+   * If the strategic plan ever grows past 5 pillars, extend with the
+   * remaining Okabe-Ito tones (#E69F00, #F0E442). */
+  --color-pillar-a: #0072B2; /* deep blue */
+  --color-pillar-b: #D55E00; /* vermillion */
+  --color-pillar-c: #009E73; /* bluish green */
+  --color-pillar-d: #CC79A7; /* reddish purple */
+  --color-pillar-e: #56B4E9; /* sky blue */
+
   /* Font token wired from next/font in layout.tsx */
   --font-sans: "Public Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-body: var(--font-sans);
@@ -89,16 +104,18 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
  * The map sets [data-focused] on the SVG root when a node is hovered,
  * tabbed to, or restored from the URL hash. Connected nodes/edges get
  * [data-focus="connected"]; the focused node itself gets
- * [data-focus="self"]. Everything else dims so the highlighted bridge
- * reads cleanly. Transitions keep it from flickering. */
-.project-map [data-node-key] circle,
-.project-map [data-node-key] text,
-.project-map [data-edge-key] {
-  transition: opacity 0.12s ease-out, stroke-opacity 0.12s ease-out, transform 0.12s ease-out;
+ * [data-focus="self"]. Unrelated elements dim, but only enough to push
+ * them back — they should remain legible context, not vanish. */
+@media (prefers-reduced-motion: no-preference) {
+  .project-map [data-node-key] circle,
+  .project-map [data-node-key] text,
+  .project-map [data-edge-key] {
+    transition: opacity 0.12s ease-out, stroke-opacity 0.12s ease-out, transform 0.12s ease-out;
+  }
 }
 .project-map[data-focused] [data-node-key] circle,
 .project-map[data-focused] [data-node-key] text {
-  opacity: 0.18;
+  opacity: 0.32;
 }
 .project-map[data-focused] [data-edge-key] {
   stroke-opacity: 0.08;
@@ -117,5 +134,14 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
 }
 .project-map[data-focused] [data-node-key][data-focus="self"] text {
   font-weight: 700;
+}
+/* Pride Gold focus ring on keyboard navigation — replaces the
+ * barely-visible 1px brand-black inline focus style. */
+.project-map [data-node-key]:focus-visible {
+  outline: none;
+}
+.project-map [data-node-key]:focus-visible > circle {
+  stroke: var(--color-brand-gold);
+  stroke-width: 2.5;
 }
 

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -34,40 +34,47 @@ const CX = VIEW_W / 2;
 const CY = VIEW_H / 2;
 const R = 380;
 const PILLAR_CENTROID_R = R * 0.55;
-const PROJECT_HALF_HEIGHT = 320;
-const ARC_LABEL_OFFSET = 8;
-const PILLAR_LABEL_OFFSET = 38;
-const PROJECT_LABEL_OFFSET = 10;
-const NODE_R = 4;
-const PROJECT_NODE_R = 5;
+const PROJECT_HALF_HEIGHT = 330;
+const ARC_LABEL_OFFSET = 10;
+const PILLAR_LABEL_OFFSET = 44;
+const PROJECT_LABEL_OFFSET = 12;
+const NODE_R = 5;
+const PROJECT_NODE_R = 6;
 const BUNDLE_BETA = 0.5;
 const TOOLTIP_OFFSET = 14;
 
+// Categorical pillar palette — Okabe-Ito subset, defined as CSS
+// variables in app/globals.css and exposed as Tailwind utilities. The
+// hue is the encoding; brand restraint is preserved at the chrome
+// layer. See globals.css for the reasoning.
 const PILLAR_FILL: Record<string, string> = {
-  A: "fill-brand-huckleberry",
-  B: "fill-brand-lupine",
-  C: "fill-brand-clearwater",
-  D: "fill-brand-silver",
-  E: "fill-ui-charcoal",
+  A: "fill-pillar-a",
+  B: "fill-pillar-b",
+  C: "fill-pillar-c",
+  D: "fill-pillar-d",
+  E: "fill-pillar-e",
 };
 const PILLAR_TEXT: Record<string, string> = {
-  A: "fill-brand-huckleberry",
-  B: "fill-brand-lupine",
-  C: "fill-brand-clearwater",
-  D: "fill-brand-silver",
-  E: "fill-ui-charcoal",
+  A: "fill-pillar-a",
+  B: "fill-pillar-b",
+  C: "fill-pillar-c",
+  D: "fill-pillar-d",
+  E: "fill-pillar-e",
 };
+// Edges saturate to /60 so the hue actually carries on a 0.7-stroke
+// path. /30-/40 was perceptible only as a wash, not as a categorical
+// signal.
 const PILLAR_STROKE: Record<string, string> = {
-  A: "stroke-brand-huckleberry/40",
-  B: "stroke-brand-lupine/40",
-  C: "stroke-brand-clearwater/40",
-  D: "stroke-brand-silver/40",
-  E: "stroke-ui-charcoal/30",
+  A: "stroke-pillar-a/60",
+  B: "stroke-pillar-b/60",
+  C: "stroke-pillar-c/60",
+  D: "stroke-pillar-d/60",
+  E: "stroke-pillar-e/60",
 };
 
-const FALLBACK_FILL = "fill-brand-silver";
+const FALLBACK_FILL = "fill-ink-muted";
 const FALLBACK_TEXT = "fill-ink-muted";
-const FALLBACK_STROKE = "stroke-brand-silver/40";
+const FALLBACK_STROKE = "stroke-ink-muted/50";
 
 const bundleLine = d3Line<[number, number]>()
   .x((d) => d[0])
@@ -489,7 +496,7 @@ export default function ProjectMap() {
               return (
                 <g
                   key={p.code}
-                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  className="project-map-node cursor-pointer outline-none"
                   data-node-key={nodeKey("priority", p.code)}
                   role="button"
                   tabIndex={0}
@@ -523,7 +530,7 @@ export default function ProjectMap() {
                     transform={`rotate(${rotation}, ${label.x}, ${label.y})`}
                     textAnchor={flip ? "end" : "start"}
                     dy="0.32em"
-                    className={`text-[9px] ${text}`}
+                    className={`text-[13px] font-semibold ${text}`}
                   >
                     {p.code}
                   </text>
@@ -548,7 +555,7 @@ export default function ProjectMap() {
                   transform={`rotate(${rotation}, ${pos.x}, ${pos.y})`}
                   textAnchor={flip ? "end" : "start"}
                   dy="0.32em"
-                  className={`text-[14px] font-black ${text}`}
+                  className={`text-[22px] font-black ${text}`}
                 >
                   {pillar}
                 </text>
@@ -566,7 +573,7 @@ export default function ProjectMap() {
               return (
                 <g
                   key={p.slug}
-                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  className="project-map-node cursor-pointer outline-none"
                   data-node-key={nodeKey("project", p.slug)}
                   role="button"
                   tabIndex={0}
@@ -595,11 +602,16 @@ export default function ProjectMap() {
                     r={PROJECT_NODE_R}
                     className="fill-brand-black"
                   />
+                  {/* Project labels render LEFT of the column dot
+                      (text-anchor=end). The right side is occupied by
+                      the category arc + its labels; pushing project
+                      labels left reclaims the gutter. */}
                   <text
-                    x={pos.x + PROJECT_LABEL_OFFSET}
+                    x={pos.x - PROJECT_LABEL_OFFSET}
                     y={pos.y}
                     dy="0.32em"
-                    className="fill-brand-black text-[10px] font-medium"
+                    textAnchor="end"
+                    className="fill-brand-black text-[14px] font-semibold"
                   >
                     {p.name}
                   </text>
@@ -624,7 +636,7 @@ export default function ProjectMap() {
               return (
                 <g
                   key={c.slug}
-                  className="project-map-node cursor-pointer outline-none focus-visible:[&>circle]:stroke-brand-black focus-visible:[&>circle]:stroke-1"
+                  className="project-map-node cursor-pointer outline-none"
                   data-node-key={nodeKey("category", c.slug)}
                   role="button"
                   tabIndex={0}
@@ -659,7 +671,7 @@ export default function ProjectMap() {
                     transform={`rotate(${rotation}, ${label.x}, ${label.y})`}
                     textAnchor={flip ? "end" : "start"}
                     dy="0.32em"
-                    className="fill-ink-muted text-[10px]"
+                    className="fill-ink-muted text-[13px]"
                   >
                     {c.label}
                   </text>


### PR DESCRIPTION
Addresses the gaps a `/critique` run flagged on `/explore?view=map` (initial score: 25/40). Scope per user direction: keep the two-semicircle layout; let color do real work as a categorical encoding rather than constraining the chart to chrome-brand colors.

## Six fixes

### 1. Palette — Okabe-Ito subset
The brand palette had three discriminability failures: A and B were both blue-violet (confusable at small sizes), D read as muted gray (no signal), E was charcoal that merged with project-node black. Replaced with a 5-color Okabe-Ito subset (colorblind-safe, max perceptual distance on white), avoiding orange/yellow which would clash with Pride Gold (reserved for focus state).

| Pillar | Hex | Token |
|---|---|---|
| A — Ignite Student Success | `#0072B2` deep blue | `--color-pillar-a` |
| B — Drive 100% Experiential Learning | `#D55E00` vermillion | `--color-pillar-b` |
| C — Adapt the Educational Model | `#009E73` bluish green | `--color-pillar-c` |
| D — Harness Research Innovation | `#CC79A7` reddish purple | `--color-pillar-d` |
| E — Optimize Operational Excellence | `#56B4E9` sky blue | `--color-pillar-e` |

Tokens declared in [`app/globals.css`](app/globals.css) under `@theme` so `fill-`, `bg-`, `stroke-`, `text-` utilities generate naturally. Edge stroke opacity bumped from `/30`–`/40` to `/60` so the hue actually carries on a 0.7-px stroke path.

### 2. Typography — scannable from across the room
| | before | after |
|---|---|---|
| Priority codes | 9px | 13px font-semibold |
| Category labels | 10px | 13px |
| Project names | 10px | 14px font-semibold |
| Pillar headers (A–E) | 14px | 22px font-black |

### 3. Layout — project labels move left of the dot
`text-anchor="end"` with `x = pos.x - 12`. The right side is the category arc's territory; pushing project names into the left gutter stops long names like *OIT Data Modernization (Huron)* from painting over the densest bundle region.

### 4. Legend — answer at rest
Server-rendered above the SVG: pillar code + full name + project count + priority count + uncovered count. Plus a summary line surfacing the chart's own analytical claim:

> **13** priorities have no aligned projects yet — they show on the arc as gaps.

A stakeholder now sees an answer in 8 seconds without hovering 50 nodes. `buildPillarSummary()` reuses the typed graph adapter, so the legend and the chart cannot disagree.

### 5. Accessibility
- Pride Gold focus ring (`stroke-width: 2.5`) replaces the barely-visible 1px brand-black inline style.
- `@media (prefers-reduced-motion: no-preference)` guard wraps the 0.12s transitions.
- Dim opacity softened `0.18` → `0.32`; unrelated context survives hover so the highlighted bridge has something to bridge from.
- Lede line-length tightened `max-w-3xl` → `max-w-prose` (~65ch). Detector flagged ~96–110 chars/line.

### 6. Caption rewrite
*"click to drill in"* misled — clicks navigate away, not drill in place. Now reads "click to open its detail page" with an `Esc` affordance.

## Verification

Captured live in the running preview:

- All five pillar colors resolve to their Okabe-Ito hex (`getComputedStyle` inspection of priority dots A.1–E.1).
- Priority codes 13px, project names 14px, pillar headers 22px.
- Project labels render with `text-anchor="end"` at `x = 538` (cx − 12) — collision with right arc gone.
- Legend shows correct counts: A=1, B=1, C=0, D=6, E=13 projects; uncovered priorities highlighted.
- Hover on `priority-D.2` → 6 connected projects + 6 connected edges highlighted; unrelated nodes settle to opacity 0.32 after the 120ms transition.
- Pride Gold (`#F1B300`) focus ring visible on tabbed nodes.
- `npm run build` clean.

## Scope kept off-limits per direction

- **P0 layout swap** to the IIDS single-tree geometry — user chose to retain the two-semicircle layout.
- Tooltip pattern consolidation — current pattern is consistent ("show identifier always, expand on hover"); my critique's framing of it as inconsistent was off.

## Test plan

- [x] `npm run build` passes
- [x] All five pillar colors render distinctly
- [x] Labels readable at default zoom on a 1280px+ viewport
- [x] Project labels do not collide with right-arc category labels
- [x] Legend shows counts + "uncovered" callout at rest
- [x] Pride Gold focus ring visible via keyboard tab
- [x] `prefers-reduced-motion` honors quiet animation
- [ ] Re-run `/critique` after merge to confirm score moves off 25/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)