### PR TITLE
Landing: cut portfolio preview, ship steering-tile Home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,22 +7,12 @@ import {
 import { artifacts, sortedArtifacts } from "@/lib/artifacts";
 import { summary as standardsSummary } from "@/lib/standards-watch";
 
-// Editorial pick of three featured projects for the landing's
-// Work tile. Curated by IIDS — rotate when the work changes. There is
-// no automated freshness signal on Project yet (no lastUpdated
-// field; tracked for a future schema extension), so framing must stay
-// editorial: the order is curator's choice, not "most recent."
-const FEATURED_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
-
 export default async function Home() {
   const all = getPubliclyVisible();
   const projectCount = all.length;
   const homeUnitCount = new Set(all.flatMap((i) => i.homeUnits)).size;
   const mostRecent = sortedArtifacts()[0]?.dateLabel;
   const stageStats = stageBreakdown(all);
-  const featuredPicks = FEATURED_PICKS
-    .map((slug) => all.find((i) => i.slug === slug))
-    .filter((i): i is NonNullable<typeof i> => i !== undefined);
   const standards = standardsSummary();
   const reportCount = artifacts.length;
   const buildDate = new Date().toLocaleDateString("en-US", {
@@ -45,7 +35,7 @@ export default async function Home() {
           (IIDS), this site tracks AI projects &mdash; the discrete
           builds, pilots, and integrations &mdash; running across UI units.
         </p>
-        <p className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-1 text-sm text-ink-muted">
+        <p className="mt-6 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-ink-muted">
           <span>
             <span className="font-bold tabular-nums text-brand-black">
               {projectCount}
@@ -56,81 +46,67 @@ export default async function Home() {
             </span>{" "}
             home units
           </span>
-          {mostRecent && (
-            <>
-              <span aria-hidden className="text-brand-silver">
+          {stageStats.map((s) => (
+            <span key={s.stage} className="inline-flex items-baseline">
+              <span aria-hidden className="mr-2 text-brand-silver">
                 ·
               </span>
-              <span>
-                most recent update{" "}
-                <span className="font-bold text-brand-black">
-                  {mostRecent}
-                </span>
+              <span className="font-bold tabular-nums text-brand-black">
+                {s.count}
               </span>
-            </>
-          )}
-        </p>
-        {stageStats.length > 1 && (
-          <p className="mt-1 text-sm text-ink-muted">
-            {stageStats.map((s, idx) => (
-              <span key={s.stage}>
-                {idx > 0 && (
-                  <span aria-hidden className="text-brand-silver">
-                    {" · "}
-                  </span>
-                )}
-                <span className="font-bold tabular-nums text-brand-black">
-                  {s.count}
-                </span>{" "}
+              <span className="ml-1.5">
                 {PUBLIC_STAGE_LABEL[s.stage].toLowerCase()}
               </span>
-            ))}
-          </p>
-        )}
+            </span>
+          ))}
+        </p>
         <p className="mt-2 text-xs text-ink-subtle">
           As of {buildDate} (last deploy)
         </p>
       </section>
 
-      <section>
+      <section
+        aria-label="Where to go next"
+        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      >
         <Link
           href="/portfolio"
-          className="group block rounded-xl border border-hairline bg-white p-8 transition-shadow hover:shadow-md"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
         >
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
             Projects
           </p>
-          <h2 className="mt-2 text-2xl">
-            {projectCount} AI projects across UI units
-          </h2>
-          <p className="mt-2 text-sm text-ink-muted">
-            Projects, their operational owners, and current status.
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            AI projects across UI units
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            <span className="font-semibold text-brand-black">
+              {projectCount}
+            </span>{" "}
+            projects across{" "}
+            <span className="font-semibold text-brand-black">
+              {homeUnitCount}
+            </span>{" "}
+            home units. Operational owners and current status.
           </p>
-          <ul className="mt-6 divide-y divide-hairline border-y border-hairline">
-            {featuredPicks.map((p) => (
-              <li key={p.slug} className="py-3">
-                <p className="text-base font-semibold text-brand-black">
-                  {p.name}
-                </p>
-                <p className="mt-1 text-sm text-ink-muted">
-                  <em className="font-semibold text-brand-black">
-                    {p.operationalOwners[0].name}
-                  </em>
-                  {" · "}
-                  {p.homeUnits[0]}
-                </p>
-              </li>
-            ))}
-          </ul>
-          <div className="mt-6">
-            <span className="inline-flex items-center gap-2 rounded-lg bg-brand-gold px-5 py-2.5 text-sm font-bold text-brand-black transition-colors group-hover:bg-brand-gold-dark">
-              Explore the portfolio &rarr;
-            </span>
-          </div>
         </Link>
-      </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
+        <Link
+          href="/explore"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Explore
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            Browse by the kind of work
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            Find projects tackling documents, processes, reconciliation,
+            and more &mdash; or open the strategic-plan coverage map.
+          </p>
+        </Link>
+
         <Link
           href="/builder-guide"
           className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
@@ -179,9 +155,14 @@ export default async function Home() {
             Activity reports + briefs
           </h3>
           <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            <span className="font-semibold text-brand-black">{reportCount}</span>{" "}
+            <span className="font-semibold text-brand-black">
+              {reportCount}
+            </span>{" "}
             published. Latest:{" "}
-            <span className="font-semibold text-brand-black">{mostRecent}</span>.
+            <span className="font-semibold text-brand-black">
+              {mostRecent}
+            </span>
+            .
           </p>
         </Link>
       </section>


### PR DESCRIPTION
## Summary

- Cuts the portfolio-preview section from `app/page.tsx` (the 15-projects tile, 3 featured-project rows, and the gold "Explore the portfolio →" CTA) plus the `FEATURED_PICKS` constant. The previous landing duplicated `/portfolio`'s lede — clicking Home → Projects showed the same opening paragraph twice.
- Demotes the stat strip + stage breakdown to a single inline line: "15 projects across 11 home units · 6 building · 7 live · 2 tracked".
- Replaces the prior 3-tile small grid with a 5-tile equal-weight steering grid for Projects, Explore, Submit a Project, Standards, Reports. Tiles render in sidebar order, with eyebrows that match sidebar labels exactly and a one-line description plus a freshness signal where one exists (project + home-unit count, outstanding/published asks, report count + most-recent date).

## Test plan

- [x] `npm run build` passes
- [x] `/` no longer repeats the `/portfolio` opening paragraph
- [x] Stat strip + stage breakdown now on a single line
- [x] Five steering tiles render in sidebar order (Projects, Explore, Submit a Project, Standards, Reports)
- [x] No `FEATURED_PICKS`, no portfolio preview, no gold CTA on landing
- [x] No browser console errors
- [ ] Reviewer: sanity check the freshness copy on each tile reads correctly against current data

closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)