### PR TITLE
Project markers as pills with edge-anchored links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -105,15 +105,19 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
  * tabbed to, or restored from the URL hash. Connected nodes/edges get
  * [data-focus="connected"]; the focused node itself gets
  * [data-focus="self"]. Unrelated elements dim, but only enough to push
- * them back — they should remain legible context, not vanish. */
+ * them back — they should remain legible context, not vanish.
+ * Selectors cover both the arc nodes (circle markers) and the project
+ * column (rect markers). */
 @media (prefers-reduced-motion: no-preference) {
   .project-map [data-node-key] circle,
+  .project-map [data-node-key] rect,
   .project-map [data-node-key] text,
   .project-map [data-edge-key] {
-    transition: opacity 0.12s ease-out, stroke-opacity 0.12s ease-out, transform 0.12s ease-out;
+    transition: opacity 0.12s ease-out, stroke-opacity 0.12s ease-out, transform 0.12s ease-out, fill 0.12s ease-out, stroke-width 0.12s ease-out;
   }
 }
 .project-map[data-focused] [data-node-key] circle,
+.project-map[data-focused] [data-node-key] rect,
 .project-map[data-focused] [data-node-key] text {
   opacity: 0.32;
 }
@@ -121,6 +125,7 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
   stroke-opacity: 0.08;
 }
 .project-map[data-focused] [data-node-key][data-focus] circle,
+.project-map[data-focused] [data-node-key][data-focus] rect,
 .project-map[data-focused] [data-node-key][data-focus] text {
   opacity: 1;
 }
@@ -132,6 +137,14 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
   transform-origin: center;
   transform: scale(1.6);
 }
+/* Project pill self-focus: bump stroke and flip fill to Pride Gold —
+ * a pill scaled 1.6× would dwarf neighbors at 240×24, but a stroke +
+ * fill flip stays within bounds while clearly tagging the focused
+ * project. */
+.project-map[data-focused] [data-node-key][data-focus="self"] rect {
+  stroke-width: 2;
+  fill: var(--color-brand-gold);
+}
 .project-map[data-focused] [data-node-key][data-focus="self"] text {
   font-weight: 700;
 }
@@ -140,7 +153,8 @@ main a[href]:not([class*="bg-"]):not([class*="rounded"]):not(.unstyled):hover {
 .project-map [data-node-key]:focus-visible {
   outline: none;
 }
-.project-map [data-node-key]:focus-visible > circle {
+.project-map [data-node-key]:focus-visible > circle,
+.project-map [data-node-key]:focus-visible > rect {
   stroke: var(--color-brand-gold);
   stroke-width: 2.5;
 }

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -37,9 +37,16 @@ const PILLAR_CENTROID_R = R * 0.55;
 const PROJECT_HALF_HEIGHT = 330;
 const ARC_LABEL_OFFSET = 10;
 const PILLAR_LABEL_OFFSET = 44;
-const PROJECT_LABEL_OFFSET = 12;
 const NODE_R = 5;
-const PROJECT_NODE_R = 6;
+// Project markers are horizontal pills, not points. The center column
+// connects on TWO sides — priority links anchor at the LEFT edge, work-
+// category links anchor at the RIGHT edge. Width is set to fit the
+// longest project name in the inventory at PROJECT_LABEL_FONT_PX with
+// a little breathing room; if a longer entry lands, bump this. The
+// label sits inside the pill so bundled curves never cross it.
+const PROJECT_BOX_W = 244;
+const PROJECT_BOX_H = 24;
+const PROJECT_LABEL_FONT_PX = 13;
 const BUNDLE_BETA = 0.5;
 const TOOLTIP_OFFSET = 14;
 
@@ -434,6 +441,12 @@ export default function ProjectMap() {
               const proj = projectPos.get(link.project);
               if (!proj) return null;
 
+              // Project markers are pills, so links anchor at their
+              // edges, not their centers. Left links emerge from the
+              // LEFT edge; right links from the RIGHT edge.
+              const projLeft = proj.x - PROJECT_BOX_W / 2;
+              const projRight = proj.x + PROJECT_BOX_W / 2;
+
               if (link.side === "left") {
                 const target = priorityPos.get(link.target);
                 if (!target) return null;
@@ -443,12 +456,12 @@ export default function ProjectMap() {
                   : undefined;
                 const points: Array<[number, number]> = centroid
                   ? [
-                      [proj.x, proj.y],
+                      [projLeft, proj.y],
                       [centroid.x, centroid.y],
                       [target.x, target.y],
                     ]
                   : [
-                      [proj.x, proj.y],
+                      [projLeft, proj.y],
                       [target.x, target.y],
                     ];
                 const d = bundleLine(points) ?? "";
@@ -467,7 +480,7 @@ export default function ProjectMap() {
               const target = categoryPos.get(link.target);
               if (!target) return null;
               const points: Array<[number, number]> = [
-                [proj.x, proj.y],
+                [projRight, proj.y],
                 [target.x, target.y],
               ];
               const d = bundleLine(points) ?? "";
@@ -596,22 +609,26 @@ export default function ProjectMap() {
                     }
                   }}
                 >
-                  <circle
-                    cx={pos.x}
-                    cy={pos.y}
-                    r={PROJECT_NODE_R}
-                    className="fill-brand-black"
+                  {/* Project marker is a pill, not a point — left
+                      links anchor on its left edge, right links on its
+                      right edge. Label sits inside the pill so bundled
+                      curves never cross the project name. */}
+                  <rect
+                    x={pos.x - PROJECT_BOX_W / 2}
+                    y={pos.y - PROJECT_BOX_H / 2}
+                    width={PROJECT_BOX_W}
+                    height={PROJECT_BOX_H}
+                    rx={4}
+                    className="fill-white stroke-brand-black"
+                    strokeWidth={1}
                   />
-                  {/* Project labels render LEFT of the column dot
-                      (text-anchor=end). The right side is occupied by
-                      the category arc + its labels; pushing project
-                      labels left reclaims the gutter. */}
                   <text
-                    x={pos.x - PROJECT_LABEL_OFFSET}
+                    x={pos.x}
                     y={pos.y}
-                    dy="0.32em"
-                    textAnchor="end"
-                    className="fill-brand-black text-[14px] font-semibold"
+                    dy="0.34em"
+                    textAnchor="middle"
+                    className={`fill-brand-black font-semibold`}
+                    fontSize={PROJECT_LABEL_FONT_PX}
                   >
                     {p.name}
                   </text>


### PR DESCRIPTION
The center column connects on **two** sides — priorities on the left, work categories on the right — so a single-point marker can't carry the visual story without bundled curves crossing through the project label. Replaces project circles with horizontal pills and anchors links at the appropriate edge.

## What

| | before | after |
|---|---|---|
| Project marker | 6px circle | 244×24 rounded rect |
| Marker fill | brand-black | white with brand-black hairline border |
| Label | text-anchor=end, left of the dot | text-anchor=middle, centered inside the pill |
| Left links anchor at | center `(cx, y)` | LEFT edge `(cx − 122, y)` |
| Right links anchor at | center `(cx, y)` | RIGHT edge `(cx + 122, y)` |
| Self-focus | scale 1.6 on circle | fill flips to Pride Gold, stroke 2px on rect |

Bundled curves for the left side still trunk through the pillar centroid; only the start point moved from center to edge.

## CSS coverage

Dim/focus rules in [`globals.css`](app/globals.css) generalize from `circle` to `circle, rect` so the pill participates in the same focus dimming + transitions. The keyboard `:focus-visible` Pride Gold ring works on both shapes. Self-focused pills get a different treatment (fill flip + stroke bump) because a 1.6× scale on a 244×24 rect would dwarf neighbors.

## Verification

Captured live in the preview:

- 15 `rect`s render in the project layer; zero leftover `circle`s.
- Pill geometry: `x=428, y=108, width=244, height=24` (matches `cx − W/2, projectY − H/2`).
- Pill fill `rgb(255,255,255)`, stroke `rgb(25,25,25)`.
- Sample left edge `d` starts at `M428,…`; right edge starts at `M672,…`.
- Hovering project-stratplan: self-pill fill flips to `rgb(241,179,0)` (Pride Gold), stroke-width `2px`, opacity `1`. Other rects + arc circles dim to `0.32`. 4 connected nodes/edges highlighted.
- `npm run build` clean.

## Test plan

- [x] `npm run build` passes
- [x] Pills render with labels inside, no curves crossing through them
- [x] Left-arc links visibly emerge from the LEFT edge of each pill
- [x] Right-arc links visibly emerge from the RIGHT edge of each pill
- [x] Hover/focus on a pill: fill flips Gold, stroke bumps, peers dim
- [x] Keyboard focus ring (Pride Gold, 2.5px) works on pills the same as on arc circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)