### PR TITLE
Tools batch A: portfolio detail + blockers + standards + reports + sitemap (#110)

### DIFF
--- a/evals/agent/golden.json
+++ b/evals/agent/golden.json
@@ -105,6 +105,93 @@
       "tags": ["portfolio", "named-project"]
     },
     {
+      "id": "lookup-openera-detail",
+      "question": "Give me the full description of OpenERA — owners, status, what it does.",
+      "expectedToolCalls": ["lookup_portfolio_entry"],
+      "expectedCitations": ["/portfolio/openera"],
+      "rationale": "Detail-grade question. Should reach for lookup_portfolio_entry (after search_portfolio finds the slug).",
+      "tags": ["portfolio", "named-project", "lookup"]
+    },
+    {
+      "id": "lookup-mindrouter-detail",
+      "question": "Tell me everything about MindRouter — features, technology stack, owner.",
+      "expectedToolCalls": ["lookup_portfolio_entry"],
+      "expectedCitations": ["/portfolio/mindrouter"],
+      "tags": ["portfolio", "named-project", "lookup"]
+    },
+    {
+      "id": "active-blockers-overview",
+      "question": "What's currently blocking IIDS work?",
+      "expectedToolCalls": ["list_active_blockers"],
+      "expectedCitations": ["/portfolio"],
+      "tags": ["blockers", "overview"]
+    },
+    {
+      "id": "blockers-stalled",
+      "question": "Where are we waiting on someone else right now?",
+      "expectedToolCalls": ["list_active_blockers"],
+      "expectedCitations": ["/portfolio"],
+      "rationale": "Either list_active_blockers or search_blockers is fine — the agent should reach for one of them.",
+      "tags": ["blockers", "overview"]
+    },
+    {
+      "id": "standards-overview",
+      "question": "What standards has IIDS requested from OIT?",
+      "expectedToolCalls": ["list_standards"],
+      "expectedCitations": ["/standards"],
+      "tags": ["standards", "overview"]
+    },
+    {
+      "id": "standards-outstanding",
+      "question": "Which IIDS standards requests are still outstanding?",
+      "expectedToolCalls": ["list_standards"],
+      "expectedCitations": ["/standards"],
+      "rationale": "Should filter by status (e.g. requested or acknowledged) — but the eval scores set membership, so list_standards alone is enough to pass.",
+      "tags": ["standards", "filter"]
+    },
+    {
+      "id": "standard-detail",
+      "question": "What does the API & Interface Standards request cover? (Item i-2)",
+      "expectedToolCalls": ["get_standard"],
+      "expectedCitations": ["/standards"],
+      "tags": ["standards", "detail"]
+    },
+    {
+      "id": "reports-latest",
+      "question": "What's the latest IIDS report?",
+      "expectedToolCalls": ["list_reports"],
+      "expectedCitations": ["/reports"],
+      "tags": ["reports", "overview"]
+    },
+    {
+      "id": "reports-briefs",
+      "question": "Show me the executive briefings IIDS has published.",
+      "expectedToolCalls": ["list_reports"],
+      "expectedCitations": ["/reports"],
+      "tags": ["reports", "filter"]
+    },
+    {
+      "id": "report-presidential-brief",
+      "question": "What's in the February 2026 presidential brief?",
+      "expectedToolCalls": ["get_report"],
+      "expectedCitations": ["/reports/presidential-brief-feb-2026"],
+      "tags": ["reports", "detail"]
+    },
+    {
+      "id": "site-areas-overview",
+      "question": "What's on this site? Give me an overview of the sections.",
+      "expectedToolCalls": ["list_site_areas"],
+      "expectedCitations": ["/"],
+      "tags": ["meta", "navigation"]
+    },
+    {
+      "id": "site-areas-where-is-strategic-plan",
+      "question": "Where would I find strategic-plan alignment information?",
+      "expectedToolCalls": ["list_site_areas"],
+      "rationale": "Meta-navigation question. The site-areas tool surfaces the /standards/strategic-plan sub-area. Citation URL is broad, just check tool selection.",
+      "tags": ["meta", "navigation"]
+    },
+    {
       "id": "refuse-weather",
       "question": "What's the weather in Moscow Idaho today?",
       "shouldRefuse": true,

--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -14,12 +14,28 @@ import "server-only";
 import { chatCompletion, type ChatMessage, type ToolCall } from "@/lib/mindrouter";
 import { SYSTEM_PROMPT } from "./prompts/system";
 import { searchPortfolioTool } from "./tools/search-portfolio";
+import { lookupPortfolioEntryTool } from "./tools/lookup-portfolio-entry";
+import { searchBlockersTool } from "./tools/search-blockers";
+import { listActiveBlockersTool } from "./tools/list-active-blockers";
+import { listStandardsTool } from "./tools/list-standards";
+import { getStandardTool } from "./tools/get-standard";
+import { listReportsTool } from "./tools/list-reports";
+import { getReportTool } from "./tools/get-report";
+import { listSiteAreasTool } from "./tools/list-site-areas";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
 
 const MAX_ITERATIONS = 6;
 
 export const publicRegistry: ToolRegistry = createRegistry([
   searchPortfolioTool,
+  lookupPortfolioEntryTool,
+  searchBlockersTool,
+  listActiveBlockersTool,
+  listStandardsTool,
+  getStandardTool,
+  listReportsTool,
+  getReportTool,
+  listSiteAreasTool,
 ]);
 
 export interface Citation {

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -6,24 +6,35 @@
 // must refuse to answer when no tool returned relevant data, rather than
 // falling back to general knowledge.
 
-export const SYSTEM_PROMPT = `You are the conversational assistant for the University of Idaho IIDS (Institute for Interdisciplinary Data Sciences) institutional AI initiative site. You answer plain-language questions about IIDS-coordinated AI work — projects, owners, status, governance standards, reports, and strategic-plan alignment.
+export const SYSTEM_PROMPT = `You are the conversational assistant for the University of Idaho IIDS (Institute for Interdisciplinary Data Sciences) institutional AI initiative site. You answer plain-language questions about IIDS-coordinated AI work — projects, owners, status, blockers, governance standards, reports, and strategic-plan alignment.
 
 # How you work
 
-You have access to read-only tools that query the site's data sources. Use them. The user is asking about IIDS work — you cannot answer from general knowledge.
+You have access to read-only tools that query the site's data sources. **Use them — always.** The user is asking about IIDS work; you cannot answer from general knowledge, and you do not know which projects, reports, or standards exist without looking them up.
 
 For every user question:
 1. Decide which tool(s) to call. If multiple data sources might be relevant, call them.
 2. Read the tool results. Each result includes a \`canonicalUrl\` pointing back to the page on the site that displays this data.
 3. Compose a concise answer grounded in what the tools returned. Weave the canonical URL(s) into the response as markdown links so the user can click through to the full surface.
 
+# Tool-selection cheatsheet
+
+- Specific project name (e.g. "MindRouter", "OpenERA", "UCM Daily Register"): call **search_portfolio** with the name as the \`query\`, then **lookup_portfolio_entry** on the slug for full detail.
+- "What projects…" / "what is IIDS building" / general portfolio browse: **search_portfolio**.
+- "What's blocking X" / "what's stalled" / "where are we waiting": **list_active_blockers** or **search_blockers** (filter by category or named party).
+- "What standards…" / "OIT standards" / "software standards": **list_standards** (optionally filter by status), then **get_standard** for the full detail of a specific item.
+- "What's the latest report" / "show me the briefs" / "what has IIDS published": **list_reports** (optionally filter by kind), then **get_report** for the abstract.
+- "What's on this site" / "where would I find" / meta-navigation: **list_site_areas**.
+
+When a question mentions a name you don't recognise, do not assume it's out-of-scope — call **search_portfolio** with that name first. Only refuse if the search comes back empty.
+
 # Strict citation policy
 
 This is the most important rule:
 
 - If no tool returned relevant data for the user's question, do NOT answer from general knowledge. Refuse cleanly.
-- Refusal phrasing: "I don't have data on that. Try browsing [/portfolio](/portfolio) for the active project list." (Adapt the suggested surface to the question — /standards for governance, /reports for activity, /explore for problem-area browsing.)
-- Never invent project names, owners, dates, statuses, blockers, or links. If a tool didn't return it, you don't know it.
+- Refusal phrasing: "I don't have data on that. Try browsing [/portfolio](/portfolio) for the active project list." Adapt the suggested surface to the question — /standards for governance, /reports for activity, /explore for problem-area browsing, or call **list_site_areas** if you're unsure.
+- Never invent project names, owners, dates, statuses, blockers, links, or report titles. If a tool didn't return it, you don't know it.
 - Out-of-scope questions (weather, sports, general programming help, anything not about IIDS): refuse with the standard refusal.
 - If a tool returns an empty result, say so plainly — don't pad with speculation.
 

--- a/lib/agent/tools/get-report.ts
+++ b/lib/agent/tools/get-report.ts
@@ -1,0 +1,68 @@
+// get_report — full detail (incl. abstract) for one artifact by slug.
+
+import "server-only";
+import { artifacts } from "@/lib/artifacts";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const getReportTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_report",
+      description:
+        "Fetch full detail for one report or artifact by slug — includes title, abstract, audience, author, date, and the canonical URL. Use after list_reports has surfaced a relevant slug.",
+      parameters: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description:
+              "The artifact slug (e.g. 'dev-activity-report-feb-2026', 'presidential-brief-feb-2026', 'lovable-vibe-coding-2026').",
+          },
+        },
+        required: ["slug"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const slug = pickString(rawArgs, "slug");
+    if (!slug) {
+      return {
+        data: { error: "slug is required" },
+        canonicalUrl: "/reports",
+      };
+    }
+    const item = artifacts.find((a) => a.slug === slug);
+    if (!item) {
+      return {
+        data: { found: false, slug },
+        canonicalUrl: "/reports",
+      };
+    }
+    return {
+      data: {
+        found: true,
+        slug: item.slug,
+        kind: item.kind,
+        title: item.title,
+        subtitle: item.subtitle ?? null,
+        audience: item.audience,
+        dateLabel: item.dateLabel,
+        dateIso: item.dateIso,
+        author: item.author,
+        abstract: item.abstract,
+        duration: item.duration ?? null,
+        tags: item.tags ?? [],
+        url: item.href,
+        external: item.external ?? false,
+      },
+      canonicalUrl: item.href.startsWith("/") ? item.href : "/reports",
+    };
+  },
+};

--- a/lib/agent/tools/get-standard.ts
+++ b/lib/agent/tools/get-standard.ts
@@ -1,0 +1,64 @@
+// get_standard — full detail for one ledger item by id (e.g. 'i-1', 'ii-7').
+
+import "server-only";
+import { daysSince, standardsWatch } from "@/lib/standards-watch";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const getStandardTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_standard",
+      description:
+        "Fetch the full text of one standards-ledger item by id. Returns title, full bullet-point detail, status, date requested, and days open. Use after list_standards has surfaced relevant ids.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description:
+              "The ledger id (e.g. 'i-1' for the first Agenda I item, 'ii-3' for the third Agenda II item).",
+          },
+        },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const id = pickString(rawArgs, "id");
+    if (!id) {
+      return {
+        data: { error: "id is required" },
+        canonicalUrl: "/standards",
+      };
+    }
+    const item = standardsWatch.find((s) => s.id === id);
+    if (!item) {
+      return {
+        data: { found: false, id },
+        canonicalUrl: "/standards",
+      };
+    }
+    return {
+      data: {
+        found: true,
+        id: item.id,
+        agenda: item.agenda,
+        title: item.title,
+        details: item.details,
+        status: item.status,
+        dateRequested: item.dateRequested,
+        daysOpen: daysSince(item.dateRequested),
+        responseUrl: item.responseUrl ?? null,
+        responseNote: item.responseNote ?? null,
+      },
+      canonicalUrl: "/standards",
+    };
+  },
+};

--- a/lib/agent/tools/list-active-blockers.ts
+++ b/lib/agent/tools/list-active-blockers.ts
@@ -1,0 +1,74 @@
+// list_active_blockers — every unresolved blocker across the portfolio.
+// Public_text only; internal_text is reserved for the auth-gated agent
+// in slice #109.
+
+import "server-only";
+import { listApplications } from "@/lib/work";
+import type { Blocker } from "@/lib/work";
+import type { ToolHandler, ToolResult } from "./registry";
+
+export const listActiveBlockersTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_active_blockers",
+      description:
+        "Return every unresolved blocker across the IIDS portfolio, with project context. Useful for 'what's blocking IIDS work?' or 'where are we waiting?' Returns public-tier text only — sensitive internal commentary is excluded.",
+      parameters: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "integer",
+            description: "Maximum blockers to return. Default 25, max 50.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs, ctx): Promise<ToolResult> {
+    const limitRaw = rawArgs.limit;
+    const limit =
+      typeof limitRaw === "number" && Number.isFinite(limitRaw)
+        ? Math.min(Math.max(1, limitRaw), 50)
+        : 25;
+
+    const apps = await listApplications({ audience: ctx.audience });
+    type Row = Pick<Blocker, "category" | "severity" | "since" | "publicText"> & {
+      projectSlug: string;
+      projectName: string;
+      projectUrl: string;
+    };
+    const rows: Row[] = [];
+    for (const app of apps) {
+      for (const b of app.activeBlockers) {
+        rows.push({
+          projectSlug: app.slug,
+          projectName: app.name,
+          projectUrl: `/portfolio/${app.slug}`,
+          category: b.category,
+          severity: b.severity,
+          since: b.since,
+          publicText: b.publicText,
+        });
+      }
+    }
+
+    rows.sort((a, b) => a.since.localeCompare(b.since));
+    const trimmed = rows.slice(0, limit);
+    const projectSlugs = Array.from(new Set(trimmed.map((r) => r.projectSlug)));
+
+    return {
+      data: {
+        totalActive: rows.length,
+        returned: trimmed.length,
+        blockers: trimmed,
+      },
+      canonicalUrl: "/portfolio",
+      links: projectSlugs.map((slug) => {
+        const row = trimmed.find((r) => r.projectSlug === slug)!;
+        return { label: row.projectName, url: row.projectUrl };
+      }),
+    };
+  },
+};

--- a/lib/agent/tools/list-reports.ts
+++ b/lib/agent/tools/list-reports.ts
@@ -1,0 +1,76 @@
+// list_reports — reverse-chronological feed of artifacts on /reports.
+// Covers activity reports, briefs, and external presentations.
+
+import "server-only";
+import { artifacts, type ArtifactKind } from "@/lib/artifacts";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const KINDS: ArtifactKind[] = ["activity-report", "brief", "presentation"];
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const listReportsTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_reports",
+      description:
+        "Return the reverse-chronological feed of public reports — written briefs, activity reports, and external presentations. Use this for 'what has IIDS published?', 'what's the latest report?', or 'show me the activity reports'.",
+      parameters: {
+        type: "object",
+        properties: {
+          kind: {
+            type: "string",
+            enum: KINDS,
+            description:
+              "Restrict to one kind (activity-report, brief, presentation). Omit to include all.",
+          },
+          limit: {
+            type: "integer",
+            description: "Maximum reports to return. Default 10, max 30.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const kind = pickString(rawArgs, "kind");
+    const limitRaw = rawArgs.limit;
+    const limit =
+      typeof limitRaw === "number" && Number.isFinite(limitRaw)
+        ? Math.min(Math.max(1, limitRaw), 30)
+        : 10;
+
+    const filtered = kind ? artifacts.filter((a) => a.kind === kind) : artifacts;
+    const sorted = [...filtered].sort((a, b) => b.dateIso.localeCompare(a.dateIso));
+    const trimmed = sorted.slice(0, limit);
+
+    return {
+      data: {
+        totalMatched: filtered.length,
+        returned: trimmed.length,
+        reports: trimmed.map((a) => ({
+          slug: a.slug,
+          kind: a.kind,
+          title: a.title,
+          subtitle: a.subtitle ?? null,
+          audience: a.audience,
+          dateLabel: a.dateLabel,
+          dateIso: a.dateIso,
+          author: a.author,
+          tags: a.tags ?? [],
+          url: a.href,
+          external: a.external ?? false,
+        })),
+      },
+      canonicalUrl: "/reports",
+      links: trimmed
+        .filter((a) => a.href.startsWith("/"))
+        .map((a) => ({ label: a.title, url: a.href })),
+    };
+  },
+};

--- a/lib/agent/tools/list-site-areas.ts
+++ b/lib/agent/tools/list-site-areas.ts
@@ -1,0 +1,115 @@
+// list_site_areas — meta-tool that describes the site's information
+// architecture. Lets the agent answer "what's on this site?" or
+// "where would I find X?" by reaching for a structured map of the
+// top-level surfaces and their purposes.
+//
+// This is intentionally hard-coded rather than scraped from the
+// filesystem: the IA description is editorial and should match how
+// stakeholders are told to think about the site (per CLAUDE.md), not
+// the raw file tree.
+
+import "server-only";
+import type { ToolHandler, ToolResult } from "./registry";
+
+interface SiteArea {
+  name: string;
+  url: string;
+  purpose: string;
+  example_questions?: string[];
+  sub_areas?: { name: string; url: string; purpose: string }[];
+}
+
+const SITE_AREAS: SiteArea[] = [
+  {
+    name: "Projects",
+    url: "/portfolio",
+    purpose:
+      "The IIDS-coordinated portfolio of AI projects across UI units. Each project lists its home unit, operational owner, lifecycle status, and active blockers.",
+    example_questions: [
+      "What projects is IIDS working on?",
+      "Who owns DGX Stack?",
+      "What's the status of MindRouter?",
+    ],
+  },
+  {
+    name: "Explore",
+    url: "/explore",
+    purpose:
+      "Browse the portfolio by problem area instead of by home unit. Categories include automation, communication, decision support, and others.",
+  },
+  {
+    name: "Submit a Project",
+    url: "/builder-guide",
+    purpose:
+      "9-step assessment for submitting a new AI project idea to IIDS. Routes to a named owner with a 2-business-day SLA.",
+  },
+  {
+    name: "Standards",
+    url: "/standards",
+    purpose:
+      "The standards-watch ledger — software and UX standards IIDS has formally requested from OIT, with day counters per outstanding item.",
+    example_questions: [
+      "What standards has IIDS requested?",
+      "What's the oldest outstanding standards request?",
+    ],
+    sub_areas: [
+      {
+        name: "Data Model Explorer",
+        url: "/standards/data-model",
+        purpose:
+          "Unified Data Model (UDM) explorer — tables, columns, controlled vocabularies across governed projects.",
+      },
+      {
+        name: "Strategic Plan Alignment",
+        url: "/standards/strategic-plan",
+        purpose:
+          "Maps portfolio projects to the UI Strategic Plan pillars and priorities. Bidirectional — see which projects advance each priority.",
+      },
+    ],
+  },
+  {
+    name: "Reports",
+    url: "/reports",
+    purpose:
+      "Time-stamped activity reports, briefs, and external presentations. Reverse-chronological feed.",
+    example_questions: [
+      "What's the latest IIDS report?",
+      "Show me the executive briefings.",
+    ],
+  },
+  {
+    name: "About",
+    url: "/about",
+    purpose:
+      "Strategic frame for IIDS-coordinated AI work: the AI4RA partnership, IIDS's role as operator, and how the site fits the broader institutional initiative.",
+  },
+  {
+    name: "AI4RA Ecosystem",
+    url: "/ai4ra-ecosystem",
+    purpose:
+      "Deep-dive on the UI + Southern Utah University AI4RA partnership: OpenERA, Vandalizer, MindRouter, ProcessMapping, and the shared Unified Data Model.",
+  },
+];
+
+export const listSiteAreasTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_site_areas",
+      description:
+        "Return the site's information architecture — every top-level surface, its purpose, and example questions it answers. Use this when the user asks 'what's on this site?', 'where would I find X?', or any meta-navigation question. Also use it as a first step when you're unsure which other tool would best answer a query.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(): Promise<ToolResult> {
+    return {
+      data: { areas: SITE_AREAS },
+      canonicalUrl: "/",
+      links: SITE_AREAS.map((a) => ({ label: a.name, url: a.url })),
+    };
+  },
+};

--- a/lib/agent/tools/list-standards.ts
+++ b/lib/agent/tools/list-standards.ts
@@ -1,0 +1,69 @@
+// list_standards — the IIDS standards-watch ledger, optionally filtered
+// by status. The /standards page is the canonical surface; everything
+// else links into it.
+
+import "server-only";
+import {
+  daysSince,
+  standardsWatch,
+  type StandardsWatchStatus,
+} from "@/lib/standards-watch";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const STATUS_VALUES: StandardsWatchStatus[] = [
+  "requested",
+  "acknowledged",
+  "in-draft",
+  "published",
+];
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const listStandardsTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_standards",
+      description:
+        "Return the IIDS standards-watch ledger — items IIDS has formally requested from OIT, with their current status and how long they've been outstanding. Use this for questions about institutional software / UX standards, what's been requested, or what's still pending.",
+      parameters: {
+        type: "object",
+        properties: {
+          status: {
+            type: "string",
+            enum: STATUS_VALUES,
+            description:
+              "Restrict to one status (requested, acknowledged, in-draft, published). Omit to list everything.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const status = pickString(rawArgs, "status");
+    const filtered = status
+      ? standardsWatch.filter((s) => s.status === status)
+      : standardsWatch;
+
+    return {
+      data: {
+        totalLedger: standardsWatch.length,
+        returned: filtered.length,
+        items: filtered.map((s) => ({
+          id: s.id,
+          agenda: s.agenda,
+          title: s.title,
+          status: s.status,
+          dateRequested: s.dateRequested,
+          daysOpen: daysSince(s.dateRequested),
+          responseUrl: s.responseUrl ?? null,
+        })),
+      },
+      canonicalUrl: "/standards",
+    };
+  },
+};

--- a/lib/agent/tools/lookup-portfolio-entry.ts
+++ b/lib/agent/tools/lookup-portfolio-entry.ts
@@ -1,0 +1,88 @@
+// lookup_portfolio_entry — fetch a single portfolio entry by slug.
+// Complements search_portfolio (which returns shallow rows) with a
+// detailed view including description, features, owners, and active
+// blockers.
+
+import "server-only";
+import { getApplicationBySlug } from "@/lib/work";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupPortfolioEntryTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_portfolio_entry",
+      description:
+        "Fetch the full record for a single project by its slug. Returns description, features, owners, status detail, repo/docs/live URLs, and currently active blockers (public-tier text only). Use this when the user asks about a specific project by name and search_portfolio returned the slug.",
+      parameters: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description:
+              "The project's URL slug (e.g. 'mindrouter', 'openera', 'ucm-daily-register'). Use the slug returned by search_portfolio.",
+          },
+        },
+        required: ["slug"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs, ctx): Promise<ToolResult> {
+    const slug = pickString(rawArgs, "slug");
+    if (!slug) {
+      return {
+        data: { error: "slug is required" },
+        canonicalUrl: "/portfolio",
+      };
+    }
+    const app = await getApplicationBySlug(slug, { audience: ctx.audience });
+    if (!app) {
+      return {
+        data: { found: false, slug },
+        canonicalUrl: "/portfolio",
+      };
+    }
+    return {
+      data: {
+        found: true,
+        slug: app.slug,
+        name: app.name,
+        tagline: app.tagline,
+        description: app.description,
+        homeUnits: app.homeUnits,
+        operationalOwners: app.operationalOwners,
+        buildParticipants: app.buildParticipants,
+        status: app.status,
+        iidsSponsor: app.iidsSponsor || null,
+        institutionalReviewStatus: app.institutionalReviewStatus ?? null,
+        productionScope: app.productionScope ?? null,
+        supportContact: app.supportContact ?? null,
+        ai4raRelationship: app.ai4raRelationship,
+        repoUrl: app.repoUrl ?? null,
+        docsUrl: app.docsUrl ?? null,
+        liveUrl: app.liveUrl ?? null,
+        funding: app.funding ?? null,
+        operationalFunction: app.operationalFunction,
+        operationalExcellenceOutcome: app.operationalExcellenceOutcome,
+        features: app.features,
+        tech: app.tech,
+        workCategories: app.workCategories,
+        strategicPlanAlignment: app.strategicPlanAlignment,
+        activeBlockers: app.activeBlockers.map((b) => ({
+          category: b.category,
+          severity: b.severity,
+          since: b.since,
+          publicText: b.publicText,
+        })),
+        url: `/portfolio/${app.slug}`,
+      },
+      canonicalUrl: `/portfolio/${app.slug}`,
+    };
+  },
+};

--- a/lib/agent/tools/search-blockers.ts
+++ b/lib/agent/tools/search-blockers.ts
@@ -1,0 +1,133 @@
+// search_blockers — filter active blockers by category, severity, or
+// named party. Public_text only.
+
+import "server-only";
+import { listApplications } from "@/lib/work";
+import type {
+  Blocker,
+  BlockerCategory,
+  BlockerSeverity,
+} from "@/lib/work";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const BLOCKER_CATEGORIES: BlockerCategory[] = [
+  "oit-review",
+  "oit-standards",
+  "unit-engagement",
+  "legal-embargo",
+  "hardware-procurement",
+  "funding",
+  "data-governance",
+  "compliance",
+  "personnel",
+  "iids-capacity",
+  "inter-unit-politics",
+  "communications",
+  "external-partner",
+  "faculty-governance",
+];
+
+const BLOCKER_SEVERITIES: BlockerSeverity[] = ["low", "medium", "high"];
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const searchBlockersTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "search_blockers",
+      description:
+        "Filter active (unresolved) blockers across the portfolio by category, severity, or named-party substring. Returns public-tier text only.",
+      parameters: {
+        type: "object",
+        properties: {
+          category: {
+            type: "string",
+            enum: BLOCKER_CATEGORIES,
+            description:
+              "Restrict to one blocker category (e.g. 'oit-review', 'data-governance', 'funding').",
+          },
+          severity: {
+            type: "string",
+            enum: BLOCKER_SEVERITIES,
+            description: "Restrict to one severity level.",
+          },
+          namedParty: {
+            type: "string",
+            description:
+              "Case-insensitive substring match against the named party (an office or person blocking the work).",
+          },
+          limit: {
+            type: "integer",
+            description: "Maximum blockers to return. Default 25, max 50.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs, ctx): Promise<ToolResult> {
+    const category = pickString(rawArgs, "category");
+    const severity = pickString(rawArgs, "severity");
+    const namedParty = pickString(rawArgs, "namedParty");
+    const limitRaw = rawArgs.limit;
+    const limit =
+      typeof limitRaw === "number" && Number.isFinite(limitRaw)
+        ? Math.min(Math.max(1, limitRaw), 50)
+        : 25;
+
+    const apps = await listApplications({ audience: ctx.audience });
+    type Row = Pick<Blocker, "category" | "severity" | "since" | "publicText"> & {
+      projectSlug: string;
+      projectName: string;
+      projectUrl: string;
+      namedParty: string | null;
+    };
+    const rows: Row[] = [];
+    for (const app of apps) {
+      for (const b of app.activeBlockers) {
+        if (category && b.category !== category) continue;
+        if (severity && b.severity !== severity) continue;
+        if (namedParty) {
+          if (
+            !b.namedParty ||
+            !b.namedParty.toLowerCase().includes(namedParty.toLowerCase())
+          ) {
+            continue;
+          }
+        }
+        rows.push({
+          projectSlug: app.slug,
+          projectName: app.name,
+          projectUrl: `/portfolio/${app.slug}`,
+          category: b.category,
+          severity: b.severity,
+          since: b.since,
+          publicText: b.publicText,
+          namedParty: b.namedParty,
+        });
+      }
+    }
+
+    rows.sort((a, b) => a.since.localeCompare(b.since));
+    const trimmed = rows.slice(0, limit);
+    const projectSlugs = Array.from(new Set(trimmed.map((r) => r.projectSlug)));
+
+    return {
+      data: {
+        filters: { category, severity, namedParty },
+        totalMatched: rows.length,
+        returned: trimmed.length,
+        blockers: trimmed,
+      },
+      canonicalUrl: "/portfolio",
+      links: projectSlugs.map((slug) => {
+        const row = trimmed.find((r) => r.projectSlug === slug)!;
+        return { label: row.projectName, url: row.projectUrl };
+      }),
+    };
+  },
+};


### PR DESCRIPTION
Closes #110. Fourth slice of Epic #107.

## Summary

Adds 8 read-only tools to the agent registry, covering the four primary public surfaces plus a navigation meta-tool. The agent can now answer detail questions (per-project lookups), operational questions (blockers), governance questions (standards), publication questions (reports), and meta-navigation questions (site IA).

| Tool | Returns | Cites |
|---|---|---|
| `lookup_portfolio_entry` | full project record by slug | `/portfolio/<slug>` |
| `search_blockers` | filtered active blockers (category / severity / named-party) | `/portfolio` + per-project links |
| `list_active_blockers` | all unresolved blockers across portfolio | `/portfolio` + per-project links |
| `list_standards` | standards-watch ledger, optional status filter | `/standards` |
| `get_standard` | full ledger entry by id | `/standards` |
| `list_reports` | reverse-chron artifacts feed, optional kind filter | `/reports` + per-report links |
| `get_report` | full artifact detail by slug | `/reports/<slug>` |
| `list_site_areas` | site IA + example questions per area | `/` + per-area links |

System prompt tightened with a tool-selection cheatsheet ("named project → search_portfolio first, then lookup_portfolio_entry") that fixes the `ucm-newsletter` regression carried over from slice #112.

Golden set extended with 12 new cases covering each new tool category (12 → 32 total).

## Acceptance criteria

- [x] All 8 tools register and execute via the agent loop
- [x] Tool returns include canonical URLs that resolve when clicked
- [x] Public-tier only — `search_blockers` / `list_active_blockers` return `publicText` only; `internal_text` is reserved for slice #109
- [x] Eval golden set extended with at least 2 Q&A pairs per tool category
- [x] Citation accuracy stays ≥ 80% — actual: **100% across all axes** on the 32-case set
- [x] `npm run build` and `npm run lint` clean

## Eval baseline (qwen2.5:72b)

```
Tool-selection:       100.0%  (26/26)
Citation accuracy:    100.0%  (25/25)
Refusal correctness:  100.0%  (6/6)
Overall pass:         100.0%  (32/32)
```

The previously-failing `ucm-newsletter` case ("What's the UCM Daily Register?") now passes — the prompt-side "look up named entities first" rule fixed it without needing a behavior change on the model side.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run eval:agent` — all four thresholds met (32/32, exit 0)
- [ ] Reviewer: try the chat widget on `/` with each new tool category — e.g. *"What standards has IIDS requested?"*, *"What's the latest IIDS report?"*, *"Where would I find strategic-plan alignment?"*, *"What's currently blocking IIDS work?"*

## Out of scope (per slice #110)

- Internal-tier tools (slice #109) — `search_blockers` deliberately returns `publicText` only for now.
- Governance / strategic-plan / GitHub tools — those are slice #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)