### PR TITLE
Tools batch B: governance + strategic-plan + GitHub (#115)

### DIFF
--- a/evals/agent/golden.json
+++ b/evals/agent/golden.json
@@ -192,6 +192,69 @@
       "tags": ["meta", "navigation"]
     },
     {
+      "id": "governance-projects-list",
+      "question": "Which projects are part of the AI4RA Unified Data Model?",
+      "expectedToolCalls": ["list_governance_projects"],
+      "expectedCitations": ["/standards/data-model"],
+      "tags": ["governance", "udm"]
+    },
+    {
+      "id": "governance-table-lookup",
+      "question": "What columns are in the AuditReport table from the audit-dashboard project?",
+      "expectedToolCalls": ["lookup_udm_table"],
+      "expectedCitations": ["/standards/data-model/tables/audit-dashboard/AuditReport"],
+      "tags": ["governance", "udm", "table"]
+    },
+    {
+      "id": "governance-vocabulary-search",
+      "question": "What ReportType values are in the audit vocabulary?",
+      "expectedToolCalls": ["search_vocabulary"],
+      "expectedCitations": ["/standards/data-model/vocabularies"],
+      "tags": ["governance", "vocabulary"]
+    },
+    {
+      "id": "strategic-plan-pillar-lookup",
+      "question": "Tell me about Pillar A of the UI Strategic Plan.",
+      "expectedToolCalls": ["lookup_pillar"],
+      "expectedCitations": ["/standards/strategic-plan/pillars/A"],
+      "tags": ["strategic-plan", "pillar"]
+    },
+    {
+      "id": "strategic-plan-priority-lookup",
+      "question": "What does priority A.1 say in the UI Strategic Plan?",
+      "expectedToolCalls": ["lookup_priority"],
+      "expectedCitations": ["/standards/strategic-plan/priorities/A.1"],
+      "tags": ["strategic-plan", "priority"]
+    },
+    {
+      "id": "strategic-plan-projects-for-priority",
+      "question": "Which IIDS projects advance priority D.3?",
+      "expectedToolCalls": ["list_projects_for_priority"],
+      "expectedCitations": ["/standards/strategic-plan/priorities/D.3"],
+      "tags": ["strategic-plan", "priority", "alignment"]
+    },
+    {
+      "id": "github-open-issues",
+      "question": "What's currently open in the AISPEG issue tracker?",
+      "expectedToolCalls": ["list_open_issues"],
+      "expectedCitations": ["https://github.com/ui-insight/AISPEG/issues"],
+      "tags": ["github", "issues"]
+    },
+    {
+      "id": "github-search-conversational-agent",
+      "question": "Are there any open issues about the conversational agent?",
+      "expectedToolCalls": ["search_issues"],
+      "rationale": "search_issues with a query like 'conversational agent' or 'agent' should pull the epic and slices. Citation URL varies, score on tool selection.",
+      "tags": ["github", "issues", "search"]
+    },
+    {
+      "id": "github-issue-detail",
+      "question": "What's in GitHub issue #107?",
+      "expectedToolCalls": ["get_issue"],
+      "expectedCitations": ["https://github.com/ui-insight/AISPEG/issues/107"],
+      "tags": ["github", "issues", "detail"]
+    },
+    {
       "id": "refuse-weather",
       "question": "What's the weather in Moscow Idaho today?",
       "shouldRefuse": true,

--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -22,6 +22,15 @@ import { getStandardTool } from "./tools/get-standard";
 import { listReportsTool } from "./tools/list-reports";
 import { getReportTool } from "./tools/get-report";
 import { listSiteAreasTool } from "./tools/list-site-areas";
+import { listGovernanceProjectsTool } from "./tools/list-governance-projects";
+import { lookupUdmTableTool } from "./tools/lookup-udm-table";
+import { searchVocabularyTool } from "./tools/search-vocabulary";
+import { lookupPillarTool } from "./tools/lookup-pillar";
+import { lookupPriorityTool } from "./tools/lookup-priority";
+import { listProjectsForPriorityTool } from "./tools/list-projects-for-priority";
+import { listOpenIssuesTool } from "./tools/list-open-issues";
+import { searchIssuesTool } from "./tools/search-issues";
+import { getIssueTool } from "./tools/get-issue";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
 
 const MAX_ITERATIONS = 6;
@@ -36,6 +45,15 @@ export const publicRegistry: ToolRegistry = createRegistry([
   listReportsTool,
   getReportTool,
   listSiteAreasTool,
+  listGovernanceProjectsTool,
+  lookupUdmTableTool,
+  searchVocabularyTool,
+  lookupPillarTool,
+  lookupPriorityTool,
+  listProjectsForPriorityTool,
+  listOpenIssuesTool,
+  searchIssuesTool,
+  getIssueTool,
 ]);
 
 export interface Citation {

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -25,6 +25,9 @@ For every user question:
 - "What standards…" / "OIT standards" / "software standards": **list_standards** (optionally filter by status), then **get_standard** for the full detail of a specific item.
 - "What's the latest report" / "show me the briefs" / "what has IIDS published": **list_reports** (optionally filter by kind), then **get_report** for the abstract.
 - "What's on this site" / "where would I find" / meta-navigation: **list_site_areas**.
+- Data governance / UDM / "what tables does X have" / "controlled vocabulary": **list_governance_projects** to find slugs, **lookup_udm_table** for one table's columns, **search_vocabulary** for vocabulary groups.
+- Strategic plan / pillars / priorities (codes like "A.1", "D.3"): **lookup_pillar** for one pillar's priorities, **lookup_priority** for one priority's text, **list_projects_for_priority** for portfolio entries advancing a given priority.
+- GitHub issues / "what's open in the tracker" / "what bug is X": **list_open_issues** (optionally filter by label), **search_issues** by title, **get_issue** for full body.
 
 When a question mentions a name you don't recognise, do not assume it's out-of-scope — call **search_portfolio** with that name first. Only refuse if the search comes back empty.
 

--- a/lib/agent/tools/get-issue.ts
+++ b/lib/agent/tools/get-issue.ts
@@ -1,0 +1,70 @@
+// get_issue — fetch one GitHub issue by number, including its body.
+
+import "server-only";
+import { fetchIssue } from "@/lib/github";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const BODY_EXCERPT_CHARS = 1500;
+
+export const getIssueTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_issue",
+      description:
+        "Fetch one GitHub issue by number from the IIDS site repository (ui-insight/AISPEG). Returns title, state, labels, milestone, body excerpt, and the canonical GitHub URL.",
+      parameters: {
+        type: "object",
+        properties: {
+          number: {
+            type: "integer",
+            description: "The issue number (positive integer).",
+          },
+        },
+        required: ["number"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const numberRaw = rawArgs.number;
+    const number =
+      typeof numberRaw === "number"
+        ? numberRaw
+        : typeof numberRaw === "string"
+          ? Number.parseInt(numberRaw, 10)
+          : NaN;
+    if (!Number.isFinite(number) || number <= 0) {
+      return {
+        data: { error: "number is required and must be a positive integer" },
+        canonicalUrl: "https://github.com/ui-insight/AISPEG/issues",
+      };
+    }
+
+    const issue = await fetchIssue(number);
+    if (!issue) {
+      return {
+        data: { found: false, number },
+        canonicalUrl: `https://github.com/ui-insight/AISPEG/issues/${number}`,
+      };
+    }
+    const body = issue.body ?? null;
+    return {
+      data: {
+        found: true,
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels: issue.labels.map((l) => l.name),
+        milestone: issue.milestone?.title ?? null,
+        createdAt: issue.created_at,
+        bodyExcerpt:
+          body && body.length > BODY_EXCERPT_CHARS
+            ? body.slice(0, BODY_EXCERPT_CHARS) + "…"
+            : body,
+        url: issue.html_url,
+      },
+      canonicalUrl: issue.html_url,
+    };
+  },
+};

--- a/lib/agent/tools/list-governance-projects.ts
+++ b/lib/agent/tools/list-governance-projects.ts
@@ -1,0 +1,46 @@
+// list_governance_projects — the apps that participate in the
+// AI4RA Unified Data Model. Sourced from the vendored governance
+// catalog so it stays in lockstep with what /standards/data-model
+// renders.
+
+import "server-only";
+import { projects as governanceProjects } from "@/lib/governance/catalog";
+import type { ToolHandler, ToolResult } from "./registry";
+
+export const listGovernanceProjectsTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_governance_projects",
+      description:
+        "Return the apps participating in the AI4RA Unified Data Model (UDM) — their names, domains, table counts, and where they sit in the data-governance catalog. Use for questions about data governance, the UDM, or which projects share a data model.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(): Promise<ToolResult> {
+    return {
+      data: {
+        total: governanceProjects.length,
+        projects: governanceProjects.map((p) => ({
+          slug: p.slug,
+          application: p.application,
+          domain: p.domain,
+          repository: p.repository,
+          tableCount: p.tableCount,
+          canonicalUdmCount: p.canonicalUdmCount,
+          projectExtensionCount: p.projectExtensionCount,
+          url: `/standards/data-model/projects/${p.slug}`,
+        })),
+      },
+      canonicalUrl: "/standards/data-model",
+      links: governanceProjects.map((p) => ({
+        label: p.application,
+        url: `/standards/data-model/projects/${p.slug}`,
+      })),
+    };
+  },
+};

--- a/lib/agent/tools/list-open-issues.ts
+++ b/lib/agent/tools/list-open-issues.ts
@@ -1,0 +1,85 @@
+// list_open_issues — open GitHub issues from the AISPEG repo, optionally
+// filtered by label substring. Backed by lib/github.ts (Next ISR-cached
+// 5min) so repeated calls in the same window are cheap.
+
+import "server-only";
+import { fetchIssues, type GitHubIssue } from "@/lib/github";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const DEFAULT_LIMIT = 15;
+const MAX_LIMIT = 50;
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function summarize(issue: GitHubIssue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    state: issue.state,
+    labels: issue.labels.map((l) => l.name),
+    milestone: issue.milestone?.title ?? null,
+    createdAt: issue.created_at,
+    url: issue.html_url,
+  };
+}
+
+export const listOpenIssuesTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_open_issues",
+      description:
+        "Return open GitHub issues from the IIDS site repository (ui-insight/AISPEG). Optionally filter by label substring. Use for 'what's tracked as open work?' or 'what bugs are open?'",
+      parameters: {
+        type: "object",
+        properties: {
+          label: {
+            type: "string",
+            description:
+              "Optional case-insensitive substring match against label names (e.g. 'bug', 'agent', 'priority-medium').",
+          },
+          limit: {
+            type: "integer",
+            description: `Maximum issues to return. Default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}.`,
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const label = pickString(rawArgs, "label");
+    const limitRaw = rawArgs.limit;
+    const limit =
+      typeof limitRaw === "number" && Number.isFinite(limitRaw)
+        ? Math.min(Math.max(1, limitRaw), MAX_LIMIT)
+        : DEFAULT_LIMIT;
+
+    const all = await fetchIssues();
+    const open = all.filter((i) => i.state === "open");
+    const matched = label
+      ? open.filter((i) =>
+          i.labels.some((l) => l.name.toLowerCase().includes(label.toLowerCase()))
+        )
+      : open;
+    const trimmed = matched.slice(0, limit);
+
+    return {
+      data: {
+        repo: "ui-insight/AISPEG",
+        totalOpen: open.length,
+        totalMatched: matched.length,
+        returned: trimmed.length,
+        issues: trimmed.map(summarize),
+      },
+      canonicalUrl: "https://github.com/ui-insight/AISPEG/issues",
+      links: trimmed.map((i) => ({
+        label: `#${i.number} ${i.title.slice(0, 60)}`,
+        url: i.html_url,
+      })),
+    };
+  },
+};

--- a/lib/agent/tools/list-projects-for-priority.ts
+++ b/lib/agent/tools/list-projects-for-priority.ts
@@ -1,0 +1,72 @@
+// list_projects_for_priority — reverse lookup: which portfolio projects
+// have declared alignment with a given strategic-plan priority?
+
+import "server-only";
+import { getProjectsForPriority } from "@/lib/strategic-plan/project-alignment";
+import { getPriority } from "@/lib/strategic-plan/catalog";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const listProjectsForPriorityTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_projects_for_priority",
+      description:
+        "Return the portfolio projects that have declared alignment with a given Strategic Plan priority code. Useful for 'which projects advance priority A.1?' or 'who's working on student success goals?'",
+      parameters: {
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description: "Priority code (e.g. 'A.1', 'D.3').",
+          },
+        },
+        required: ["code"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const codeRaw = pickString(rawArgs, "code");
+    if (!codeRaw) {
+      return {
+        data: { error: "code is required" },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    const code = codeRaw.toUpperCase();
+    const priority = getPriority(code);
+    if (!priority) {
+      return {
+        data: { found: false, code },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    const aligned = getProjectsForPriority(code);
+    const priorityUrl = `/standards/strategic-plan/priorities/${code}`;
+    return {
+      data: {
+        found: true,
+        priority: { code: priority.code, text: priority.text, pillar: priority.pillar },
+        totalAligned: aligned.length,
+        projects: aligned.map((p) => ({
+          slug: p.slug,
+          name: p.name,
+          tagline: p.tagline,
+          status: p.status,
+          homeUnits: p.homeUnits,
+          ownerNames: p.ownerNames,
+          url: `/portfolio/${p.slug}`,
+        })),
+        priorityUrl,
+      },
+      canonicalUrl: priorityUrl,
+      links: aligned.map((p) => ({ label: p.name, url: `/portfolio/${p.slug}` })),
+    };
+  },
+};

--- a/lib/agent/tools/lookup-pillar.ts
+++ b/lib/agent/tools/lookup-pillar.ts
@@ -1,0 +1,67 @@
+// lookup_pillar — strategic-plan pillar by code (A, B, C, D, E).
+// Sourced from the vendored strategic-plan catalog.
+
+import "server-only";
+import { pillars, getPillar } from "@/lib/strategic-plan/catalog";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupPillarTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_pillar",
+      description:
+        "Fetch one University of Idaho Strategic Plan pillar by code. Returns name and the priorities it contains. Codes are single letters: A (Ignite Student Success), B, C, D, E. Use list_site_areas if you don't know the codes.",
+      parameters: {
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description: "Pillar code: a single uppercase letter A through E.",
+          },
+        },
+        required: ["code"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const codeRaw = pickString(rawArgs, "code");
+    if (!codeRaw) {
+      return {
+        data: {
+          error: "code is required",
+          availableCodes: pillars.map((p) => p.code),
+        },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    const code = codeRaw.toUpperCase();
+    const pillar = getPillar(code);
+    if (!pillar) {
+      return {
+        data: {
+          found: false,
+          code,
+          availableCodes: pillars.map((p) => p.code),
+        },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    return {
+      data: {
+        found: true,
+        code: pillar.code,
+        name: pillar.name,
+        priorities: pillar.priorities,
+        url: `/standards/strategic-plan/pillars/${pillar.code}`,
+      },
+      canonicalUrl: `/standards/strategic-plan/pillars/${pillar.code}`,
+    };
+  },
+};

--- a/lib/agent/tools/lookup-priority.ts
+++ b/lib/agent/tools/lookup-priority.ts
@@ -1,0 +1,72 @@
+// lookup_priority — strategic-plan priority by code (e.g. A.1, D.3).
+
+import "server-only";
+import { getPillar, getPriority, priorities } from "@/lib/strategic-plan/catalog";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupPriorityTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_priority",
+      description:
+        "Fetch one University of Idaho Strategic Plan priority by code. Returns the full priority text and the parent pillar. Codes have the form 'A.1', 'B.3', etc.",
+      parameters: {
+        type: "object",
+        properties: {
+          code: {
+            type: "string",
+            description:
+              "Priority code in the form '<letter>.<number>' (e.g. 'A.1', 'D.3').",
+          },
+        },
+        required: ["code"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const codeRaw = pickString(rawArgs, "code");
+    if (!codeRaw) {
+      return {
+        data: {
+          error: "code is required",
+          availableCodes: priorities.map((p) => p.code),
+        },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    const code = codeRaw.toUpperCase();
+    const priority = getPriority(code);
+    if (!priority) {
+      return {
+        data: {
+          found: false,
+          code,
+          availableCodes: priorities.map((p) => p.code),
+        },
+        canonicalUrl: "/standards/strategic-plan",
+      };
+    }
+    const parent = getPillar(priority.pillar);
+    return {
+      data: {
+        found: true,
+        code: priority.code,
+        text: priority.text,
+        pillar: {
+          code: priority.pillar,
+          name: parent?.name ?? null,
+          url: `/standards/strategic-plan/pillars/${priority.pillar}`,
+        },
+        url: `/standards/strategic-plan/priorities/${priority.code}`,
+      },
+      canonicalUrl: `/standards/strategic-plan/priorities/${priority.code}`,
+    };
+  },
+};

--- a/lib/agent/tools/lookup-udm-table.ts
+++ b/lib/agent/tools/lookup-udm-table.ts
@@ -1,0 +1,76 @@
+// lookup_udm_table — fetch the columns + classification for one table
+// in the AI4RA Unified Data Model catalog.
+
+import "server-only";
+import { tables as governanceTables } from "@/lib/governance/catalog";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupUdmTableTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_udm_table",
+      description:
+        "Fetch a single Unified Data Model table by project slug and table name. Returns columns (name, type, FK), classification (canonical-udm vs project-extension), and the canonical URL. Use when the user asks about specific tables, schemas, or columns in a governed project.",
+      parameters: {
+        type: "object",
+        properties: {
+          project: {
+            type: "string",
+            description:
+              "Project slug from list_governance_projects (e.g. 'audit-dashboard', 'openera', 'processmapping').",
+          },
+          table: {
+            type: "string",
+            description:
+              "Table name (case-insensitive, exact match). Examples: 'AuditReport', 'Observation', 'Project'.",
+          },
+        },
+        required: ["project", "table"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const project = pickString(rawArgs, "project");
+    const table = pickString(rawArgs, "table");
+    if (!project || !table) {
+      return {
+        data: { error: "project and table are required" },
+        canonicalUrl: "/standards/data-model",
+      };
+    }
+    const wanted = table.toLowerCase();
+    const found = governanceTables.find(
+      (t) => t.project === project && t.name.toLowerCase() === wanted
+    );
+    if (!found) {
+      return {
+        data: { found: false, project, table },
+        canonicalUrl: `/standards/data-model/tables`,
+      };
+    }
+    const url = `/standards/data-model/tables/${project}/${found.name}`;
+    return {
+      data: {
+        found: true,
+        project,
+        name: found.name,
+        kind: found.kind,
+        classification: found.classification,
+        description: found.description ?? null,
+        modelClass: found.modelClass ?? null,
+        columns: found.columns,
+        uniqueConstraints: found.uniqueConstraints,
+        relationships: found.relationships,
+        url,
+      },
+      canonicalUrl: url,
+    };
+  },
+};

--- a/lib/agent/tools/search-issues.ts
+++ b/lib/agent/tools/search-issues.ts
@@ -1,0 +1,96 @@
+// search_issues — case-insensitive substring search across GitHub issue
+// titles in the AISPEG repo. Uses the same cached fetchIssues() backing
+// list_open_issues / get_issue.
+
+import "server-only";
+import { fetchIssues, type GitHubIssue } from "@/lib/github";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 30;
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function summarize(issue: GitHubIssue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    state: issue.state,
+    labels: issue.labels.map((l) => l.name),
+    milestone: issue.milestone?.title ?? null,
+    createdAt: issue.created_at,
+    url: issue.html_url,
+  };
+}
+
+export const searchIssuesTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "search_issues",
+      description:
+        "Search GitHub issues in the IIDS site repository (ui-insight/AISPEG) by title substring. Includes both open and closed issues by default; restrict with the `state` filter.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Required. Case-insensitive substring matched against issue titles.",
+          },
+          state: {
+            type: "string",
+            enum: ["open", "closed", "all"],
+            description: "Restrict by issue state. Defaults to 'all'.",
+          },
+          limit: {
+            type: "integer",
+            description: `Maximum issues to return. Default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}.`,
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const query = pickString(rawArgs, "query");
+    if (!query) {
+      return {
+        data: { error: "query is required" },
+        canonicalUrl: "https://github.com/ui-insight/AISPEG/issues",
+      };
+    }
+    const stateRaw = pickString(rawArgs, "state");
+    const state = stateRaw === "open" || stateRaw === "closed" ? stateRaw : "all";
+    const limitRaw = rawArgs.limit;
+    const limit =
+      typeof limitRaw === "number" && Number.isFinite(limitRaw)
+        ? Math.min(Math.max(1, limitRaw), MAX_LIMIT)
+        : DEFAULT_LIMIT;
+
+    const all = await fetchIssues();
+    const filtered = all.filter((i) => {
+      if (state !== "all" && i.state !== state) return false;
+      return i.title.toLowerCase().includes(query.toLowerCase());
+    });
+    const trimmed = filtered.slice(0, limit);
+
+    return {
+      data: {
+        query,
+        state,
+        totalMatched: filtered.length,
+        returned: trimmed.length,
+        issues: trimmed.map(summarize),
+      },
+      canonicalUrl: "https://github.com/ui-insight/AISPEG/issues",
+      links: trimmed.map((i) => ({
+        label: `#${i.number} ${i.title.slice(0, 60)}`,
+        url: i.html_url,
+      })),
+    };
+  },
+};

--- a/lib/agent/tools/search-vocabulary.ts
+++ b/lib/agent/tools/search-vocabulary.ts
@@ -1,0 +1,98 @@
+// search_vocabulary — find controlled-vocabulary groups by domain or
+// by value. Returns matching groups with their values and canonical URLs.
+
+import "server-only";
+import { vocabularyGroups } from "@/lib/governance/vocabularies";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const MAX_RESULTS = 10;
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function matches(haystack: string, needle: string): boolean {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+export const searchVocabularyTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "search_vocabulary",
+      description:
+        "Search controlled-vocabulary groups across the AI4RA Unified Data Model. Match by domain (e.g. 'audit', 'openera'), group name, or value code/label. Returns matching groups with all their values and the canonical /standards/data-model/vocabularies URL.",
+      parameters: {
+        type: "object",
+        properties: {
+          domain: {
+            type: "string",
+            description:
+              "Substring match against the vocabulary's domain (e.g. 'audit', 'openera', 'ucm').",
+          },
+          group: {
+            type: "string",
+            description:
+              "Substring match against the group name (e.g. 'ReportType', 'ObservationStatus').",
+          },
+          value: {
+            type: "string",
+            description:
+              "Substring match against any value's code or label inside the group.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const domain = pickString(rawArgs, "domain");
+    const group = pickString(rawArgs, "group");
+    const value = pickString(rawArgs, "value");
+
+    if (!domain && !group && !value) {
+      return {
+        data: {
+          error:
+            "At least one of domain, group, or value is required to avoid dumping the entire vocabulary catalog.",
+        },
+        canonicalUrl: "/standards/data-model/vocabularies",
+      };
+    }
+
+    const matched = vocabularyGroups.filter((g) => {
+      if (domain && !matches(g.domain, domain)) return false;
+      if (group && !matches(g.group, group)) return false;
+      if (value) {
+        const hit = g.values.some(
+          (v) => matches(v.code, value) || matches(v.label, value)
+        );
+        if (!hit) return false;
+      }
+      return true;
+    });
+
+    const trimmed = matched.slice(0, MAX_RESULTS);
+
+    return {
+      data: {
+        totalMatched: matched.length,
+        returned: trimmed.length,
+        groups: trimmed.map((g) => ({
+          domain: g.domain,
+          application: g.application,
+          group: g.group,
+          description: g.description ?? null,
+          values: g.values,
+          url: `/standards/data-model/vocabularies/${g.domain}/${g.group}`,
+        })),
+      },
+      canonicalUrl: "/standards/data-model/vocabularies",
+      links: trimmed.map((g) => ({
+        label: `${g.domain}/${g.group}`,
+        url: `/standards/data-model/vocabularies/${g.domain}/${g.group}`,
+      })),
+    };
+  },
+};

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -14,6 +14,8 @@ export interface GitHubIssue {
   labels: GitHubLabel[];
   html_url: string;
   created_at: string;
+  /** Body markdown — populated only by fetchIssue(); omitted from list endpoints. */
+  body?: string | null;
   milestone?: {
     title: string;
   } | null;
@@ -56,6 +58,39 @@ export async function fetchIssues(): Promise<GitHubIssue[]> {
   } catch (error) {
     console.error("Failed to fetch GitHub issues:", error);
     return [];
+  }
+}
+
+/**
+ * Fetch a single issue by number, including its body. Used by the
+ * conversational agent's get_issue tool. Same 5-minute ISR cache.
+ */
+export async function fetchIssue(
+  number: number
+): Promise<GitHubIssue | null> {
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+    };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const res = await fetch(`${API}/${number}`, {
+      next: { revalidate: 300 },
+      headers,
+    });
+    if (!res.ok) {
+      if (res.status !== 404) {
+        console.error(`GitHub API error: ${res.status} ${res.statusText}`);
+      }
+      return null;
+    }
+    const data = (await res.json()) as GitHubIssue & { pull_request?: unknown };
+    if ("pull_request" in data && data.pull_request) return null;
+    return data;
+  } catch (error) {
+    console.error(`Failed to fetch GitHub issue #${number}:`, error);
+    return null;
   }
 }
 


### PR DESCRIPTION
Closes #115. Fifth slice of Epic #107 — covers the three remaining data surfaces (Data Governance Explorer, Strategic Plan Alignment Explorer, GitHub Issues).

## Summary

Adds 9 read-only tools to the agent registry. Combined with [#242](https://github.com/ui-insight/AISPEG/pull/242), the agent now has tool coverage of every site surface listed in Epic #107.

| Tool | Purpose | Cites |
|---|---|---|
| `list_governance_projects` | Apps in the AI4RA UDM catalog | `/standards/data-model` |
| `lookup_udm_table` | Columns + relationships for one table | `/standards/data-model/tables/<project>/<table>` |
| `search_vocabulary` | Vocabulary groups by domain / group / value | `/standards/data-model/vocabularies/<domain>/<group>` |
| `lookup_pillar` | One pillar (A-E) with its priorities | `/standards/strategic-plan/pillars/<code>` |
| `lookup_priority` | One priority by code (e.g. A.1, D.3) | `/standards/strategic-plan/priorities/<code>` |
| `list_projects_for_priority` | Reverse alignment lookup | `/standards/strategic-plan/priorities/<code>` |
| `list_open_issues` | Open GitHub issues, optional label filter | `https://github.com/ui-insight/AISPEG/issues` |
| `search_issues` | Title-substring across all issues | per-issue GitHub URLs |
| `get_issue` | Single issue with body excerpt | per-issue GitHub URL |

Supporting changes:

- New `fetchIssue(number)` helper in `lib/github.ts` for single-issue fetch with body (5-min ISR cache, same as `fetchIssues`).
- System prompt's tool-selection cheatsheet extended with sections for each new category.
- Golden set extended with 9 new cases (32 → 41 total).

## Acceptance criteria

- [x] All 9 tools register and execute
- [x] Strategic-plan tools degrade gracefully if `getPillar` / `getPriority` return undefined (return `{ found: false, code, availableCodes }` rather than throwing)
- [x] GitHub tools respect rate limits (use `lib/github.ts` with 5-min ISR cache; never N+1 single-issue calls when a list will do)
- [x] Eval golden set extended with at least 2 Q&A pairs per tool category
- [x] Citation accuracy stays ≥ 80% — actual: **100%** (33/33), tool-selection 94.3% (33/35), overall 95.1% (39/41)

## Eval baseline (qwen2.5:72b, 41 cases)

```
Tool-selection:       94.3%  (33/35)
Citation accuracy:    100.0%  (33/33)
Refusal correctness:  100.0%  (6/6)
Overall pass:         95.1%  (39/41)
```

### Two known false positives

Both failures are over-specified test cases — the model found valid alternative paths:

- `report-presidential-brief` ("What's in the February 2026 presidential brief?") — model went straight to `list_reports` (which already includes the brief's abstract) instead of `list_reports → get_report`. Answer was correct and grounded.
- `site-areas-where-is-strategic-plan` ("Where would I find strategic-plan alignment information?") — model called `lookup_pillar` / `lookup_priority` directly instead of `list_site_areas`. The strategic-plan tools are reasonable entry points for the question.

Tracking as a follow-up to extend the eval framework with acceptable-OR semantics (`anyOf: ["list_reports", "get_report"]`). Reluctant to reword the cases — they exercise real user phrasings.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run eval:agent` against live MindRouter — all four thresholds met (39/41, exit 0)
- [ ] Reviewer: try the chat widget on `/standards/strategic-plan` with each new category — e.g. *"Tell me about Pillar B"*, *"Which projects advance priority A.1?"*, *"What's in issue #107?"*, *"What ReportType values are in the audit vocabulary?"*

## Out of scope (per slice #115)

- Internal-tier visibility (slice #109) — all tools return public-tier data only.
- Observability / rate limiting / outage handling — slice #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)