### PR TITLE
/portfolio: surface work-categories as a primary browse axis

### DIFF
--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -256,12 +256,89 @@ export default async function PortfolioPage({
         </div>
       </header>
 
+      {/* Browse-by-problem entry strip — categories are also reachable
+          via filter chips inside PortfolioFilters in spirit, but cold
+          visitors need a discoverable announcement that the by-problem
+          axis exists. ADR 0003 designated /portfolio's chips as the
+          home for this browse; this strip makes the claim visible.
+          Refinement (composing with stage/unit/blockers) lives in the
+          filter component below. Per #260. */}
+      <section aria-labelledby="browse-by-problem-heading">
+        <p
+          id="browse-by-problem-heading"
+          className="text-xs font-medium uppercase tracking-wider text-brand-silver"
+        >
+          Browse by problem
+        </p>
+        <p className="mt-1 max-w-2xl text-sm text-ink-muted">
+          The kinds of operational work AI is helping with at UI &mdash;
+          pick a category to filter the projects below.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {(() => {
+            const categoryHref = (cat: string | null) => {
+              const sp = new URLSearchParams();
+              if (selectedUnit) sp.set("unit", selectedUnit);
+              if (selectedStage) sp.set("stage", selectedStage);
+              if (selectedStatus) sp.set("status", selectedStatus);
+              if (cat) sp.set("category", cat);
+              if (blockersOnly) sp.set("blockers", "1");
+              if (sortMode !== "default") sp.set("sort", sortMode);
+              const qs = sp.toString();
+              return qs ? `/portfolio?${qs}` : "/portfolio";
+            };
+            const allActive = !selectedCategory;
+            return (
+              <>
+                <Link
+                  href={categoryHref(null)}
+                  className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                    allActive
+                      ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                      : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                  }`}
+                >
+                  All categories
+                  <span className="rounded-full bg-surface-alt px-1.5 py-0 text-[10px] font-semibold text-ink-subtle">
+                    {allApps.length}
+                  </span>
+                </Link>
+                {categoryOptions.map((c) => {
+                  const active = selectedCategory === c.value;
+                  return (
+                    <Link
+                      key={c.value}
+                      href={categoryHref(c.value)}
+                      className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                        active
+                          ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                          : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                      }`}
+                    >
+                      {c.label}
+                      <span
+                        className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${
+                          active
+                            ? "bg-brand-black/10 text-brand-black"
+                            : "bg-surface-alt text-ink-subtle"
+                        }`}
+                      >
+                        {c.count}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </>
+            );
+          })()}
+        </div>
+      </section>
+
       {/* Filter / sort UI */}
       <PortfolioFilters
         homeUnits={homeUnitOptions}
         stageOptions={stageFilterOptions}
         operationalOptions={operationalFilterOptions}
-        categories={categoryOptions}
         totalCount={allApps.length}
         filteredCount={filtered.length}
         blockerCount={blockerCount}

--- a/components/PortfolioFilters.tsx
+++ b/components/PortfolioFilters.tsx
@@ -17,11 +17,14 @@ import {
 // updates the searchParams via plain anchor navigation, which re-renders
 // the server component with the new filter applied.
 //
-// Layout follows the IA from #209: Stage stays default-visible (it's the
-// most-asked-about facet from ADR 0001). Home Unit and Category collapse
-// behind native <details> disclosures that auto-open whenever a filter
-// inside is active, so the active state is never hidden. Sort moves to a
-// native <select> aligned with the result-count line.
+// Layout follows the IA from #209 (with #260 update): Stage stays
+// default-visible (it's the most-asked-about facet from ADR 0001). Home
+// Unit collapses behind a native <details> disclosure that auto-opens
+// whenever a filter inside is active. Sort moves to a native <select>
+// aligned with the result-count line. Category lives in the dedicated
+// "Browse by problem" strip on the page (above this component) per
+// #260 — it's a discovery axis, not a refinement, so it doesn't belong
+// behind a disclosure here.
 
 interface FilterOption {
   label: string;
@@ -43,7 +46,6 @@ export interface PortfolioFiltersProps {
   homeUnits: FilterOption[];
   stageOptions: StageFilterOption[];
   operationalOptions: OperationalFilterOption[];
-  categories: FilterOption[];
   totalCount: number;
   filteredCount: number;
   blockerCount: number;
@@ -51,6 +53,9 @@ export interface PortfolioFiltersProps {
     unit: string | null;
     stage: PublicStage | null;
     status: ProjectStatus | null;
+    // Category is selected via the page-level "Browse by problem" strip
+    // (per #260). Kept in the prop so this component can preserve it in
+    // hrefs for the other filter chips.
     category: string | null;
     blockers: boolean;
     sort: "default" | "name" | "blockers";
@@ -146,7 +151,6 @@ export default function PortfolioFilters({
   homeUnits,
   stageOptions,
   operationalOptions,
-  categories,
   totalCount,
   filteredCount,
   blockerCount,
@@ -194,11 +198,6 @@ export default function PortfolioFilters({
   const activeUnitLabel =
     selected.unit && homeUnits.find((u) => u.value === selected.unit)?.label
       ? homeUnits.find((u) => u.value === selected.unit)!.label
-      : null;
-  const activeCategoryLabel =
-    selected.category &&
-    categories.find((c) => c.value === selected.category)?.label
-      ? categories.find((c) => c.value === selected.category)!.label
       : null;
 
   const sortOptions: { value: "default" | "name" | "blockers"; label: string }[] = [
@@ -350,28 +349,6 @@ export default function PortfolioFilters({
                 count={u.count}
                 active={selected.unit === u.value}
                 href={buildHref({ ...baseParams, unit: u.value })}
-              />
-            ))}
-          </div>
-        </FilterDisclosure>
-      </div>
-
-      {/* Category (collapsed by default; auto-opens when active) */}
-      <div className="mt-3">
-        <FilterDisclosure label="Category" activeLabel={activeCategoryLabel}>
-          <div className="flex flex-wrap gap-1.5">
-            <Chip
-              label="All"
-              active={!selected.category}
-              href={buildHref({ ...baseParams, category: null })}
-            />
-            {categories.map((c) => (
-              <Chip
-                key={c.value}
-                label={c.label}
-                count={c.count}
-                active={selected.category === c.value}
-                href={buildHref({ ...baseParams, category: c.value })}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary

Closes the gap between [ADR 0003](https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0003-strategic-plan-map-home.md)'s claim ("`/portfolio`'s filter chips own the by-problem browse") and the actual UI. Before this change, work-categories were hidden behind a collapsed-by-default `<details>` disclosure inside `PortfolioFilters` — a cold visitor with no prior knowledge of the taxonomy had no way to discover it.

## What changed

**Approach B from [#260](https://github.com/ui-insight/AISPEG/issues/260):** dedicated discovery strip above the filter UI on `/portfolio`. The strip is the entry point; the filter UI below remains the refinement tool.

- New `<section>` in `app/portfolio/page.tsx`: eyebrow "Browse by problem" + caption + 8 category chips with counts + an "All categories" pill.
- Hrefs preserve other filter state (unit, stage, status, blockers, sort) so picking a category composes with whatever the user already had selected.
- Active-state chip uses the same `border-ui-gold bg-ui-gold/15` treatment as the existing `PortfolioFilters` Chip — consistent visual vocabulary.
- Removed the redundant Category `FilterDisclosure` from `PortfolioFilters` along with the `categories` prop and `activeCategoryLabel` derivation. `selected.category` stays in the props so the other filter chips can preserve it in their hrefs.

## Test plan

- [x] `npm run build` passes
- [x] Strip renders above the filter UI with all 8 categories visible at page load (no disclosure to expand)
- [x] Counts are shown per category
- [x] Active-state styling on the strip matches the filter UI's chip vocabulary
- [x] No raw hex colors; native HTML + Tailwind only
- [ ] Reviewer (post-deploy verification on dev): clicking a category in the strip applies the \`?category=…\` URL param; clicking it again or "All categories" clears it
- [ ] Reviewer: composing — applying e.g. Stage: Live, then clicking a category in the strip, preserves the stage filter
- [ ] Reviewer: the Category disclosure is gone from the filter UI; Stage / Operational / Home unit still work

closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)