### PR TITLE
Home: restore hierarchy and warmth (Projects primary tile + Map secondary)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,13 @@ import {
 } from "@/lib/portfolio";
 import { artifacts, sortedArtifacts } from "@/lib/artifacts";
 import { summary as standardsSummary } from "@/lib/standards-watch";
+import { buildProjectMapGraph } from "@/lib/project-map-graph";
+
+// Editorial pick of three featured projects for the landing's primary
+// Projects tile. Curator's choice — rotate when the work changes. The
+// landing leads with these to put real owners in front of stakeholders;
+// the full inventory lives at /portfolio.
+const FEATURED_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
 
 export default async function Home() {
   const all = getPubliclyVisible();
@@ -15,6 +22,21 @@ export default async function Home() {
   const stageStats = stageBreakdown(all);
   const standards = standardsSummary();
   const reportCount = artifacts.length;
+  const featuredPicks = FEATURED_PICKS.map((slug) =>
+    all.find((i) => i.slug === slug),
+  ).filter((i): i is NonNullable<typeof i> => i !== undefined);
+
+  // Map freshness — count of strategic-plan priorities with no
+  // aligned project. Reuses the same graph adapter the map renders
+  // from so the count can never drift.
+  const graph = buildProjectMapGraph("public");
+  const linkedPriorities = new Set(
+    graph.links.filter((l) => l.side === "left").map((l) => l.target),
+  );
+  const uncoveredCount = graph.priorities.filter(
+    (p) => !linkedPriorities.has(p.code),
+  ).length;
+
   const buildDate = new Date().toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
@@ -65,32 +87,54 @@ export default async function Home() {
         </p>
       </section>
 
-      <section
-        aria-label="Where to go next"
-        className="grid gap-4 sm:grid-cols-2"
-      >
+      {/* Primary tile — Projects, with featured-project warmth signal.
+          Visually heavier than the secondary row and carries the gold
+          CTA per .impeccable.md (Pride Gold for the primary CTA). */}
+      <section>
         <Link
           href="/portfolio"
-          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+          className="group block rounded-xl border border-hairline bg-white p-6 transition-shadow hover:shadow-md sm:p-8"
         >
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
             Projects
           </p>
-          <h3 className="mt-1 text-base font-semibold text-brand-black">
+          <h2 className="mt-2 text-2xl font-black tracking-tight text-brand-black">
             AI projects across UI units
-          </h3>
+          </h2>
           <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            <span className="font-semibold text-brand-black">
-              {projectCount}
-            </span>{" "}
-            projects across{" "}
-            <span className="font-semibold text-brand-black">
-              {homeUnitCount}
-            </span>{" "}
-            home units. Operational owners and current status.
+            Operational owners, home units, and current status.
           </p>
+          <ul className="mt-6 divide-y divide-hairline border-y border-hairline">
+            {featuredPicks.map((p) => (
+              <li key={p.slug} className="py-3">
+                <p className="text-base font-semibold text-brand-black">
+                  {p.name}
+                </p>
+                <p className="mt-1 text-sm text-ink-muted">
+                  <em className="font-semibold not-italic text-brand-black">
+                    {p.operationalOwners[0].name}
+                  </em>
+                  {" · "}
+                  {p.homeUnits[0]}
+                </p>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6">
+            <span className="inline-flex items-center gap-1.5 rounded-md border-2 border-ui-gold bg-ui-gold/10 px-3.5 py-1.5 text-sm font-semibold text-brand-black transition-colors group-hover:bg-ui-gold/25">
+              Explore all {projectCount} projects &rarr;
+            </span>
+          </div>
         </Link>
+      </section>
 
+      {/* Secondary tile row — wayfinding to the four other primary
+          surfaces. Equal-weight to each other, smaller than the
+          primary Projects tile. */}
+      <section
+        aria-label="Where to go next"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      >
         <Link
           href="/builder-guide"
           className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
@@ -120,7 +164,7 @@ export default async function Home() {
             <span className="font-semibold text-brand-black">
               {standards.outstanding}
             </span>{" "}
-            outstanding asks.{" "}
+            outstanding.{" "}
             <span className="font-semibold text-brand-black">
               {standards.counts.published}
             </span>{" "}
@@ -147,6 +191,30 @@ export default async function Home() {
               {mostRecent}
             </span>
             .
+          </p>
+        </Link>
+
+        <Link
+          href="/standards/strategic-plan/map"
+          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+            Map
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-brand-black">
+            Strategic plan coverage
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            {uncoveredCount > 0 ? (
+              <>
+                <span className="font-semibold text-brand-black">
+                  {uncoveredCount}
+                </span>{" "}
+                priorit{uncoveredCount === 1 ? "y" : "ies"} uncovered.
+              </>
+            ) : (
+              <>All priorities covered.</>
+            )}
           </p>
         </Link>
       </section>


### PR DESCRIPTION
## Summary

Walks back part of [#254](https://github.com/ui-insight/AISPEG/pull/254) deliberately. The IA collision was the *lede duplication* (stat strip + project list rendered identically on Home and `/portfolio`); the fix in #254 over-corrected by flattening Home into four equal-weight tiles, losing the institutional warmth and the primary action signal.

This PR restores hierarchy without re-introducing the duplication.

## What changed

- **Primary tile** — Projects, full-width, restores `FEATURED_PICKS` (stratplan, audit-dashboard, vandalizer) with operational owners + home units. Gold-bordered "Explore all N projects →" CTA. The H2 is descriptive only ("AI projects across UI units"); the count is on the CTA, not as a duplicate lede.
- **Secondary tile row** — four small equal-weight tiles for Submit a Project, Standards, Reports, **Map**. The Map tile is new — points at `/standards/strategic-plan/map` (the surface promoted in [ADR 0003](https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0003-strategic-plan-map-home.md)) and surfaces "13 priorities uncovered" computed via `buildProjectMapGraph` so the count can never drift from the map page.
- **Stat strip** stays single-line per #254 — that was the real duplication, demotion is correct.

## Test plan

- [x] `npm run build` passes
- [x] Primary Projects tile is visually heavier than the secondary tiles
- [x] Three featured projects render with names + owners + home units
- [x] Gold "Explore all 15 projects →" CTA renders inside the primary tile
- [x] Secondary row has 4 tiles (Submit a Project, Standards, Reports, Map)
- [x] Map tile shows "13 priorities uncovered"
- [x] Stat strip stays on one line — no breakdown row regression
- [ ] Reviewer: spot-check that visiting Home → Projects no longer feels redundant (the primary tile is a curated sample, not a duplicate of the full inventory)

closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)