### PR TITLE
Conversational agent observability: rate limit + query log + /internal/agent-log (#113)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ MINDROUTER_API_KEY=
 # Optional overrides; defaults are baked into lib/mindrouter.ts.
 # MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu
 # MINDROUTER_MODEL=qwen2.5:72b
+
+# Salt for hashing client IPs in the agent_queries log. Set per
+# environment so hashes can't be precomputed against a known IP space.
+# A random 32+ char string is fine.
+AGENT_LOG_SALT=

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { runAgent } from "@/lib/agent/loop";
-import type { ChatMessage } from "@/lib/mindrouter";
+import { checkRate } from "@/lib/agent/rate-limit";
+import { hashIp, logAgentQuery, type AgentOutcome } from "@/lib/agent/log";
+import { currentMindRouterModel, type ChatMessage } from "@/lib/mindrouter";
 
 const ALLOWED_HISTORY_ROLES = new Set(["user", "assistant"]);
 const MAX_HISTORY_MESSAGES = 20;
 const MAX_MESSAGE_LENGTH = 2000;
+
+const MINDROUTER_OUTAGE_MESSAGE =
+  "The AI assistant is temporarily unavailable. Try browsing /portfolio for active projects, or refresh and try again in a moment.";
 
 interface RawHistoryMessage {
   role?: unknown;
@@ -30,47 +35,209 @@ function sanitizeHistory(history: unknown): ChatMessage[] {
   return out;
 }
 
+function clientIp(request: NextRequest): string {
+  // Trust the leftmost X-Forwarded-For entry when behind the reverse
+  // proxy on openera.insight.uidaho.edu; fall back to the request's
+  // direct IP otherwise.
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = request.headers.get("x-real-ip");
+  if (real) return real;
+  return "unknown";
+}
+
 export async function POST(request: NextRequest) {
+  const startedAt = Date.now();
+  const ip = clientIp(request);
+  const ipHash = hashIp(ip);
+  const audience = "public" as const;
+  const model = currentMindRouterModel();
+
+  let message = "";
+  let history: ChatMessage[] = [];
   try {
     const body = await request.json();
-    const message =
-      typeof body?.message === "string" ? body.message.trim() : "";
-
-    if (message.length === 0) {
-      return NextResponse.json(
-        { error: "message is required" },
-        { status: 400 }
-      );
-    }
-    if (message.length > MAX_MESSAGE_LENGTH) {
-      return NextResponse.json(
-        { error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer` },
-        { status: 400 }
-      );
-    }
-
-    if (!process.env.MINDROUTER_API_KEY) {
-      return NextResponse.json(
-        {
-          error:
-            "The conversational agent is not configured on this environment.",
-          unconfigured: true,
-        },
-        { status: 503 }
-      );
-    }
-
-    const result = await runAgent({
+    message = typeof body?.message === "string" ? body.message.trim() : "";
+    history = sanitizeHistory(body?.history);
+  } catch {
+    return finalize({
+      ipHash,
+      audience,
       message,
-      history: sanitizeHistory(body?.history),
-      audience: "public",
+      latencyMs: Date.now() - startedAt,
+      outcome: "bad_request",
+      httpStatus: 400,
+      errorMessage: "Request body was not valid JSON.",
+      payload: { error: "Invalid JSON body" },
+      model,
     });
-
-    return NextResponse.json(result);
-  } catch (error) {
-    console.error("POST /api/ask error:", error);
-    const message =
-      error instanceof Error ? error.message : "agent request failed";
-    return NextResponse.json({ error: message }, { status: 500 });
   }
+
+  if (message.length === 0) {
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome: "bad_request",
+      httpStatus: 400,
+      errorMessage: "missing message",
+      payload: { error: "message is required" },
+      model,
+    });
+  }
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome: "bad_request",
+      httpStatus: 400,
+      errorMessage: "message too long",
+      payload: {
+        error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer`,
+      },
+      model,
+    });
+  }
+
+  const rate = checkRate(ipHash, audience);
+  if (!rate.allowed) {
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome: "rate_limited",
+      httpStatus: 429,
+      errorMessage: `over ${rate.limit}/hr`,
+      payload: {
+        error: `Rate limit exceeded (${rate.limit}/hour). Try again in ${rate.retryAfterSeconds} seconds.`,
+        retryAfterSeconds: rate.retryAfterSeconds,
+      },
+      headers: {
+        "Retry-After": String(rate.retryAfterSeconds),
+        "X-RateLimit-Limit": String(rate.limit),
+        "X-RateLimit-Remaining": "0",
+      },
+      model,
+    });
+  }
+
+  if (!process.env.MINDROUTER_API_KEY) {
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome: "unconfigured",
+      httpStatus: 503,
+      errorMessage: "MINDROUTER_API_KEY not set",
+      payload: {
+        error:
+          "The conversational agent is not configured on this environment.",
+        unconfigured: true,
+      },
+      model,
+    });
+  }
+
+  try {
+    const result = await runAgent({ message, history, audience });
+    const toolErrors = result.toolCalls.filter((t) => !t.ok);
+    const outcome: AgentOutcome =
+      toolErrors.length > 0 ? "tool_error" : "ok";
+    const errorMessage =
+      toolErrors.length > 0
+        ? toolErrors.map((t) => `${t.name}: ${t.error}`).join("; ")
+        : null;
+
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome,
+      httpStatus: 200,
+      response: result.response,
+      toolCalls: result.toolCalls.map((t) => t.name),
+      citationCount: result.citations.length,
+      iterations: result.iterations,
+      truncated: result.truncated,
+      errorMessage,
+      payload: result,
+      model,
+    });
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message : String(error);
+    // Tool errors are caught inside the loop and turned into refusals,
+    // so anything bubbling out of runAgent is a MindRouter-side failure
+    // (network error, auth error, malformed response, etc.).
+    console.error("POST /api/ask error:", error);
+    return finalize({
+      ipHash,
+      audience,
+      message,
+      latencyMs: Date.now() - startedAt,
+      outcome: "mindrouter_error",
+      httpStatus: 200, // friendly fallback — don't 500 the chat widget
+      response: MINDROUTER_OUTAGE_MESSAGE,
+      payload: {
+        response: MINDROUTER_OUTAGE_MESSAGE,
+        citations: [],
+        toolCalls: [],
+        iterations: 0,
+        truncated: false,
+        fallback: true,
+      },
+      errorMessage: detail,
+      model,
+    });
+  }
+}
+
+interface FinalizeArgs {
+  ipHash: string;
+  audience: "public" | "internal";
+  message: string;
+  latencyMs: number;
+  outcome: AgentOutcome;
+  httpStatus: number;
+  response?: string | null;
+  toolCalls?: string[];
+  citationCount?: number;
+  iterations?: number;
+  truncated?: boolean;
+  errorMessage?: string | null;
+  payload: unknown;
+  headers?: Record<string, string>;
+  model: string;
+}
+
+async function finalize(args: FinalizeArgs): Promise<NextResponse> {
+  // Log first; if logging fails it just no-ops (logAgentQuery never throws).
+  await logAgentQuery({
+    ipHash: args.ipHash,
+    audience: args.audience,
+    message: args.message,
+    response: args.response ?? null,
+    toolCalls: args.toolCalls ?? [],
+    citationCount: args.citationCount ?? 0,
+    iterations: args.iterations ?? 0,
+    truncated: args.truncated ?? false,
+    latencyMs: args.latencyMs,
+    outcome: args.outcome,
+    httpStatus: args.httpStatus,
+    model: args.model,
+    errorMessage: args.errorMessage ?? null,
+  });
+  return NextResponse.json(args.payload, {
+    status: args.httpStatus,
+    headers: args.headers,
+  });
 }

--- a/app/internal/agent-log/page.tsx
+++ b/app/internal/agent-log/page.tsx
@@ -1,0 +1,316 @@
+// /internal/agent-log — auth-gated review of recent /api/ask traffic.
+// Slice #113 of Epic #107.
+//
+// The middleware (middleware.ts) gates /internal/* with basic auth.
+// Reads from agent_queries (Migration 009).
+
+import Link from "next/link";
+import {
+  getAgentSummary,
+  listRecentAgentQueries,
+  type AgentLogRow,
+  type AgentOutcome,
+} from "@/lib/agent/log";
+
+export const dynamic = "force-dynamic";
+
+interface SearchParams {
+  outcome?: string;
+  sort?: string;
+  limit?: string;
+}
+
+const VALID_OUTCOMES: AgentOutcome[] = [
+  "ok",
+  "mindrouter_error",
+  "tool_error",
+  "rate_limited",
+  "bad_request",
+  "unconfigured",
+  "internal_error",
+];
+
+const OUTCOME_TONE: Record<AgentOutcome, string> = {
+  ok: "bg-emerald-50 text-emerald-700",
+  mindrouter_error: "bg-amber-50 text-amber-800",
+  tool_error: "bg-amber-50 text-amber-800",
+  rate_limited: "bg-amber-50 text-amber-800",
+  bad_request: "bg-gray-100 text-gray-700",
+  unconfigured: "bg-gray-100 text-gray-700",
+  internal_error: "bg-rose-50 text-rose-700",
+};
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+function truncate(s: string | null, n: number): string {
+  if (!s) return "—";
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+function FilterChip({
+  label,
+  href,
+  active,
+}: {
+  label: string;
+  href: string;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      className={
+        "rounded-full border px-3 py-1 text-xs font-medium transition-colors " +
+        (active
+          ? "border-ui-charcoal bg-ui-charcoal text-brand-white"
+          : "border-gray-200 bg-white text-gray-700 hover:border-ui-gold/40")
+      }
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default async function AgentLogPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const sp = await searchParams;
+  const outcomeFilter = VALID_OUTCOMES.includes(sp.outcome as AgentOutcome)
+    ? (sp.outcome as AgentOutcome)
+    : undefined;
+  const sort = sp.sort === "slowest" ? "slowest" : "recent";
+  const limit = (() => {
+    const parsed = sp.limit ? Number.parseInt(sp.limit, 10) : 100;
+    return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 500) : 100;
+  })();
+
+  let summary: Awaited<ReturnType<typeof getAgentSummary>> | null = null;
+  let rows: AgentLogRow[] = [];
+  let error: string | null = null;
+
+  try {
+    [summary, rows] = await Promise.all([
+      getAgentSummary(),
+      listRecentAgentQueries({ outcome: outcomeFilter, sort, limit }),
+    ]);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  function buildHref(updates: Partial<SearchParams>): string {
+    const next = new URLSearchParams();
+    const merged = { outcome: outcomeFilter, sort, limit: String(limit), ...updates };
+    if (merged.outcome) next.set("outcome", merged.outcome);
+    if (merged.sort && merged.sort !== "recent") next.set("sort", merged.sort);
+    if (merged.limit && merged.limit !== "100") next.set("limit", merged.limit);
+    const qs = next.toString();
+    return qs ? `/internal/agent-log?${qs}` : "/internal/agent-log";
+  }
+
+  return (
+    <div className="space-y-10">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          IIDS Internal · Agent log
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+          Conversational agent traffic
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-relaxed text-gray-700">
+          Recent queries to <code>/api/ask</code>, logged via Migration 009.
+          IPs are stored as a salted SHA-256 hash, not raw addresses.
+          Use this view to see what stakeholders are asking, where the
+          agent is failing, and where to tune the system prompt or add
+          tool coverage.
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-800">
+          <p className="font-semibold">Couldn&apos;t load agent log.</p>
+          <p className="mt-1">{error}</p>
+          <p className="mt-2 text-xs text-rose-700">
+            Migration 009 may not be applied to this database — run{" "}
+            <code>npm run migrate</code> against the dev DB.
+          </p>
+        </div>
+      )}
+
+      {summary && (
+        <section className="grid gap-4 md:grid-cols-4">
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Last 24h
+            </p>
+            <p className="mt-1 text-3xl font-black text-ui-charcoal">
+              {summary.total24h}
+            </p>
+            <p className="mt-2 text-xs text-gray-500">queries</p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Median latency (24h)
+            </p>
+            <p className="mt-1 text-3xl font-black text-ui-charcoal">
+              {(summary.p50LatencyMs / 1000).toFixed(1)}s
+            </p>
+            <p className="mt-2 text-xs text-gray-500">
+              p95 {(summary.p95LatencyMs / 1000).toFixed(1)}s
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Successes (24h)
+            </p>
+            <p className="mt-1 text-3xl font-black text-emerald-700">
+              {summary.byOutcome.ok ?? 0}
+            </p>
+          </div>
+          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Failures (24h)
+            </p>
+            <p className="mt-1 text-3xl font-black text-rose-700">
+              {Object.entries(summary.byOutcome)
+                .filter(([k]) => k !== "ok")
+                .reduce((sum, [, n]) => sum + (n ?? 0), 0)}
+            </p>
+            <p className="mt-2 text-xs text-gray-500">
+              {(summary.byOutcome.mindrouter_error ?? 0)} MindRouter ·{" "}
+              {(summary.byOutcome.tool_error ?? 0)} tool ·{" "}
+              {(summary.byOutcome.rate_limited ?? 0)} rate-limited
+            </p>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="mr-1 text-xs font-medium uppercase tracking-wider text-gray-500">
+            Outcome:
+          </span>
+          <FilterChip
+            label="All"
+            href={buildHref({ outcome: undefined })}
+            active={!outcomeFilter}
+          />
+          {VALID_OUTCOMES.map((o) => (
+            <FilterChip
+              key={o}
+              label={o.replace(/_/g, " ")}
+              href={buildHref({ outcome: o })}
+              active={outcomeFilter === o}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="mr-1 text-xs font-medium uppercase tracking-wider text-gray-500">
+            Sort:
+          </span>
+          <FilterChip
+            label="Most recent"
+            href={buildHref({ sort: "recent" })}
+            active={sort === "recent"}
+          />
+          <FilterChip
+            label="Slowest first"
+            href={buildHref({ sort: "slowest" })}
+            active={sort === "slowest"}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        {rows.length === 0 && !error && (
+          <p className="text-sm text-gray-600">
+            No queries logged yet for the current filter.
+          </p>
+        )}
+        {rows.map((r) => (
+          <article
+            key={r.id}
+            className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm"
+          >
+            <header className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 pb-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={
+                    "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium " +
+                    OUTCOME_TONE[r.outcome]
+                  }
+                >
+                  {r.outcome}
+                </span>
+                <span className="text-xs text-gray-500">
+                  HTTP {r.httpStatus} · {r.latencyMs} ms · {r.iterations} iter
+                  {r.truncated ? " (truncated)" : ""}
+                </span>
+              </div>
+              <span className="text-xs text-gray-500">{fmtDate(r.createdAt)}</span>
+            </header>
+
+            <div className="mt-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+                User
+              </p>
+              <p className="whitespace-pre-wrap text-sm text-ink">
+                {truncate(r.message, 600)}
+              </p>
+            </div>
+
+            <div className="mt-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+                Assistant
+              </p>
+              <p className="whitespace-pre-wrap text-sm text-ink">
+                {truncate(r.response, 1200)}
+              </p>
+            </div>
+
+            <div className="mt-3 grid gap-2 text-xs text-gray-600 md:grid-cols-3">
+              <div>
+                <span className="font-medium text-gray-500">Tools:</span>{" "}
+                {r.toolCalls.length === 0 ? (
+                  <span className="text-gray-400">none</span>
+                ) : (
+                  r.toolCalls.join(", ")
+                )}
+              </div>
+              <div>
+                <span className="font-medium text-gray-500">Citations:</span>{" "}
+                {r.citationCount}
+              </div>
+              <div>
+                <span className="font-medium text-gray-500">Model:</span>{" "}
+                <code className="text-[11px]">{r.model ?? "—"}</code>
+              </div>
+            </div>
+
+            {r.errorMessage && (
+              <div className="mt-3 rounded-md bg-rose-50 px-3 py-2 text-xs text-rose-800">
+                <span className="font-medium">Error:</span> {r.errorMessage}
+              </div>
+            )}
+          </article>
+        ))}
+      </section>
+
+      <p className="text-xs text-gray-500">
+        IPs are stored as <code>SHA-256(ip:AGENT_LOG_SALT)</code>. Set{" "}
+        <code>AGENT_LOG_SALT</code> per environment to avoid hash
+        precomputation against a known IP space.
+      </p>
+    </div>
+  );
+}

--- a/app/internal/page.tsx
+++ b/app/internal/page.tsx
@@ -62,6 +62,23 @@ export default async function InternalHome() {
         </Link>
       </section>
 
+      <section className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/internal/agent-log"
+          className="group rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md md:col-span-2"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            Conversational agent
+          </p>
+          <p className="mt-1 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            Agent traffic &amp; failures &rarr;
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            Recent /api/ask queries, tool calls, latency, and errors
+          </p>
+        </Link>
+      </section>
+
       <section className="rounded-xl border border-dashed border-gray-300 bg-white/50 p-6">
         <h2 className="text-base font-semibold text-ui-charcoal">
           Coming in Sprint 3

--- a/db/migrations/009_agent_queries.sql
+++ b/db/migrations/009_agent_queries.sql
@@ -1,0 +1,62 @@
+-- Migration 009: agent_queries log
+--
+-- Slice #113 of Epic #107 (conversational agent observability). Captures
+-- every /api/ask invocation for offline review at /internal/agent-log.
+-- Stores anonymised IP hashes (not raw IPs) so review and rate-limiting
+-- can happen without keeping PII at rest.
+--
+-- Retention is unbounded for now. If the table grows unwieldy, add a
+-- per-row retention policy later (e.g. drop after 90 days) — the schema
+-- is intentionally simple to make that easy.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_queries (
+  id              BIGSERIAL PRIMARY KEY,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- SHA-256 of `<ip>:<AGENT_LOG_SALT>`. Hex digest, 64 chars. Salt comes
+  -- from the AGENT_LOG_SALT env var; a per-deployment value keeps the
+  -- hash from being precomputed against a known IP space.
+  ip_hash         TEXT NOT NULL,
+  -- Audience tier the request was scoped to. Mirrors lib/agent loop's
+  -- Audience type ('public' | 'internal').
+  audience        TEXT NOT NULL CHECK (audience IN ('public', 'internal')),
+  -- Verbatim user message. Capped at 2000 chars by the route handler.
+  message         TEXT NOT NULL,
+  -- Final assistant text. Null if the request errored before we got one.
+  response        TEXT,
+  -- Names of tools the agent invoked, in call order. Empty array on
+  -- refusal-without-tool-call cases.
+  tool_calls      TEXT[] NOT NULL DEFAULT '{}',
+  -- Number of citation entries the loop returned.
+  citation_count  INTEGER NOT NULL DEFAULT 0,
+  -- How many loop iterations the request used.
+  iterations      INTEGER NOT NULL DEFAULT 0,
+  -- True if the loop hit MAX_ITERATIONS without producing a final answer
+  -- and was forced to synthesise.
+  truncated       BOOLEAN NOT NULL DEFAULT FALSE,
+  -- Latency in milliseconds, route entry to JSON response.
+  latency_ms      INTEGER NOT NULL,
+  -- One of: 'ok', 'mindrouter_error', 'tool_error', 'rate_limited',
+  -- 'bad_request', 'unconfigured', 'internal_error'. Lets the review
+  -- surface group failures without parsing the message.
+  outcome         TEXT NOT NULL,
+  -- HTTP status the route handler returned.
+  http_status     INTEGER NOT NULL,
+  -- Model identifier used for this request.
+  model           TEXT,
+  -- Free-form error message when outcome != 'ok'.
+  error_message   TEXT
+);
+
+-- Reverse-chron review on the log page hits this constantly.
+CREATE INDEX IF NOT EXISTS agent_queries_created_at_idx
+  ON agent_queries (created_at DESC);
+
+-- Per-IP rate-limit lookups: count rows for a given hash since N minutes
+-- ago. The rate limiter currently runs in-process, but querying directly
+-- from the table is the durable fallback if we move multi-instance.
+CREATE INDEX IF NOT EXISTS agent_queries_ip_hash_idx
+  ON agent_queries (ip_hash, created_at);
+
+COMMIT;

--- a/lib/agent/log.ts
+++ b/lib/agent/log.ts
@@ -1,0 +1,211 @@
+// agent_queries logger — Slice #113 of Epic #107.
+//
+// Captures every /api/ask invocation for offline review at
+// /internal/agent-log. IP addresses are stored only as a SHA-256 hash
+// of `<ip>:<AGENT_LOG_SALT>` so the log carries no PII at rest.
+
+import "server-only";
+import { createHash } from "node:crypto";
+import { query } from "@/lib/db";
+
+export type AgentOutcome =
+  | "ok"
+  | "mindrouter_error"
+  | "tool_error"
+  | "rate_limited"
+  | "bad_request"
+  | "unconfigured"
+  | "internal_error";
+
+export interface AgentLogRow {
+  id: string;
+  createdAt: string;
+  ipHash: string;
+  audience: "public" | "internal";
+  message: string;
+  response: string | null;
+  toolCalls: string[];
+  citationCount: number;
+  iterations: number;
+  truncated: boolean;
+  latencyMs: number;
+  outcome: AgentOutcome;
+  httpStatus: number;
+  model: string | null;
+  errorMessage: string | null;
+}
+
+export interface InsertAgentQuery {
+  ipHash: string;
+  audience: "public" | "internal";
+  message: string;
+  response?: string | null;
+  toolCalls?: string[];
+  citationCount?: number;
+  iterations?: number;
+  truncated?: boolean;
+  latencyMs: number;
+  outcome: AgentOutcome;
+  httpStatus: number;
+  model?: string | null;
+  errorMessage?: string | null;
+}
+
+const FALLBACK_SALT = "aispeg-agent-default-salt";
+
+/**
+ * Hash a client IP with the per-deployment salt. Returns a 64-char hex
+ * digest. Same IP + same salt always produces the same hash, so the
+ * rate-limiter can key on it.
+ */
+export function hashIp(ip: string): string {
+  const salt = process.env.AGENT_LOG_SALT || FALLBACK_SALT;
+  return createHash("sha256").update(`${ip}:${salt}`).digest("hex");
+}
+
+/**
+ * Best-effort log insert. Never throws — we don't want a logging failure
+ * to fail the user's request.
+ */
+export async function logAgentQuery(row: InsertAgentQuery): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO agent_queries
+         (ip_hash, audience, message, response, tool_calls,
+          citation_count, iterations, truncated, latency_ms,
+          outcome, http_status, model, error_message)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+      [
+        row.ipHash,
+        row.audience,
+        row.message,
+        row.response ?? null,
+        row.toolCalls ?? [],
+        row.citationCount ?? 0,
+        row.iterations ?? 0,
+        row.truncated ?? false,
+        row.latencyMs,
+        row.outcome,
+        row.httpStatus,
+        row.model ?? null,
+        row.errorMessage ?? null,
+      ]
+    );
+  } catch (err) {
+    console.error("logAgentQuery failed:", err);
+  }
+}
+
+interface RawAgentRow {
+  id: string;
+  created_at: Date | string;
+  ip_hash: string;
+  audience: "public" | "internal";
+  message: string;
+  response: string | null;
+  tool_calls: string[];
+  citation_count: number;
+  iterations: number;
+  truncated: boolean;
+  latency_ms: number;
+  outcome: AgentOutcome;
+  http_status: number;
+  model: string | null;
+  error_message: string | null;
+}
+
+function rowToLog(row: RawAgentRow): AgentLogRow {
+  return {
+    id: String(row.id),
+    createdAt:
+      row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    ipHash: row.ip_hash,
+    audience: row.audience,
+    message: row.message,
+    response: row.response,
+    toolCalls: row.tool_calls ?? [],
+    citationCount: row.citation_count,
+    iterations: row.iterations,
+    truncated: row.truncated,
+    latencyMs: row.latency_ms,
+    outcome: row.outcome,
+    httpStatus: row.http_status,
+    model: row.model,
+    errorMessage: row.error_message,
+  };
+}
+
+export interface ListRecentOptions {
+  limit?: number;
+  outcome?: AgentOutcome;
+  sort?: "recent" | "slowest";
+}
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+export async function listRecentAgentQueries(
+  opts: ListRecentOptions = {}
+): Promise<AgentLogRow[]> {
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const sort = opts.sort ?? "recent";
+  const orderClause =
+    sort === "slowest"
+      ? "ORDER BY latency_ms DESC, created_at DESC"
+      : "ORDER BY created_at DESC";
+
+  const params: unknown[] = [];
+  let where = "";
+  if (opts.outcome) {
+    params.push(opts.outcome);
+    where = `WHERE outcome = $${params.length}`;
+  }
+  params.push(limit);
+
+  const rows = await query<RawAgentRow>(
+    `SELECT * FROM agent_queries ${where} ${orderClause} LIMIT $${params.length}`,
+    params
+  );
+  return rows.map(rowToLog);
+}
+
+export interface AgentSummary {
+  total24h: number;
+  byOutcome: Partial<Record<AgentOutcome, number>>;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+}
+
+export async function getAgentSummary(): Promise<AgentSummary> {
+  const rows = await query<{
+    total: string;
+    p50: string;
+    p95: string;
+  }>(
+    `SELECT
+       COUNT(*)::text AS total,
+       COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_ms), 0)::text AS p50,
+       COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::text AS p95
+     FROM agent_queries
+     WHERE created_at >= now() - interval '24 hours'`
+  );
+  const head = rows[0];
+
+  const byRows = await query<{ outcome: AgentOutcome; n: string }>(
+    `SELECT outcome, COUNT(*)::text AS n
+       FROM agent_queries
+      WHERE created_at >= now() - interval '24 hours'
+      GROUP BY outcome`
+  );
+  const byOutcome: Partial<Record<AgentOutcome, number>> = {};
+  for (const r of byRows) {
+    byOutcome[r.outcome] = Number.parseInt(r.n, 10);
+  }
+
+  return {
+    total24h: head ? Number.parseInt(head.total, 10) : 0,
+    byOutcome,
+    p50LatencyMs: head ? Math.round(Number.parseFloat(head.p50)) : 0,
+    p95LatencyMs: head ? Math.round(Number.parseFloat(head.p95)) : 0,
+  };
+}

--- a/lib/agent/rate-limit.ts
+++ b/lib/agent/rate-limit.ts
@@ -1,0 +1,65 @@
+// Per-IP-hash rate limiter — Slice #113 of Epic #107.
+//
+// Sliding-window in memory. Acceptable for a single-instance deployment
+// (the current dev / prod containers are one instance each). If the
+// stack ever scales horizontally, swap this for a Postgres COUNT(*)
+// against agent_queries — the index in Migration 009 covers exactly
+// that query.
+
+import "server-only";
+
+const PUBLIC_LIMIT_PER_HOUR = 60;
+const INTERNAL_LIMIT_PER_HOUR = 600;
+const WINDOW_MS = 60 * 60 * 1000;
+
+type Bucket = { stamps: number[] };
+const buckets = new Map<string, Bucket>();
+
+export interface RateCheck {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  retryAfterSeconds: number;
+}
+
+function limitFor(audience: "public" | "internal"): number {
+  return audience === "internal" ? INTERNAL_LIMIT_PER_HOUR : PUBLIC_LIMIT_PER_HOUR;
+}
+
+export function checkRate(
+  ipHash: string,
+  audience: "public" | "internal"
+): RateCheck {
+  const now = Date.now();
+  const limit = limitFor(audience);
+  const cutoff = now - WINDOW_MS;
+
+  const key = `${audience}:${ipHash}`;
+  const bucket = buckets.get(key) ?? { stamps: [] };
+  // Drop stamps older than the window.
+  const fresh = bucket.stamps.filter((t) => t >= cutoff);
+
+  if (fresh.length >= limit) {
+    const oldest = fresh[0]!;
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((oldest + WINDOW_MS - now) / 1000)
+    );
+    buckets.set(key, { stamps: fresh });
+    return { allowed: false, limit, remaining: 0, retryAfterSeconds };
+  }
+
+  fresh.push(now);
+  buckets.set(key, { stamps: fresh });
+  return {
+    allowed: true,
+    limit,
+    remaining: Math.max(0, limit - fresh.length),
+    retryAfterSeconds: 0,
+  };
+}
+
+// Exposed for tests; resets the in-memory buckets.
+export function resetRateLimiterForTesting(): void {
+  buckets.clear();
+}

--- a/lib/mindrouter.ts
+++ b/lib/mindrouter.ts
@@ -16,6 +16,11 @@ const MINDROUTER_KEY = process.env.MINDROUTER_API_KEY || "";
 // MINDROUTER_MODEL.
 const MINDROUTER_MODEL = process.env.MINDROUTER_MODEL || "qwen2.5:72b";
 
+/** The model identifier requests will be sent to. Used by the agent log. */
+export function currentMindRouterModel(): string {
+  return MINDROUTER_MODEL;
+}
+
 export interface ToolCall {
   id: string;
   type: "function";


### PR DESCRIPTION
Closes #113. **Final slice of Epic #107** — operationalises `/api/ask` with per-IP rate limiting, durable query logging, an auth-gated review surface, and clean MindRouter outage handling.

## Summary

- **Migration 009** adds the `agent_queries` table — anonymised IP hash (SHA-256 of `<ip>:<AGENT_LOG_SALT>`), tool calls, citation count, iteration count, latency, outcome, model, error message. Two indexes (created_at DESC, ip_hash + created_at) cover the review page and a durable rate-limit fallback path.
- **`lib/agent/rate-limit.ts`** — in-process sliding-window per-IP-hash counter. **60/hour** public, **600/hour** internal. Returns HTTP 429 with `Retry-After` + `X-RateLimit-*` headers.
- **`lib/agent/log.ts`** — `hashIp()`, `logAgentQuery()` (best-effort, never throws), `listRecentAgentQueries(filters)`, `getAgentSummary()` for the 24h totals + p50/p95 stat strip.
- **`app/api/ask/route.ts`** — rewritten to thread every code path through a `finalize()` that logs first then responds. Outcomes: `ok`, `bad_request`, `rate_limited`, `unconfigured`, `tool_error`, `mindrouter_error`. **MindRouter outage returns HTTP 200** with a friendly fallback message + `fallback: true` flag so the chat widget renders cleanly instead of throwing in the user's face.
- **`app/internal/agent-log/page.tsx`** — auth-gated review surface with a 24h summary strip, outcome + sort filters, and per-row detail cards. Linked from the `/internal` landing.
- **`AGENT_LOG_SALT`** documented in `.env.example`. `lib/mindrouter.ts` exports `currentMindRouterModel()` so log rows record which model produced each response.

## Acceptance criteria

- [x] Rate limit returns **HTTP 429** with informative body when exceeded (verified — 60 parallel requests trip the limit, 61st returns the canonical body)
- [x] All queries (success and failure) logged to `agent_queries` with anonymised IP hash
- [x] `/internal/agent-log` renders recent queries with response and tool calls visible (verified — summary stats + filter chips + per-row cards all render)
- [x] MindRouter outage returns user-friendly fallback, **not a 500 page** (verified — pointed `MINDROUTER_BASE_URL` at a dead host, got HTTP 200 with the fallback message)
- [x] Tool errors don't crash the request — clean refuse-to-answer (existing loop behaviour from #239 preserved; tool error rows are now classified as `tool_error` outcome)
- [x] **Migration 009** applied, schema documented in the migration header

## End-to-end verification (against the dev DB)

| Test | Outcome row | HTTP | Detail |
|---|---|---|---|
| *"What projects is IIDS working on?"* | `ok` | 200 | latency 35107ms, 11 citations, 1 tool call, model `qwen2.5:72b` |
| 60 parallel `/api/ask` POSTs, then 61st | `rate_limited` | 429 | body: *"Rate limit exceeded (60/hour). Try again in 3598 seconds."* |
| `MINDROUTER_BASE_URL=http://127.0.0.1:9` then valid query | `mindrouter_error` | 200 | fallback message, `fallback: true` flag, error: "fetch failed" |
| `/internal/agent-log` (basic auth) | — | 200 | summary stats + filter chips + per-row cards rendered |

## Important deploy step

> Per project memory, the dev `docker compose` deploy flow does NOT run migrations.

After this merges, **Migration 009 must be applied manually** to the dev (and eventually prod) DB before the next deploy:

```bash
ssh -fN -L 5433:localhost:5433 devops@openera.insight.uidaho.edu
DATABASE_URL=postgresql://aispeg:aispeg_secret@localhost:5433/aispeg_dev npm run migrate
```

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run migrate` against dev DB applies 009 cleanly
- [x] All four end-to-end scenarios above
- [ ] Reviewer: visit `/internal/agent-log` after deploy and confirm real public traffic shows up

## Out of scope

- Postgres-backed (multi-instance) rate limiting — the in-process limiter is fine for single-container deploys; the table index is in place for the durable fallback when the stack scales horizontally.
- Per-row retention policy on `agent_queries` — schema is intentionally simple to make a "drop after N days" follow-up trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)