### PR TITLE
Project Map: tighter arcs + curved right-side links; hide standards dates

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,11 +160,7 @@ export default async function Home() {
             <span className="font-semibold text-brand-black">
               {standards.outstanding}
             </span>{" "}
-            outstanding asks. Oldest is{" "}
-            <span className="font-semibold text-brand-black">
-              {standards.oldestOutstanding} days
-            </span>{" "}
-            old.{" "}
+            outstanding asks.{" "}
             <span className="font-semibold text-brand-black">
               {standards.counts.published}
             </span>{" "}

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -1,7 +1,6 @@
 import {
   standardsWatch,
   summary,
-  daysSince,
   type StandardsWatchItem,
   type StandardsWatchStatus,
 } from "@/lib/standards-watch";
@@ -30,22 +29,6 @@ function StatusChip({ status }: { status: StandardsWatchStatus }) {
   );
 }
 
-function DayCounter({ since, status }: { since: string; status: StandardsWatchStatus }) {
-  if (status === "published") return null;
-  const days = daysSince(since);
-  const tone =
-    days >= 90
-      ? "text-red-700"
-      : days >= 30
-      ? "text-orange-700"
-      : "text-gray-700";
-  return (
-    <span className={`text-xs font-medium ${tone}`}>
-      Day {days} since requested
-    </span>
-  );
-}
-
 function StandardRow({ item }: { item: StandardsWatchItem }) {
   return (
     <article className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
@@ -61,10 +44,6 @@ function StandardRow({ item }: { item: StandardsWatchItem }) {
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
             <StatusChip status={item.status} />
-            <DayCounter since={item.dateRequested} status={item.status} />
-            <span className="text-gray-400">
-              Requested {item.dateRequested}
-            </span>
             {item.responseUrl && (
               <a
                 href={item.responseUrl}
@@ -115,14 +94,12 @@ export default function StandardsWatchPage() {
         </h1>
         <p className="mt-3 max-w-3xl text-base leading-relaxed text-ink-muted">
           The institutional standards IIDS has formally requested from the
-          Office of Information Technology. Each entry shows the date
-          requested and elapsed time since. Entries move to{" "}
+          Office of Information Technology. Entries move to{" "}
           <span className="font-medium text-green-700">Published</span> as
           OIT releases them.
         </p>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-brand-black">
-          <span className="font-bold">{stats.oldestOutstanding} days</span>{" "}
-          since the oldest of <span className="font-bold">{stats.outstanding}</span>{" "}
+          <span className="font-bold">{stats.outstanding}</span>{" "}
           outstanding asks. <span className="font-bold">{stats.counts.published}</span>{" "}
           published.
         </p>

--- a/components/ProjectMap.tsx
+++ b/components/ProjectMap.tsx
@@ -94,14 +94,18 @@ interface Polar {
   angleDeg: number;
 }
 
+// Arc spans are intentionally narrower than 180° so node positions stay
+// clear of the central project column. Left = 130° (priorities + pillar
+// labels), right = 110° (work categories — tighter because category
+// labels are full phrases, not short codes).
 function leftArcAngle(i: number, n: number): number {
   if (n === 1) return 180;
-  return 260 - (i / (n - 1)) * 160;
+  return 245 - (i / (n - 1)) * 130;
 }
 
 function rightArcAngle(i: number, n: number): number {
   if (n === 1) return 0;
-  return -80 + (i / (n - 1)) * 160;
+  return -55 + (i / (n - 1)) * 110;
 }
 
 function polar(angleDeg: number, radius: number): Polar {
@@ -479,8 +483,13 @@ export default function ProjectMap() {
 
               const target = categoryPos.get(link.target);
               if (!target) return null;
+              // Mirror the left side: insert a control point at a
+              // smaller radius along the same angle as the target so
+              // the link draws as an arc, not a straight chord.
+              const control = polar(target.angleDeg, PILLAR_CENTROID_R);
               const points: Array<[number, number]> = [
                 [projRight, proj.y],
+                [control.x, control.y],
                 [target.x, target.y],
               ];
               const d = bundleLine(points) ?? "";


### PR DESCRIPTION
## Summary

- **/explore Project Map**: priority arc tightened 160°→130°, category arc tightened 160°→110° so end-of-arc nodes (e.g. `E.4`) no longer render under the central project column. Right-side links now use a control point at smaller radius along the target's angle, so they draw as arcs matching the left side instead of straight chords.
- **/standards + landing card**: removed rendered "Day X since requested" badges, the per-row "Requested {date}" line, the "X days since the oldest…" header callout, and the "Oldest is X days old" line on the landing-page Standards card. `dateRequested` stays in the data and `daysSince` / `oldestOutstanding` stay in `lib/standards-watch.ts`, so the DB and the `list-standards` / `get-standard` agent tools are unchanged.

## Test plan

- [x] `npm run build` clean
- [x] `/explore?view=map` at 1600×1400 — both arcs sit clear of the central project column; right-side links arc, no chords
- [x] `/standards` — no Day/Requested rows, no "X days since the oldest" header line; `outstanding` and `published` counts still render
- [x] `/` — Standards card reads "20 outstanding asks. 0 published." (no "Oldest is X days old")
- [ ] Hover/focus highlight still works across left + right edges (visual spot check on dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)