### PR TITLE
Bump default MindRouter model to qwen/qwen3.6-27b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ BASIC_AUTH_PASS=
 MINDROUTER_API_KEY=
 # Optional overrides; defaults are baked into lib/mindrouter.ts.
 # MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu
-# MINDROUTER_MODEL=qwen2.5:72b
+# MINDROUTER_MODEL=qwen/qwen3.6-27b   # default; swap to qwen/qwen3.6-35b for lower latency
 
 # Salt for hashing client IPs in the agent_queries log. Set per
 # environment so hashes can't be precomputed against a known IP space.

--- a/lib/mindrouter.ts
+++ b/lib/mindrouter.ts
@@ -9,12 +9,13 @@
 const MINDROUTER_BASE =
   process.env.MINDROUTER_BASE_URL || "https://mindrouter.uidaho.edu";
 const MINDROUTER_KEY = process.env.MINDROUTER_API_KEY || "";
-// Default model picked from the live MindRouter registry on 2026-05-04.
-// Qwen2.5:72b is the strongest Qwen2.5 currently exposed and has well-
-// documented OpenAI-style tool-calling support — required for the
-// conversational agent loop in lib/agent/. Override per environment with
-// MINDROUTER_MODEL.
-const MINDROUTER_MODEL = process.env.MINDROUTER_MODEL || "qwen2.5:72b";
+// Default model. Bumped 2026-05-04 to qwen3.6-27b on Luke Sheneman's
+// (IIDS / MindRouter operator) recommendation — qwen2.5 is "old school";
+// qwen3.6-27b is the current "better" pick on the institutional
+// deployment. Sibling option: qwen/qwen3.6-35b ("faster"); set
+// MINDROUTER_MODEL to override per environment when latency outweighs
+// accuracy.
+const MINDROUTER_MODEL = process.env.MINDROUTER_MODEL || "qwen/qwen3.6-27b";
 
 /** The model identifier requests will be sent to. Used by the agent log. */
 export function currentMindRouterModel(): string {


### PR DESCRIPTION
Per Luke Sheneman (IIDS / MindRouter operator): qwen2.5 is "old school." `qwen/qwen3.6-27b` is the current "better" pick on the institutional deployment; `qwen/qwen3.6-35b` is the "faster" sibling. Defaulting to **27b** — accuracy is the contract for an agent whose behaviour is gated by strict citation. Overriding to 35b is a one-env-var change when latency outweighs accuracy.

## Eval result on qwen/qwen3.6-27b

```
Tool-selection:       100.0%  (35/35)
Citation accuracy:    100.0%  (33/33)
Refusal correctness:  100.0%  (6/6)
Overall pass:         100.0%  (41/41)
```

Both previously-known false positives — `report-presidential-brief` and `site-areas-where-is-strategic-plan` — now pass cleanly. The new model picks the expected tools without needing the cheatsheet to spell out every variant. (For comparison, qwen2.5:72b scored 95.1% overall on the same set in [#243](https://github.com/ui-insight/AISPEG/pull/243).)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run eval:agent` against live MindRouter — 41/41 (exit 0)
- [ ] After merge: bump dev host's `MINDROUTER_MODEL` env var to `qwen/qwen3.6-27b` and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)