### PR TITLE
Home: fix MindRouter URL + Use-lane liveUrl filter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,14 +10,15 @@ import { buildProjectMapGraph } from "@/lib/project-map-graph";
 
 export default async function Home() {
   const all = getPubliclyVisible();
-  // Stakeholder-facing live products only. AI infrastructure (MindRouter,
-  // DGX Stack, TEMPLATE-app) is excluded from the Use lane — it's a
-  // backend that powers the tools, not something a Dean or VP "uses."
-  // Surfaces in /portfolio under the ai-infrastructure category.
+  // Use lane requires an openable production URL. Live projects without a
+  // public liveUrl (e.g. dev infrastructure like DGX Stack and TEMPLATE-app)
+  // surface in /portfolio's full inventory but not here — "Use" means
+  // there is something for a stakeholder to click and open.
   const liveProjects = all.filter(
     (p) =>
       computePublicStage(p.status) === "live" &&
-      !p.workCategories?.includes("ai-infrastructure"),
+      !!p.liveUrl &&
+      !p.liveUrlIsStaging,
   );
   const buildingCount = all.filter(
     (p) => computePublicStage(p.status) === "building",
@@ -201,7 +202,6 @@ export default async function Home() {
 }
 
 function UseRow({ project: p }: { project: Project }) {
-  const useLiveUrl = !!p.liveUrl && !p.liveUrlIsStaging;
   const ownerName = p.operationalOwners[0]?.name ?? "IIDS";
   const homeUnit = p.homeUnits[0] ?? "UI";
 
@@ -225,25 +225,14 @@ function UseRow({ project: p }: { project: Project }) {
             </p>
           )}
         </div>
-        <div className="shrink-0">
-          {useLiveUrl ? (
-            <a
-              href={p.liveUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs font-semibold text-brand-clearwater hover:underline"
-            >
-              Open &rarr;
-            </a>
-          ) : (
-            <Link
-              href={`/portfolio#${p.slug}`}
-              className="text-xs font-semibold text-brand-clearwater hover:underline"
-            >
-              View &rarr;
-            </Link>
-          )}
-        </div>
+        <a
+          href={p.liveUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-xs font-semibold text-brand-clearwater hover:underline"
+        >
+          Open &rarr;
+        </a>
       </div>
     </li>
   );

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -476,7 +476,7 @@ export const projects: Project[] = [
     productionScope: "external",
     supportContact: "Luke Sheneman",
     repoUrl: "https://github.com/ui-insight/MindRouter",
-    liveUrl: "https://mindrouter.ai",
+    liveUrl: "https://mindrouter.uidaho.edu",
     operationalFunction:
       "Shared institutional LLM inference substrate. Every AI app at UI routes through it. Fair-share scheduling, quotas, audit trail, on-prem compute, cost control.",
     operationalExcellenceOutcome:


### PR DESCRIPTION
## Summary

- MindRouter's `liveUrl` was pointing at the open-source project page (`mindrouter.ai`) instead of the deployed UI instance (`mindrouter.uidaho.edu`). It is in active institutional use and belongs in the Use lane.
- Switches the Use-lane filter from *"exclude ai-infrastructure"* — which was a workaround for the wrong URL masquerading as a category problem — to the principled version: a project shows in Use only if it has a real, non-staging `liveUrl`.
- Effect on the home page: Use lane grows from 4 to 5 (MindRouter rejoins). DGX Stack and TEMPLATE-app stay out because they have no `liveUrl`. Coverage rollup updates to *5 tools live across 5 of 11 UI units · 6 more in build*.
- The previous `View →` fallback branch in `UseRow` becomes unreachable under the new filter and is dropped.

## Test plan

- [x] `npm run build` passes
- [x] `npm run verify:portfolio` passes (15 projects, 0 errors)
- [x] Dev preview verified: 5 Open links resolve to expected URLs (`strategicplan.insight.uidaho.edu`, `vandalizer.uidaho.edu`, `rfdcareerclub.insight.uidaho.edu`, `universo.insight.uidaho.edu`, `mindrouter.uidaho.edu`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)