### PR TITLE
Fix #247: suppress global ChatWidget on /builder-guide

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -12,7 +12,14 @@
 // rendering them properly was a no-brainer pull-forward.
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+
+// Routes that mount their own purpose-built chat assistant and should
+// suppress the global ChatWidget to avoid a floating-button collision
+// in the bottom-right corner. /builder-guide owns the idea-refinement
+// assistant (AiChatPanel) — see #247.
+const ROUTES_WITHOUT_GLOBAL_CHAT = ["/builder-guide"];
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -224,6 +231,7 @@ function SendIcon() {
 }
 
 export default function ChatWidget() {
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [draft, setDraft] = useState("");
@@ -231,6 +239,10 @@ export default function ChatWidget() {
   const [error, setError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const suppressed = ROUTES_WITHOUT_GLOBAL_CHAT.some(
+    (route) => pathname === route || pathname?.startsWith(`${route}/`),
+  );
 
   // Keep the latest turn in view as new messages stream in.
   useEffect(() => {
@@ -296,6 +308,8 @@ export default function ChatWidget() {
       send();
     }
   }
+
+  if (suppressed) return null;
 
   return (
     <>


### PR DESCRIPTION
Closes #247.

## Summary
Two floating chat assistants were stacking at `fixed bottom-6 right-6 z-50` on `/builder-guide`:

- **Global `ChatWidget`** ([components/ChatWidget.tsx](components/ChatWidget.tsx), mounted in [app/layout.tsx](app/layout.tsx)) — grounded retrieval via `/api/ask`, present on every page.
- **Local `AiChatPanel`** ([app/builder-guide/page.tsx](app/builder-guide/page.tsx)) — idea-refinement assistant via `/api/ai/refine` with a purpose-built "friendly IT consultant" system prompt.

Submitters saw two competing widgets in the same corner and couldn't tell which was which. Per the chosen fix direction (smallest viable change, preserve both purpose-built prompts), `ChatWidget` now checks `usePathname()` and returns `null` on routes that own their own chat. The list is a single constant at the top of the file so adding future exceptions is trivial.

Routes currently suppressed: `/builder-guide` (and any future sub-paths).

## Test plan
- [x] `npm run build` passes
- [x] Local preview: `/builder-guide` shows only the local "Ask a question" button; no global "Open assistant" circular button
- [x] Local preview: `/standards`, `/` continue to show the global "Open assistant" widget
- [ ] Manual: open the local AiChatPanel on `/builder-guide` and send a message — refinement chat still works end-to-end against `/api/ai/refine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)