### PR TITLE
Standards: rename statuses + soften tracking language

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,8 +160,8 @@ export default async function Home() {
                   Standards
                 </span>
                 <span className="text-xs text-ink-muted">
-                  {standards.counts.published} published &middot;{" "}
-                  {standards.outstanding} drafted
+                  {standards.counts.approved} approved &middot;{" "}
+                  {standards.outstanding} in progress
                 </span>
               </Link>
             </li>

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -6,17 +6,17 @@ import {
 } from "@/lib/standards-watch";
 
 const STATUS_LABEL: Record<StandardsWatchStatus, string> = {
-  requested: "Requested",
-  acknowledged: "Acknowledged",
+  "not-started": "Not started",
+  "in-discussion": "In discussion",
   "in-draft": "In draft",
-  published: "Published",
+  approved: "Approved",
 };
 
 const STATUS_STYLES: Record<StandardsWatchStatus, string> = {
-  requested: "bg-orange-100 text-orange-800",
-  acknowledged: "bg-yellow-100 text-yellow-800",
+  "not-started": "bg-gray-100 text-gray-700",
+  "in-discussion": "bg-amber-100 text-amber-800",
   "in-draft": "bg-blue-100 text-blue-800",
-  published: "bg-green-100 text-green-800",
+  approved: "bg-green-100 text-green-800",
 };
 
 function StatusChip({ status }: { status: StandardsWatchStatus }) {
@@ -114,15 +114,17 @@ export default function StandardsWatchPage() {
           Software-development and user-experience standards
         </h1>
         <p className="mt-3 max-w-3xl text-base leading-relaxed text-ink-muted">
-          The institutional standards IIDS has formally requested from the
-          Office of Information Technology. Entries move to{" "}
-          <span className="font-medium text-green-700">Published</span> as
-          OIT releases them.
+          The catalog of institutional IT, data, and AI governance
+          standards surfaced through this portal &mdash; drafting status,
+          the artifacts that ratify them, and the references behind each.
+          Entries move to{" "}
+          <span className="font-medium text-green-700">Approved</span> as
+          the Office of Information Technology publishes them.
         </p>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-brand-black">
           <span className="font-bold">{stats.outstanding}</span>{" "}
-          outstanding asks. <span className="font-bold">{stats.counts.published}</span>{" "}
-          published.
+          in progress. <span className="font-bold">{stats.counts.approved}</span>{" "}
+          approved.
         </p>
       </header>
 
@@ -172,8 +174,8 @@ export default function StandardsWatchPage() {
             In draft
           </span>{" "}
           or{" "}
-          <span className="rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-yellow-800">
-            Acknowledged
+          <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800">
+            In discussion
           </span>{" "}
           are addressed in part or whole by this source.
         </p>
@@ -186,8 +188,8 @@ export default function StandardsWatchPage() {
             Software Development Standards
           </h2>
           <p className="mt-1 text-sm text-ink-muted">
-            Requested deliverables governing how applications are architected,
-            secured, deployed, and maintained at the University of Idaho.
+            Standards governing how applications are architected, secured,
+            deployed, and maintained at the University of Idaho.
           </p>
         </div>
         <div className="space-y-3">
@@ -204,8 +206,8 @@ export default function StandardsWatchPage() {
             User Experience Standards
           </h2>
           <p className="mt-1 text-sm text-ink-muted">
-            Requested deliverables governing how University of Idaho
-            applications look, behave, and treat the people who use them.
+            Standards governing how University of Idaho applications look,
+            behave, and treat the people who use them.
           </p>
         </div>
         <div className="space-y-3">

--- a/lib/agent/tools/list-site-areas.ts
+++ b/lib/agent/tools/list-site-areas.ts
@@ -47,10 +47,10 @@ const SITE_AREAS: SiteArea[] = [
     name: "Standards",
     url: "/standards",
     purpose:
-      "The standards-watch ledger — software and UX standards IIDS has formally requested from OIT, with day counters per outstanding item.",
+      "The institutional standards ledger — the catalog of IT, data, and AI governance standards surfaced through this portal, with drafting status (not started / in discussion / in draft / approved) per entry.",
     example_questions: [
-      "What standards has IIDS requested?",
-      "What's the oldest outstanding standards request?",
+      "What standards are in draft?",
+      "Which standards have been approved?",
     ],
     sub_areas: [
       {

--- a/lib/agent/tools/list-standards.ts
+++ b/lib/agent/tools/list-standards.ts
@@ -1,6 +1,6 @@
-// list_standards — the IIDS standards-watch ledger, optionally filtered
-// by status. The /standards page is the canonical surface; everything
-// else links into it.
+// list_standards — the institutional standards ledger, optionally
+// filtered by status. The /standards page is the canonical surface;
+// everything else links into it.
 
 import "server-only";
 import {
@@ -11,10 +11,10 @@ import {
 import type { ToolHandler, ToolResult } from "./registry";
 
 const STATUS_VALUES: StandardsWatchStatus[] = [
-  "requested",
-  "acknowledged",
+  "not-started",
+  "in-discussion",
   "in-draft",
-  "published",
+  "approved",
 ];
 
 function pickString(args: Record<string, unknown>, key: string): string | undefined {
@@ -28,7 +28,7 @@ export const listStandardsTool: ToolHandler = {
     function: {
       name: "list_standards",
       description:
-        "Return the IIDS standards-watch ledger — items IIDS has formally requested from OIT, with their current status and how long they've been outstanding. Use this for questions about institutional software / UX standards, what's been requested, or what's still pending.",
+        "Return the institutional standards ledger — the catalog of IT, data, and AI governance standards surfaced through this portal, each with its current drafting status and how long it has been open. Use this for questions about institutional software / UX standards, what's being drafted, or what's been approved.",
       parameters: {
         type: "object",
         properties: {
@@ -36,7 +36,7 @@ export const listStandardsTool: ToolHandler = {
             type: "string",
             enum: STATUS_VALUES,
             description:
-              "Restrict to one status (requested, acknowledged, in-draft, published). Omit to list everything.",
+              "Restrict to one status (not-started, in-discussion, in-draft, approved). Omit to list everything.",
           },
         },
         additionalProperties: false,

--- a/lib/standards-watch.ts
+++ b/lib/standards-watch.ts
@@ -1,16 +1,17 @@
-// Standards Watch — public ledger of standards IIDS has formally requested
-// from OIT, with a per-entry day counter. Each entry is a commit-worthy
-// event; treat this file as the audit trail.
+// Standards ledger — the catalog of institutional IT, data, and AI
+// governance standards surfaced through this portal: drafting status,
+// references, and the artifacts that ratify them. Each entry is a
+// commit-worthy event; treat this file as the audit trail.
 //
 // Current dateRequested values are placeholders set to mid-February 2026,
-// approximating when these items were first surfaced. Replace per-entry
-// with actual request dates as those become canonical.
+// approximating when these items were first surfaced. Refine per-entry
+// as canonical dates become available.
 
 export type StandardsWatchStatus =
-  | "requested"
-  | "acknowledged"
+  | "not-started"
+  | "in-discussion"
   | "in-draft"
-  | "published";
+  | "approved";
 
 export interface StandardsWatchItem {
   id: string;
@@ -69,7 +70,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Contract testing expectations",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "acknowledged",
+    status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
       "Framework picks FastAPI + Uvicorn as the backend API layer and Microsoft Entra ID (OAuth2/OIDC) for authentication. Pagination/filtering, error-response schemas, rate limiting, OpenAPI documentation, and contract-testing expectations are not yet specified in the draft.",
@@ -88,7 +89,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Backup and disaster recovery standards",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "acknowledged",
+    status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
       "Framework adopts APM 30.11 (Low / Moderate / High) as the binding classification scheme and specifies PostgreSQL + pgaudit for audit logging. Prompt and completion logs inherit the classification of underlying data. Canonical data models, retention, lineage, and DR standards are not yet specified.",
@@ -143,7 +144,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Change management requirements",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "acknowledged",
+    status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
       "Framework names the required pre-deploy artifacts (systems architecture diagram, per-module data-flow diagrams, risk assessment, runbook covering deployment/rollback/incident response/alerting/ownership, EAR if new tech, VASA if new vendor). Long-term application ownership and support model is an explicit open question in the draft — options range from full product-team ownership to OIT-assumed long-term support; decision affects how applications are scoped, staffed, and funded.",
@@ -193,7 +194,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Communication expectations for breaking changes",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "i-10",
@@ -228,7 +229,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Versioning and governance of the design system",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-2",
@@ -241,7 +242,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Accessibility of interactive elements (keyboard nav, focus states)",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-3",
@@ -279,7 +280,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       },
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "acknowledged",
+    status: "in-discussion",
     responseNote:
       "WCAG 2.1 Level AA confirmed as the binding compliance level for institutional UI applications. The OIT Enterprise AI Development Framework draft does not yet enumerate accessibility-specific testing requirements, ARIA expectations, or per-component checks; this entry tracks the elaboration alongside the WCAG references.",
   },
@@ -296,7 +297,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Mobile vs. desktop expectations",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-5",
@@ -310,7 +311,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Responsiveness across screen sizes",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-6",
@@ -324,7 +325,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Logging vs. user-facing errors separation",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-7",
@@ -338,7 +339,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Documentation and in-app guidance expectations",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-8",
@@ -351,7 +352,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Iteration expectations based on feedback",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-9",
@@ -364,7 +365,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Reporting expectations",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "requested",
+    status: "not-started",
   },
   {
     id: "ii-10",
@@ -377,7 +378,7 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Process for updating standards over time",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "acknowledged",
+    status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
       "Framework establishes EAR (Enterprise Architecture Review) as the deviation process for tech-stack exceptions and VASA for vendor exceptions — these cover the engineering side of the decision authority structure. UX-specific ownership and conflict resolution between design / engineering / OIT are not yet specified.",
@@ -393,13 +394,13 @@ export function daysSince(isoDate: string): number {
 
 export function summary(items: StandardsWatchItem[] = standardsWatch) {
   const counts = {
-    requested: 0,
-    acknowledged: 0,
+    "not-started": 0,
+    "in-discussion": 0,
     "in-draft": 0,
-    published: 0,
+    approved: 0,
   } as Record<StandardsWatchStatus, number>;
   for (const item of items) counts[item.status]++;
-  const outstanding = items.filter((i) => i.status !== "published");
+  const outstanding = items.filter((i) => i.status !== "approved");
   const oldestOutstanding = outstanding
     .map((i) => daysSince(i.dateRequested))
     .sort((a, b) => b - a)[0] ?? 0;


### PR DESCRIPTION
## Summary
- Reframes `/standards` from "items IIDS has requested from OIT" to "catalog of institutional IT, data, and AI governance standards surfaced through this portal" — supports the project's evolution into a shared governance-portal example.
- Status taxonomy moves to a softer set: `requested → not-started`, `acknowledged → in-discussion`, `in-draft` (unchanged), `published → approved`. The orange "Requested" chip — the most adversarial visual on the page — is gone (gray / amber / blue / green now).
- Updates the page lede, the rollup line ("20 in progress · 0 approved"), agenda sub-heads, the active-sources callout, the home-page Evaluate tile, and the agent tools (`list_standards`, `list_site_areas`) to match the new vocabulary.
- Internal type names (`StandardsWatchStatus`, `StandardsWatchItem`, `dateRequested`, file path) intentionally left as-is — the reframe is scoped to user-visible copy and status values.

## Test plan
- [x] `npm run build` passes (type-check + prerender)
- [x] Local preview: `/standards` renders new lede, "20 in progress · 0 approved" rollup, and the three chip variants (gray "Not started", amber "In discussion", blue "In draft")
- [x] Local preview: `/` Evaluate tile reads "0 approved · 20 in progress"
- [ ] Agent QA: try "what standards are in draft?" and "which standards have been approved?" — should route through `list_standards` with the new enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)