### PR TITLE
Home: OPS-first three-lane redesign (Use · Build · Evaluate)

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -5,26 +5,118 @@ It is read before any design work and keeps future design decisions coherent.
 
 ## Design Context
 
-### Users
+### Cold-start design constraint (governs everything below)
 
-Three overlapping audiences, prioritized in this order:
+**As of May 2026, the site has no returning users.** No member of the Senior
+Leadership Council uses it today. The audience won't visit until the site is
+*"so easy to use and so useful that it overcomes their laziness."* This is a
+cold-start problem, not a retention problem. Every public surface must be
+designed as a **first-touch artifact** — answer the visitor's question in the
+first viewport, then earn the click. The most important persona field is
+**trigger** (what gets them to open the link the first time), not frequency.
+Success is *"they bookmarked / forwarded / cited"*, not *"they read deeply."*
 
-1. **Institutional stakeholders** — the President, Provost, Deans, ORED leadership,
-   working-group members (Operational Excellence, Strategic Enrollment,
-   Faculty Development, Internal Audit). They view the site on desktop browsers
-   during business hours, often alongside other institutional tools. They are
-   AI-skeptical by default and well-calibrated against hype. The job-to-be-done
-   is *"help me quickly see what AI work is happening at UI, who owns each
-   piece, and what it means for my unit"*.
+### Users — Senior Leadership Council (primary audience, 44 design-relevant)
 
-2. **AISPEG and partner-unit practitioners** — IIDS staff, partner-unit
-   co-builders (SEM, UCM), AI4RA partners at SUU. They need operational detail:
-   schemas, relationships, governance artifacts, the ingestion portal. They
-   trust the tool and want density.
+Source data lives in `persona-mapping.csv` at the repo root (working file —
+not committed). Three primary buckets plus four cross-cutting interest
+overlays. Counts are populations on the SLC.
 
-3. **Peer institutions** — higher-ed AI/research-admin professionals reached
-   through REACH, NSF GRANTED, and AI4RA. They arrive through a public link
-   and are evaluating whether they can learn from or adopt what UI is doing.
+#### Base: EXEC (22)
+
+President, Provost, all VPs, Vice Provosts, Regional CEOs (Boise/CdA/IF),
+General Counsel & Chief Compliance Officer, Internal Audit head, ORED VP,
+Athletics AD, Comms ED, President's Senior Executive Assistant.
+
+| Field | Value |
+|---|---|
+| Trigger | Email from President / Provost / IIDS Director with a specific link · SLC agenda packet · Board materials reference · *"Read this before Friday's meeting"* |
+| JTBD (click) | *"Tell me in 60 seconds whether this is real institutional work and whether I should care."* |
+| JTBD (forward) | *"Can I confidently send this to a peer VP with a one-line endorsement?"* |
+| Vocabulary uses | initiative, strategic plan, operational excellence, governance, unit, named owner, outcome, risk, accountability |
+| Vocabulary does NOT recognize | MindRouter, DGX Stack, vendor submodule, catalog, vocabularies, priority code, taxonomy (in software sense), registry, drift CI, lifecycle stage tokens (*tracked / building*), repo names |
+| Bounce | Lede that doesn't answer "what is this and why" within one paragraph · technical jargon in first viewport · "we're working on it" without artifacts |
+| Next action | Forward · raise as agenda item · assign a staffer to "find where my unit fits" · bookmark for quarterly review |
+
+#### Base: DEAN (12)
+
+All college Deans + Library + Law + Graduate Studies + SHAMP. Note:
+SHAMP is overseen by Russell Baker (Associate Director, IOURMR) — the
+*Dean* role here is functional, not titular.
+
+| Field | Value |
+|---|---|
+| Trigger | Email from Provost / IIDS / Faculty Senate referencing AI · faculty member asking *"is this approved?"* · peer Dean mentioning a tool at Deans Council · advance materials for Deans Council |
+| JTBD (click) | *"Show me what's running in MY college, and what's running in OTHER colleges that my faculty might want."* |
+| JTBD (forward) | *"Can I send this to a department chair with 'check if your faculty want this'?"* |
+| Vocabulary uses | college, faculty, department chair, curriculum, research, student success, enrollment, workload, advising, accreditation |
+| Vocabulary does NOT recognize | same as EXEC — anything that smells like infrastructure |
+| Bounce | No way to filter by *home unit* / college · faculty/student angle absent · everything looks like operational/admin AI with no academic edge |
+| Next action | *"Talk to [named owner] about bringing X to my college"* · share with chair · raise at Deans Council |
+
+#### Base: SLC (10)
+
+Senior Director Marketing, AVP Finance/UI Foundation, AVP Operations,
+regional CEOs (where they're not VP-level), Director of Institutional
+Effectiveness, AVP Auxiliary Services, Director HR, Buyer Procurement,
+IIDS Director (Ken Udas).
+
+| Field | Value |
+|---|---|
+| Trigger | Their boss (a VP or President) cc'd them on a link · they're tasked with a specific operational question · vendor evaluation in flight · staffing a working group |
+| JTBD (click) | *"Find the project most adjacent to a problem my unit has, see who runs it, and decide whether to talk to them."* |
+| JTBD (forward) | *"Can I cite this to my boss as evidence we're tracking what UI is doing?"* |
+| Vocabulary uses | vendor, contract, workflow, tool, pilot, evaluation, integration, security, student data, FERPA, rollout, change management |
+| Vocabulary does NOT recognize | catalog drift, vocabulary registry, ADR, schema, submodule — but tolerates *more* technical detail than EXEC if it's signposted |
+| Bounce | Too high-level (no operational detail) · no contact pathway · can't tell what's mature vs. early · Submit-a-Project hidden under generic chrome |
+| Next action | Email named owner · loop into vendor evaluation · submit a project · bring to working group |
+
+#### Cross-cutting overlays (modify base JTBD when a person carries the interest)
+
+- **OPS (22 — dominant cross-cut, ~50% of the council).** *"Show me a tool I
+  can put in front of my staff next week, with low risk."* Wants live products
+  with adoption signals, governance posture, a clear pilot path. Bounces on
+  research-project framing.
+- **COMPLIANCE (9).** *"Show me how lifecycle, risk, and accountability are
+  handled here."* Wants standards published, lifecycle taxonomy visible,
+  audit trail, FERPA/HIPAA/IRB posture per project. Bounces on missing
+  governance framing.
+- **COMMS (8).** *"Give me defensible talking points and named owners I can
+  quote."* Wants clean one-liners, names spelled correctly, milestone dates,
+  no marketing-speak. Bounces on hype language and un-attributed claims.
+- **FINANCIAL (6 — hardest to satisfy).** *"Show me cost, ROI, who's funding
+  it, and what it returns."* Wants funding source, cost framing (in-house vs.
+  licensed), outcome metrics or honest *"measurement begins Q3 2026."*
+  Bounces on cost-blind framing.
+
+#### What this implies for design
+
+- **OPS is the dominant cross-cut.** Lead the home page with operational
+  utility (*"Tools your unit can use. Today."*), not strategic vision.
+- **DEAN's JTBD is currently unserved.** *"What's in MY college, what's in
+  OTHER colleges"* needs a home-unit / college axis at the landing level —
+  the existing *by-problem* filter does not satisfy it.
+- **Cold-start changes the metric.** Every section above the fold must be
+  screenshot-able and self-explanatory enough to forward to a peer.
+
+### Other audiences (deferred persona work)
+
+These exist but were not part of the May 2026 SLC persona pass.
+
+- **Strategic-plan working-group members** — Operational Excellence, Strategic
+  Enrollment, Faculty Development, Internal Audit. Some overlap the SLC list;
+  most do not. Roster collection deferred — handle as a separate persona pass
+  once rosters are confirmed.
+- **AISPEG and partner-unit practitioners** — IIDS staff, partner-unit
+  co-builders (SEM, UCM), AI4RA partners at SUU. They need operational
+  detail: schemas, relationships, governance artifacts, the ingestion portal.
+  They trust the tool and want density. Different design constraint from the
+  cold-start audiences above — they are repeat users by definition.
+- **Peer institutions** — higher-ed AI / research-admin professionals reached
+  through REACH, NSF GRANTED, and AI4RA. They arrive through a public link
+  and are evaluating whether they can learn from or adopt what UI is doing.
+  Cold-start applies; their bounce trigger is *"this looks early-stage, watch
+  later."*
 
 ### Brand Personality
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,34 +1,34 @@
 import Link from "next/link";
 import {
   getPubliclyVisible,
-  PUBLIC_STAGE_LABEL,
-  stageBreakdown,
+  computePublicStage,
+  type Project,
 } from "@/lib/portfolio";
 import { artifacts, sortedArtifacts } from "@/lib/artifacts";
 import { summary as standardsSummary } from "@/lib/standards-watch";
 import { buildProjectMapGraph } from "@/lib/project-map-graph";
 
-// Editorial pick of three featured projects for the landing's primary
-// Projects tile. Curator's choice — rotate when the work changes. The
-// landing leads with these to put real owners in front of stakeholders;
-// the full inventory lives at /portfolio.
-const FEATURED_PICKS = ["stratplan", "audit-dashboard", "vandalizer"];
-
 export default async function Home() {
   const all = getPubliclyVisible();
-  const projectCount = all.length;
-  const homeUnitCount = new Set(all.flatMap((i) => i.homeUnits)).size;
-  const mostRecent = sortedArtifacts()[0]?.dateLabel;
-  const stageStats = stageBreakdown(all);
+  // Stakeholder-facing live products only. AI infrastructure (MindRouter,
+  // DGX Stack, TEMPLATE-app) is excluded from the Use lane — it's a
+  // backend that powers the tools, not something a Dean or VP "uses."
+  // Surfaces in /portfolio under the ai-infrastructure category.
+  const liveProjects = all.filter(
+    (p) =>
+      computePublicStage(p.status) === "live" &&
+      !p.workCategories?.includes("ai-infrastructure"),
+  );
+  const buildingCount = all.filter(
+    (p) => computePublicStage(p.status) === "building",
+  ).length;
+  const totalUnits = new Set(all.flatMap((p) => p.homeUnits)).size;
+  const liveUnits = new Set(liveProjects.flatMap((p) => p.homeUnits)).size;
+
   const standards = standardsSummary();
   const reportCount = artifacts.length;
-  const featuredPicks = FEATURED_PICKS.map((slug) =>
-    all.find((i) => i.slug === slug),
-  ).filter((i): i is NonNullable<typeof i> => i !== undefined);
+  const mostRecent = sortedArtifacts()[0]?.dateLabel;
 
-  // Map freshness — count of strategic-plan priorities with no
-  // aligned project. Reuses the same graph adapter the map renders
-  // from so the count can never drift.
   const graph = buildProjectMapGraph("public");
   const linkedPriorities = new Set(
     graph.links.filter((l) => l.side === "left").map((l) => l.target),
@@ -44,180 +44,207 @@ export default async function Home() {
   });
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-12">
+      {/* Lede — OPS-first, named-and-owned framing */}
       <section>
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
           Institutional AI Initiative
         </p>
         <h1 className="mt-2 text-3xl font-black leading-tight sm:text-4xl">
-          AI work at the University of Idaho
+          Tools your unit can use today, plus the work that&rsquo;s coming
+          next.
         </h1>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
           Coordinated by the Institute for Interdisciplinary Data Sciences
-          (IIDS), this site tracks AI projects &mdash; the discrete
-          builds, pilots, and integrations &mdash; running across UI units.
+          (IIDS). Every project here is named, owned, and tracked &mdash;
+          with a real person you can talk to in a real UI unit.
         </p>
-        <p className="mt-6 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-ink-muted">
-          <span>
-            <span className="font-bold tabular-nums text-brand-black">
-              {projectCount}
-            </span>{" "}
-            projects across{" "}
-            <span className="font-bold tabular-nums text-brand-black">
-              {homeUnitCount}
-            </span>{" "}
-            home units
-          </span>
-          {stageStats.map((s) => (
-            <span key={s.stage} className="inline-flex items-baseline">
-              <span aria-hidden className="mr-2 text-brand-silver">
-                ·
-              </span>
-              <span className="font-bold tabular-nums text-brand-black">
-                {s.count}
-              </span>
-              <span className="ml-1.5">
-                {PUBLIC_STAGE_LABEL[s.stage].toLowerCase()}
-              </span>
-            </span>
-          ))}
+
+        {/* Coverage rollup — decision 3C */}
+        <p className="mt-6 text-sm text-ink-muted">
+          <span className="font-bold tabular-nums text-brand-black">
+            {liveProjects.length}
+          </span>{" "}
+          tools live across{" "}
+          <span className="font-bold tabular-nums text-brand-black">
+            {liveUnits}
+          </span>{" "}
+          of{" "}
+          <span className="font-bold tabular-nums text-brand-black">
+            {totalUnits}
+          </span>{" "}
+          UI units &middot;{" "}
+          <span className="font-bold tabular-nums text-brand-black">
+            {buildingCount}
+          </span>{" "}
+          more in build
         </p>
         <p className="mt-2 text-xs text-ink-subtle">
-          As of {buildDate} (last deploy)
+          Outcome measurement begins as projects move into production use.
+          Page reflects the inventory as of {buildDate}.
         </p>
       </section>
 
-      {/* Primary tile — Projects, with featured-project warmth signal.
-          Visually heavier than the secondary row and carries the gold
-          CTA per .impeccable.md (Pride Gold for the primary CTA). */}
+      {/* USE lane — dominant, OPS-first.
+          Lists every live project with name, tagline, owner, and an
+          Open or View affordance. Gold CTA at the foot routes to the
+          full inventory. */}
       <section>
-        <Link
-          href="/portfolio"
-          className="group block rounded-xl border border-hairline bg-white p-6 transition-shadow hover:shadow-md sm:p-8"
-        >
-          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            Projects
-          </p>
-          <h2 className="mt-2 text-2xl font-black tracking-tight text-brand-black">
-            AI projects across UI units
-          </h2>
-          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            Operational owners, home units, and current status.
-          </p>
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Use
+        </p>
+        <h2 className="mt-2 text-2xl font-black tracking-tight text-brand-black">
+          Open what&rsquo;s running
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
+          {liveProjects.length === 0
+            ? "No tools are live yet — the inventory is in build."
+            : `${liveProjects.length} tools are live across UI units. Click to open the tool, or contact the named owner.`}
+        </p>
+
+        {liveProjects.length > 0 && (
           <ul className="mt-6 divide-y divide-hairline border-y border-hairline">
-            {featuredPicks.map((p) => (
-              <li key={p.slug} className="py-3">
-                <p className="text-base font-semibold text-brand-black">
-                  {p.name}
-                </p>
-                <p className="mt-1 text-sm text-ink-muted">
-                  <em className="font-semibold not-italic text-brand-black">
-                    {p.operationalOwners[0].name}
-                  </em>
-                  {" · "}
-                  {p.homeUnits[0]}
-                </p>
-              </li>
+            {liveProjects.map((p) => (
+              <UseRow key={p.slug} project={p} />
             ))}
           </ul>
-          <div className="mt-6">
-            <span className="inline-flex items-center gap-1.5 rounded-md border-2 border-ui-gold bg-ui-gold/10 px-3.5 py-1.5 text-sm font-semibold text-brand-black transition-colors group-hover:bg-ui-gold/25">
-              Explore all {projectCount} projects &rarr;
-            </span>
-          </div>
-        </Link>
+        )}
+
+        <div className="mt-6">
+          <Link
+            href="/portfolio"
+            className="inline-flex items-center gap-1.5 rounded-md border-2 border-ui-gold bg-ui-gold/10 px-3.5 py-1.5 text-sm font-semibold text-brand-black transition-colors hover:bg-ui-gold/25"
+          >
+            Browse all {all.length} projects (live, building, tracked) &rarr;
+          </Link>
+        </div>
       </section>
 
-      {/* Secondary tile row — wayfinding to the four other primary
-          surfaces. Equal-weight to each other, smaller than the
-          primary Projects tile. */}
-      <section
-        aria-label="Where to go next"
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
-      >
+      {/* BUILD + EVALUATE — secondary lanes, side-by-side at desktop */}
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Link
           href="/builder-guide"
-          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
+          className="group block rounded-xl border border-hairline bg-white p-6 transition-shadow hover:shadow-md"
         >
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            Submit a Project
+            Build
           </p>
-          <h3 className="mt-1 text-base font-semibold text-brand-black">
-            9-step assessment
-          </h3>
-          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            Routes to a named IIDS owner with a 2-business-day SLA.
+          <h2 className="mt-2 text-xl font-black tracking-tight text-brand-black">
+            Have a problem AI could help with?
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-ink-muted">
+            A 9-step assessment routes your idea to a named IIDS owner with
+            a 2-business-day SLA. We tell you whether it&rsquo;s a candidate,
+            what&rsquo;s already adjacent, and what comes next.
+          </p>
+          <p className="mt-4 inline-flex items-center text-sm font-semibold text-brand-clearwater group-hover:underline">
+            Submit a project &rarr;
           </p>
         </Link>
 
-        <Link
-          href="/standards"
-          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
-        >
+        <div className="rounded-xl border border-hairline bg-white p-6">
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            Standards
+            Evaluate
           </p>
-          <h3 className="mt-1 text-base font-semibold text-brand-black">
-            Software + UX standards
-          </h3>
-          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            <span className="font-semibold text-brand-black">
-              {standards.outstanding}
-            </span>{" "}
-            outstanding.{" "}
-            <span className="font-semibold text-brand-black">
-              {standards.counts.published}
-            </span>{" "}
-            published.
-          </p>
-        </Link>
-
-        <Link
-          href="/reports"
-          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
-        >
-          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            Reports
-          </p>
-          <h3 className="mt-1 text-base font-semibold text-brand-black">
-            Activity reports + briefs
-          </h3>
-          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            <span className="font-semibold text-brand-black">
-              {reportCount}
-            </span>{" "}
-            published. Latest:{" "}
-            <span className="font-semibold text-brand-black">
-              {mostRecent}
-            </span>
-            .
-          </p>
-        </Link>
-
-        <Link
-          href="/standards/strategic-plan/map"
-          className="group block rounded-xl border border-hairline bg-white p-5 transition-shadow hover:shadow-md"
-        >
-          <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-            Map
-          </p>
-          <h3 className="mt-1 text-base font-semibold text-brand-black">
-            Strategic plan coverage
-          </h3>
-          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            {uncoveredCount > 0 ? (
-              <>
-                <span className="font-semibold text-brand-black">
-                  {uncoveredCount}
-                </span>{" "}
-                priorit{uncoveredCount === 1 ? "y" : "ies"} uncovered.
-              </>
-            ) : (
-              <>All priorities covered.</>
-            )}
-          </p>
-        </Link>
+          <h2 className="mt-2 text-xl font-black tracking-tight text-brand-black">
+            How we judge our own work
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm">
+            <li>
+              <Link
+                href="/standards"
+                className="group flex items-baseline justify-between gap-3"
+              >
+                <span className="font-semibold text-brand-black group-hover:text-brand-clearwater">
+                  Standards
+                </span>
+                <span className="text-xs text-ink-muted">
+                  {standards.counts.published} published &middot;{" "}
+                  {standards.outstanding} drafted
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/reports"
+                className="group flex items-baseline justify-between gap-3"
+              >
+                <span className="font-semibold text-brand-black group-hover:text-brand-clearwater">
+                  Reports
+                </span>
+                <span className="text-xs text-ink-muted">
+                  {reportCount} published
+                  {mostRecent ? ` · latest ${mostRecent}` : ""}
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/standards/strategic-plan/map"
+                className="group flex items-baseline justify-between gap-3"
+              >
+                <span className="font-semibold text-brand-black group-hover:text-brand-clearwater">
+                  Strategic plan coverage
+                </span>
+                <span className="text-xs text-ink-muted">
+                  {uncoveredCount > 0
+                    ? `${uncoveredCount} priorit${uncoveredCount === 1 ? "y" : "ies"} uncovered`
+                    : "All priorities covered"}
+                </span>
+              </Link>
+            </li>
+          </ul>
+        </div>
       </section>
     </div>
+  );
+}
+
+function UseRow({ project: p }: { project: Project }) {
+  const useLiveUrl = !!p.liveUrl && !p.liveUrlIsStaging;
+  const ownerName = p.operationalOwners[0]?.name ?? "IIDS";
+  const homeUnit = p.homeUnits[0] ?? "UI";
+
+  return (
+    <li className="py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p className="text-base font-semibold text-brand-black">{p.name}</p>
+          <p className="mt-0.5 text-sm leading-snug text-ink-muted">
+            {p.tagline}
+          </p>
+          <p className="mt-1.5 text-xs text-ink-muted">
+            <em className="font-semibold not-italic text-brand-black">
+              {ownerName}
+            </em>{" "}
+            &middot; {homeUnit}
+          </p>
+          {p.usageNote && (
+            <p className="mt-1 text-xs italic text-ink-subtle">
+              {p.usageNote}
+            </p>
+          )}
+        </div>
+        <div className="shrink-0">
+          {useLiveUrl ? (
+            <a
+              href={p.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-semibold text-brand-clearwater hover:underline"
+            >
+              Open &rarr;
+            </a>
+          ) : (
+            <Link
+              href={`/portfolio#${p.slug}`}
+              className="text-xs font-semibold text-brand-clearwater hover:underline"
+            >
+              View &rarr;
+            </Link>
+          )}
+        </div>
+      </div>
+    </li>
   );
 }

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -128,6 +128,12 @@ export interface Project {
   // lib/strategic-plan/catalog.ts; scripts/verify-portfolio.ts fails the
   // build on unknown codes. Ship empty; IIDS fills in over time.
   strategicPlanAlignment?: string[];
+
+  // Optional adoption proxy surfaced on the landing's Use lane. Use only
+  // where defensibly true — e.g. "Used in 3 SLC meetings since March 2026"
+  // or "Tracking 47 active observations." Omit if no honest signal exists.
+  // Renders italic, small, below the owner line.
+  usageNote?: string;
 }
 
 export const projects: Project[] = [


### PR DESCRIPTION
## Summary

- Reframes the home page around utility (*Tools your unit can use today, plus the work that's coming next*) to serve the SLC cold-start audience: every surface must be a forwardable, screenshot-able first-touch artifact.
- Three intent lanes replace the Projects-tile + 4-tile row. **Use** lists live stakeholder products by name + named owner + open-link; **Build** routes to Submit a Project; **Evaluate** condenses Standards · Reports · Strategic-plan coverage into a 3-row mini-table.
- **Use** lane filters out `ai-infrastructure`-tagged entries (MindRouter, DGX Stack, TEMPLATE-app) so stakeholders only see tools they can actually open. Coverage rollup *4 tools live across 4 of 11 UI units · 6 more in build* replaces the build-counting stat strip.
- `lib/portfolio.ts`: adds optional `usageNote?: string` field for per-project adoption proxies (empty initially; fill as defensible signals appear).
- `.impeccable.md`: rewritten Users section with canonical SLC persona taxonomy (3 bases × 4 overlays) + a cold-start design constraint that governs subsequent design work.

## Why

Per the May 2026 critique arc plateauing at 30/40, the prior steering-tile Home was structurally addressing the wrong problem (wayfinding for engaged users) when the actual problem is cold-start: no member of the Senior Leadership Council uses the site today. Persona work surfaced that **OPS interest dominates the SLC (22 of 44, ~50%)**, so the lede leads with operational utility instead of strategic vision. **DEAN's *by-college* JTBD remains unserved** — flagged for follow-up against `/portfolio`.

## Test plan

- [x] `npm run build` passes
- [x] `npm run verify:portfolio` passes (15 projects, 0 errors)
- [x] Dev preview renders cleanly at `/` with no console errors from the home page
- [x] Use lane shows 4 stakeholder tools with named owners + Open links
- [x] Coverage rollup numbers match `getPubliclyVisible()` reality
- [x] Build + Evaluate cards visible side-by-side at desktop, stacked at mobile (responsive: `lg:grid-cols-2`)
- [ ] Reviewer sanity-check on copy: lede phrasing, *"How we judge our own work"* heading on Evaluate
- [ ] Reviewer sanity-check on filter intent: confirm MindRouter/DGX/TEMPLATE belong in `/portfolio` rather than the Use lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)