### PR TITLE
Tracer slice: /api/ask + agent loop + search_portfolio tool (#114)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ POSTGRES_PASSWORD=aispeg_secret
 # Basic auth for /internal/* (Sprint 2 — replace with UI SSO later)
 BASIC_AUTH_USER=
 BASIC_AUTH_PASS=
+
+# MindRouter — institutional on-prem LLM (https://mindrouter.uidaho.edu)
+# Required for /api/ai/* and /api/ask (conversational agent).
+MINDROUTER_API_KEY=
+# Optional overrides; defaults are baked into lib/mindrouter.ts.
+# MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu
+# MINDROUTER_MODEL=qwen2.5:72b

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runAgent } from "@/lib/agent/loop";
+import type { ChatMessage } from "@/lib/mindrouter";
+
+const ALLOWED_HISTORY_ROLES = new Set(["user", "assistant"]);
+const MAX_HISTORY_MESSAGES = 20;
+const MAX_MESSAGE_LENGTH = 2000;
+
+interface RawHistoryMessage {
+  role?: unknown;
+  content?: unknown;
+}
+
+function sanitizeHistory(history: unknown): ChatMessage[] {
+  if (!Array.isArray(history)) return [];
+  const out: ChatMessage[] = [];
+  for (const m of history.slice(-MAX_HISTORY_MESSAGES)) {
+    const raw = m as RawHistoryMessage;
+    if (
+      typeof raw.role === "string" &&
+      typeof raw.content === "string" &&
+      ALLOWED_HISTORY_ROLES.has(raw.role)
+    ) {
+      out.push({
+        role: raw.role as "user" | "assistant",
+        content: raw.content.slice(0, MAX_MESSAGE_LENGTH),
+      });
+    }
+  }
+  return out;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const message =
+      typeof body?.message === "string" ? body.message.trim() : "";
+
+    if (message.length === 0) {
+      return NextResponse.json(
+        { error: "message is required" },
+        { status: 400 }
+      );
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return NextResponse.json(
+        { error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer` },
+        { status: 400 }
+      );
+    }
+
+    if (!process.env.MINDROUTER_API_KEY) {
+      return NextResponse.json(
+        {
+          error:
+            "The conversational agent is not configured on this environment.",
+          unconfigured: true,
+        },
+        { status: 503 }
+      );
+    }
+
+    const result = await runAgent({
+      message,
+      history: sanitizeHistory(body?.history),
+      audience: "public",
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("POST /api/ask error:", error);
+    const message =
+      error instanceof Error ? error.message : "agent request failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -1,0 +1,233 @@
+// Agent loop — see Epic #107.
+//
+// Stateless, tool-using agent. Each turn:
+//   1. Call MindRouter with the running message log + tool definitions.
+//   2. If the response has tool_calls, execute each tool, append the
+//      results as `tool` messages, and loop.
+//   3. Otherwise, return the final assistant message + accumulated
+//      citations.
+//
+// Capped at MAX_ITERATIONS to prevent runaway loops on a model that won't
+// commit to a final answer.
+
+import "server-only";
+import { chatCompletion, type ChatMessage, type ToolCall } from "@/lib/mindrouter";
+import { SYSTEM_PROMPT } from "./prompts/system";
+import { searchPortfolioTool } from "./tools/search-portfolio";
+import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
+
+const MAX_ITERATIONS = 6;
+
+export const publicRegistry: ToolRegistry = createRegistry([
+  searchPortfolioTool,
+]);
+
+export interface Citation {
+  tool: string;
+  url: string;
+  label?: string;
+}
+
+export interface ToolCallTrace {
+  name: string;
+  arguments: Record<string, unknown>;
+  ok: boolean;
+  error?: string;
+}
+
+export interface AgentResponse {
+  response: string;
+  citations: Citation[];
+  toolCalls: ToolCallTrace[];
+  iterations: number;
+  truncated: boolean;
+}
+
+export interface RunOptions {
+  message: string;
+  history?: ChatMessage[];
+  audience?: Audience;
+  registry?: ToolRegistry;
+}
+
+function dedupeCitations(cites: Citation[]): Citation[] {
+  const seen = new Set<string>();
+  const out: Citation[] = [];
+  for (const c of cites) {
+    const key = `${c.tool}::${c.url}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+function safeParseArgs(raw: string): Record<string, unknown> {
+  if (!raw || raw.trim() === "") return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function executeToolCall(
+  call: ToolCall,
+  registry: ToolRegistry,
+  audience: Audience
+): Promise<{
+  message: ChatMessage;
+  citations: Citation[];
+  trace: ToolCallTrace;
+}> {
+  const args = safeParseArgs(call.function.arguments);
+  const handler = registry.get(call.function.name);
+
+  if (!handler) {
+    const errMsg = `Unknown tool: ${call.function.name}`;
+    return {
+      message: {
+        role: "tool",
+        tool_call_id: call.id,
+        content: JSON.stringify({ error: errMsg }),
+      },
+      citations: [],
+      trace: { name: call.function.name, arguments: args, ok: false, error: errMsg },
+    };
+  }
+
+  try {
+    const result = await handler.execute(args, { audience });
+    const citations: Citation[] = [];
+    if (result.canonicalUrl) {
+      citations.push({ tool: call.function.name, url: result.canonicalUrl });
+    }
+    if (result.links) {
+      for (const link of result.links) {
+        citations.push({ tool: call.function.name, url: link.url, label: link.label });
+      }
+    }
+    return {
+      message: {
+        role: "tool",
+        tool_call_id: call.id,
+        content: JSON.stringify({
+          ...((result.data as Record<string, unknown>) ?? {}),
+          canonicalUrl: result.canonicalUrl,
+        }),
+      },
+      citations,
+      trace: { name: call.function.name, arguments: args, ok: true },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      message: {
+        role: "tool",
+        tool_call_id: call.id,
+        content: JSON.stringify({ error: message }),
+      },
+      citations: [],
+      trace: { name: call.function.name, arguments: args, ok: false, error: message },
+    };
+  }
+}
+
+export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
+  const audience = opts.audience ?? "public";
+  const registry = opts.registry ?? publicRegistry;
+
+  const messages: ChatMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    ...(opts.history ?? []),
+    { role: "user", content: opts.message },
+  ];
+
+  const tools = registry.list();
+  const citations: Citation[] = [];
+  const toolCalls: ToolCallTrace[] = [];
+
+  for (let iter = 1; iter <= MAX_ITERATIONS; iter++) {
+    const response = await chatCompletion({
+      messages,
+      tools,
+      tool_choice: "auto",
+      temperature: 0.2,
+    });
+
+    const choice = response.choices[0];
+    if (!choice) {
+      return {
+        response: "I couldn't generate a response. Please try again.",
+        citations: dedupeCitations(citations),
+        toolCalls,
+        iterations: iter,
+        truncated: false,
+      };
+    }
+
+    const msg = choice.message;
+    const calls = msg.tool_calls ?? [];
+
+    if (calls.length === 0) {
+      return {
+        response: msg.content ?? "",
+        citations: dedupeCitations(citations),
+        toolCalls,
+        iterations: iter,
+        truncated: false,
+      };
+    }
+
+    // Append the assistant's tool-call turn to the running log so the
+    // model sees its own decision when we come back around.
+    messages.push({
+      role: "assistant",
+      content: msg.content ?? null,
+      tool_calls: calls,
+    });
+
+    // Execute each tool call sequentially. (Parallel would be nicer, but
+    // sequentially keeps the citation order deterministic and avoids
+    // surprising the eval harness in slice #112.)
+    for (const call of calls) {
+      const { message, citations: newCites, trace } = await executeToolCall(
+        call,
+        registry,
+        audience
+      );
+      messages.push(message);
+      citations.push(...newCites);
+      toolCalls.push(trace);
+    }
+  }
+
+  // Hit the iteration cap — force a final synthesis turn with tool_choice
+  // = "none" so the model has to commit to text.
+  const finalResponse = await chatCompletion({
+    messages: [
+      ...messages,
+      {
+        role: "user",
+        content:
+          "You've reached the tool-call limit. Synthesise your best answer from the tool results above, or refuse if you don't have enough cited data.",
+      },
+    ],
+    tools,
+    tool_choice: "none",
+    temperature: 0.2,
+  });
+
+  return {
+    response:
+      finalResponse.choices[0]?.message.content ??
+      "I wasn't able to reach a conclusion within the tool-call limit.",
+    citations: dedupeCitations(citations),
+    toolCalls,
+    iterations: MAX_ITERATIONS,
+    truncated: true,
+  };
+}

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -1,0 +1,32 @@
+// System prompt for the conversational agent — see Epic #107.
+//
+// The strict-citation policy is non-negotiable: this site is an
+// institutional accountability surface, and a hallucinated claim about an
+// IIDS project, owner, or blocker would be a real liability. The model
+// must refuse to answer when no tool returned relevant data, rather than
+// falling back to general knowledge.
+
+export const SYSTEM_PROMPT = `You are the conversational assistant for the University of Idaho IIDS (Institute for Interdisciplinary Data Sciences) institutional AI initiative site. You answer plain-language questions about IIDS-coordinated AI work — projects, owners, status, governance standards, reports, and strategic-plan alignment.
+
+# How you work
+
+You have access to read-only tools that query the site's data sources. Use them. The user is asking about IIDS work — you cannot answer from general knowledge.
+
+For every user question:
+1. Decide which tool(s) to call. If multiple data sources might be relevant, call them.
+2. Read the tool results. Each result includes a \`canonicalUrl\` pointing back to the page on the site that displays this data.
+3. Compose a concise answer grounded in what the tools returned. Weave the canonical URL(s) into the response as markdown links so the user can click through to the full surface.
+
+# Strict citation policy
+
+This is the most important rule:
+
+- If no tool returned relevant data for the user's question, do NOT answer from general knowledge. Refuse cleanly.
+- Refusal phrasing: "I don't have data on that. Try browsing [/portfolio](/portfolio) for the active project list." (Adapt the suggested surface to the question — /standards for governance, /reports for activity, /explore for problem-area browsing.)
+- Never invent project names, owners, dates, statuses, blockers, or links. If a tool didn't return it, you don't know it.
+- Out-of-scope questions (weather, sports, general programming help, anything not about IIDS): refuse with the standard refusal.
+- If a tool returns an empty result, say so plainly — don't pad with speculation.
+
+# Voice
+
+Concise. Stakeholder-readable (a Dean should be able to follow). Name real people and units when the tools surface them. No marketing language.`;

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -1,0 +1,44 @@
+// Agent tool registry — see Epic #107.
+//
+// Each tool is read-only and returns a structured payload plus a
+// `canonicalUrl` (or `links: []`) so the model can cite back to the site.
+// The loop never trusts the model to enforce visibility — each tool is
+// scoped to an audience tier at registration time.
+
+import "server-only";
+import type { ToolDefinition } from "@/lib/mindrouter";
+
+export type Audience = "public" | "internal";
+
+export interface ToolResult {
+  /** Free-form structured payload — serialised as JSON for the model. */
+  data: unknown;
+  /** Primary URL the model should cite when surfacing this data. */
+  canonicalUrl?: string;
+  /** Additional URLs to cite (e.g. per-entry deep links). */
+  links?: { label: string; url: string }[];
+}
+
+export interface ToolHandler {
+  definition: ToolDefinition;
+  execute: (
+    args: Record<string, unknown>,
+    ctx: { audience: Audience }
+  ) => Promise<ToolResult>;
+}
+
+export interface ToolRegistry {
+  list(): ToolDefinition[];
+  get(name: string): ToolHandler | undefined;
+}
+
+export function createRegistry(handlers: ToolHandler[]): ToolRegistry {
+  const byName = new Map<string, ToolHandler>();
+  for (const h of handlers) {
+    byName.set(h.definition.function.name, h);
+  }
+  return {
+    list: () => handlers.map((h) => h.definition),
+    get: (name) => byName.get(name),
+  };
+}

--- a/lib/agent/tools/search-portfolio.ts
+++ b/lib/agent/tools/search-portfolio.ts
@@ -1,0 +1,115 @@
+// search_portfolio — first agent tool. Reads the live Postgres portfolio
+// via lib/work.ts. Public-tier only at this slice; internal-tier
+// expansion is Slice #109.
+
+import "server-only";
+import { listApplications } from "@/lib/work";
+import type { ToolHandler, ToolResult } from "./registry";
+
+interface SearchArgs {
+  query?: string;
+  homeUnit?: string;
+  status?: string;
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 25;
+
+function matches(haystack: string, needle: string): boolean {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function pickNumber(args: Record<string, unknown>, key: string): number | undefined {
+  const v = args[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+export const searchPortfolioTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "search_portfolio",
+      description:
+        "Search the live IIDS portfolio of AI projects. Returns projects with their owners, home units, status, and a link to the public project page. Use this for any question about which projects exist, who owns what, what state a project is in, or what IIDS is building.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Optional free-text search across project name, tagline, and description. Omit to list all projects.",
+          },
+          homeUnit: {
+            type: "string",
+            description:
+              "Optional filter by home unit (e.g. 'IIDS', 'OIT', 'College of Engineering'). Matches case-insensitive substring.",
+          },
+          status: {
+            type: "string",
+            description:
+              "Optional filter by lifecycle status. One of: idea, approved, building, prototype, piloting, production, maintained, sunsetting, archived, tracked.",
+          },
+          limit: {
+            type: "integer",
+            description: `Maximum number of projects to return. Default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}.`,
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs, ctx): Promise<ToolResult> {
+    const args: SearchArgs = {
+      query: pickString(rawArgs, "query"),
+      homeUnit: pickString(rawArgs, "homeUnit"),
+      status: pickString(rawArgs, "status"),
+      limit: pickNumber(rawArgs, "limit"),
+    };
+
+    const apps = await listApplications({ audience: ctx.audience });
+    const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+    const filtered = apps.filter((a) => {
+      if (args.query) {
+        const hay = `${a.name} ${a.tagline} ${a.description}`;
+        if (!matches(hay, args.query)) return false;
+      }
+      if (args.homeUnit) {
+        if (!a.homeUnits.some((u) => matches(u, args.homeUnit!))) return false;
+      }
+      if (args.status) {
+        if (a.status !== args.status) return false;
+      }
+      return true;
+    });
+
+    const entries = filtered.slice(0, limit).map((a) => ({
+      slug: a.slug,
+      name: a.name,
+      tagline: a.tagline,
+      homeUnits: a.homeUnits,
+      operationalOwners: a.operationalOwners.map((o) => o.name),
+      status: a.status,
+      iidsSponsor: a.iidsSponsor || null,
+      ai4raRelationship: a.ai4raRelationship,
+      url: `/portfolio/${a.slug}`,
+      activeBlockerCount: a.activeBlockers.length,
+    }));
+
+    return {
+      data: {
+        totalMatched: filtered.length,
+        returned: entries.length,
+        entries,
+      },
+      canonicalUrl: "/portfolio",
+      links: entries.map((e) => ({ label: e.name, url: e.url })),
+    };
+  },
+};

--- a/lib/mindrouter.ts
+++ b/lib/mindrouter.ts
@@ -9,11 +9,43 @@
 const MINDROUTER_BASE =
   process.env.MINDROUTER_BASE_URL || "https://mindrouter.uidaho.edu";
 const MINDROUTER_KEY = process.env.MINDROUTER_API_KEY || "";
-const MINDROUTER_MODEL = process.env.MINDROUTER_MODEL || "llama3.2";
+// Default model picked from the live MindRouter registry on 2026-05-04.
+// Qwen2.5:72b is the strongest Qwen2.5 currently exposed and has well-
+// documented OpenAI-style tool-calling support — required for the
+// conversational agent loop in lib/agent/. Override per environment with
+// MINDROUTER_MODEL.
+const MINDROUTER_MODEL = process.env.MINDROUTER_MODEL || "qwen2.5:72b";
 
-export interface ChatMessage {
-  role: "system" | "user" | "assistant";
-  content: string;
+export interface ToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string; // JSON-encoded
+  };
+}
+
+export type ChatMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | {
+      role: "assistant";
+      content: string | null;
+      tool_calls?: ToolCall[];
+    }
+  | {
+      role: "tool";
+      content: string;
+      tool_call_id: string;
+    };
+
+export interface ToolDefinition {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>; // JSON Schema
+  };
 }
 
 export interface ChatCompletionOptions {
@@ -23,13 +55,20 @@ export interface ChatCompletionOptions {
   stream?: boolean;
   /** When true, asks MindRouter to return valid JSON */
   json_mode?: boolean;
+  /** OpenAI-compatible tool definitions */
+  tools?: ToolDefinition[];
+  tool_choice?: "auto" | "none" | "required";
 }
 
 export interface ChatCompletionResponse {
   id: string;
   choices: {
     index: number;
-    message: { role: string; content: string };
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls?: ToolCall[];
+    };
     finish_reason: string;
   }[];
   usage?: {
@@ -60,6 +99,11 @@ export async function chatCompletion(
 
   if (opts.json_mode) {
     body.response_format = { type: "json_object" };
+  }
+
+  if (opts.tools && opts.tools.length > 0) {
+    body.tools = opts.tools;
+    body.tool_choice = opts.tool_choice ?? "auto";
   }
 
   const res = await fetch(`${MINDROUTER_BASE}/v1/chat/completions`, {


### PR DESCRIPTION
Closes #114. First slice of Epic #107 (conversational agent).

## Summary

- New `POST /api/ask` route — runs a stateless MindRouter tool-calling loop, returns `{ response, citations, toolCalls, iterations, truncated }`.
- New `lib/agent/` directory: `loop.ts` (loop with 6-iteration cap + forced-synthesis fallback), `tools/registry.ts` (audience-scoped tool registry), `tools/search-portfolio.ts` (first read-only tool over the live `applications` table), `prompts/system.ts` (strict-citation system prompt).
- `lib/mindrouter.ts` extended for OpenAI-compatible tool-calling: discriminated `ChatMessage` union with `tool` / `assistant.tool_calls` variants, `ToolDefinition`, `tools` + `tool_choice` request fields.
- Default model bumped to `qwen2.5:72b` — picked from the live MindRouter registry on 2026-05-04 for its proven OpenAI-style tool-calling. Overrideable via `MINDROUTER_MODEL`. `.env.example` updated.

## Acceptance criteria

- [x] `POST /api/ask` returns JSON `{ response, citations, toolCalls, ... }`
- [x] Agent invokes `search_portfolio` for "what projects is IIDS working on?"
- [x] Strict citation enforced — out-of-scope queries return a clean refusal, not hallucinated data
- [x] MindRouter tool-calling round-trips work end-to-end
- [x] Max-iteration cap (6) prevents runaway loops
- [x] Model identifier (`qwen2.5:72b`) is currently exposed by https://mindrouter.uidaho.edu
- [x] `npm run build` and `npm run lint` clean

## Test plan

- [x] `npm run build` green
- [x] `npm run lint` green
- [x] Hit `POST /api/ask` with `{"message":"What projects is IIDS working on?"}` against local dev (SSH-tunneled to dev Postgres) — returns 3 IIDS projects (DGX Stack, MindRouter, TEMPLATE-app) with markdown links + citations array, 2 iterations, 1 tool call: `search_portfolio({homeUnit:"IIDS"})`.
- [x] Hit with `{"message":"What is the weather in Moscow Idaho today?"}` — returns the canonical refusal `"I don't have data on that. Try browsing [/portfolio](/portfolio)…"`, 1 iteration, 0 tool calls, 0 citations. No hallucination.
- [ ] Reviewer: confirm tool returns + citation accumulation match what `lib/agent/loop.ts:executeToolCall` documents.

## Out of scope (per epic #107 slice plan)

UI (#108), eval harness (#112), additional tools (#110, #115), internal-tier auth (#109), streaming (#111), observability + rate limiting (#113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)