### PR TITLE
ClickUp ingestion read-side: migration 010, client, sync engine (ADR 0003)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ MINDROUTER_API_KEY=
 # MINDROUTER_MODEL=qwen/qwen3.6-27b   # default; swap to qwen/qwen3.6-35b for lower latency
 
 # ClickUp read-only ingestion — project status updates, ROI, and the
-# scored request backlog (ADR 0003). A personal API token with read
+# scored request backlog (ADR 0004). A personal API token with read
 # access to the IIDS-AI4UI space. Workspace/space/list ids are code,
 # not config — see lib/clickup-map.ts.
 CLICKUP_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ MINDROUTER_API_KEY=
 # MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu
 # MINDROUTER_MODEL=qwen/qwen3.6-27b   # default; swap to qwen/qwen3.6-35b for lower latency
 
+# ClickUp read-only ingestion — project status updates, ROI, and the
+# scored request backlog (ADR 0003). A personal API token with read
+# access to the IIDS-AI4UI space. Workspace/space/list ids are code,
+# not config — see lib/clickup-map.ts.
+CLICKUP_API_TOKEN=
+
 # Salt for hashing client IPs in the agent_queries log. Set per
 # environment so hashes can't be precomputed against a known IP space.
 # A random 32+ char string is fine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,9 @@ lib/                       # Domain logic
   github.ts                # GitHub Issues API
   mindrouter.ts            # MindRouter LLM client
   db.ts                    # Postgres connection pool
+  clickup.ts               # ClickUp REST client + typed custom-field extraction (ADR 0003)
+  clickup-map.ts           # IIDS-AI4UI list ids ↔ portfolio slugs (typed map)
+  clickup-sync.ts          # ClickUp → Postgres sync engine (script + /internal/sync share it)
   governance/              # Data Governance Explorer typed modules
     types.ts               # Shared interfaces (Project, Table, Column, Vocabulary*)
     canonical-udm-tables.ts # Hand-curated canonical-vs-extension tagging (v1)
@@ -239,7 +242,7 @@ lib/                       # Domain logic
     project-alignment.ts   # Reverse lookup — projects advancing each priority
     catalog.ts             # AUTO-GENERATED — pillars + priorities (do not edit)
 
-db/migrations/             # SQL migrations (001 → 008; 007 = lifecycle, 008 = strategic-plan-alignment)
+db/migrations/             # SQL migrations (001 → 010; 007 = lifecycle, 008 = strategic-plan-alignment, 010 = clickup ingestion)
 
 scripts/                   # Node scripts run via tsx
   build-governance-catalog.ts     # vendor/data-governance/ → lib/governance/{catalog,vocabularies}.ts
@@ -251,6 +254,7 @@ scripts/                   # Node scripts run via tsx
   seed-portfolio.ts               # lib/portfolio.ts → applications table
   verify-portfolio.ts             # ADR 0001 status-rule enforcer
   refresh-commit-dates.ts         # GitHub API → lib/portfolio-meta.ts (weekly Action)
+  sync-clickup.ts                 # ClickUp IIDS-AI4UI space → clickup_* tables (ADR 0003)
 
 vendor/                    # Vendored dependencies (git submodules)
   data-governance/         # ui-insight/data-governance — UDM + controlled vocabs
@@ -309,6 +313,10 @@ npm run migrate                # Apply pending SQL migrations against $DATABASE_
 npm run seed:portfolio         # lib/portfolio.ts → applications table (dev DB)
 npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this)
 npm run refresh:commit-dates   # Hit GitHub API → regenerate lib/portfolio-meta.ts
+
+# ClickUp ingestion (ADR 0003; needs CLICKUP_API_TOKEN)
+npm run sync:clickup           # IIDS-AI4UI space → clickup_* tables (status, ROI, rubric)
+                               # Prod runs the same engine via POST /internal/sync (host cron)
 
 # Submodule freshness (used by PR-summary workflows)
 npm run governance:freshness        # Renders submodule-staleness comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ lib/                       # Domain logic
   github.ts                # GitHub Issues API
   mindrouter.ts            # MindRouter LLM client
   db.ts                    # Postgres connection pool
-  clickup.ts               # ClickUp REST client + typed custom-field extraction (ADR 0003)
+  clickup.ts               # ClickUp REST client + typed custom-field extraction (ADR 0004)
   clickup-map.ts           # IIDS-AI4UI list ids ↔ portfolio slugs (typed map)
   clickup-sync.ts          # ClickUp → Postgres sync engine (script + /internal/sync share it)
   governance/              # Data Governance Explorer typed modules
@@ -254,7 +254,7 @@ scripts/                   # Node scripts run via tsx
   seed-portfolio.ts               # lib/portfolio.ts → applications table
   verify-portfolio.ts             # ADR 0001 status-rule enforcer
   refresh-commit-dates.ts         # GitHub API → lib/portfolio-meta.ts (weekly Action)
-  sync-clickup.ts                 # ClickUp IIDS-AI4UI space → clickup_* tables (ADR 0003)
+  sync-clickup.ts                 # ClickUp IIDS-AI4UI space → clickup_* tables (ADR 0004)
 
 vendor/                    # Vendored dependencies (git submodules)
   data-governance/         # ui-insight/data-governance — UDM + controlled vocabs
@@ -314,7 +314,7 @@ npm run seed:portfolio         # lib/portfolio.ts → applications table (dev DB
 npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this)
 npm run refresh:commit-dates   # Hit GitHub API → regenerate lib/portfolio-meta.ts
 
-# ClickUp ingestion (ADR 0003; needs CLICKUP_API_TOKEN)
+# ClickUp ingestion (ADR 0004; needs CLICKUP_API_TOKEN)
 npm run sync:clickup           # IIDS-AI4UI space → clickup_* tables (status, ROI, rubric)
                                # Prod runs the same engine via POST /internal/sync (host cron)
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -286,11 +286,15 @@ ClickUp-independent. Reads from Postgres directly; ClickUp later replaces
   engine actually finds matches. Heuristic mapping per slug; refine in
   the seed script or via the admin registry.
 
-#### Sprint 3b — ClickUp wiring *(deferred to Colin)*
+#### Sprint 3b — ClickUp wiring *(read side shipped July 2026; write side still open)*
 
 - ClickUp custom fields setup (in person with Colin).
-- ClickUp API integration: read-side (sync blocker/status data Postgres
-  ← ClickUp on cron), then write-side (new submissions create CU tasks).
+- ClickUp API integration: **read-side shipped** per
+  [ADR 0003](./docs/adr/0003-clickup-ingestion-boundary.md) — the
+  IIDS-AI4UI space (project status-update comments, ROI fields, and the
+  scored request backlog) syncs into `clickup_*` tables (Migration 010)
+  via `npm run sync:clickup` or `POST /internal/sync`. Write-side (new
+  submissions create CU tasks) remains future work.
 - Once ClickUp wiring is solid, retire `/admin/submissions`.
 
 **Sprint 3a output:** intake portal materially better than TDX in

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -290,7 +290,7 @@ ClickUp-independent. Reads from Postgres directly; ClickUp later replaces
 
 - ClickUp custom fields setup (in person with Colin).
 - ClickUp API integration: **read-side shipped** per
-  [ADR 0003](./docs/adr/0003-clickup-ingestion-boundary.md) — the
+  [ADR 0004](./docs/adr/0004-clickup-ingestion-boundary.md) — the
   IIDS-AI4UI space (project status-update comments, ROI fields, and the
   scored request backlog) syncs into `clickup_*` tables (Migration 010)
   via `npm run sync:clickup` or `POST /internal/sync`. Write-side (new

--- a/db/migrations/010_clickup_ingestion.sql
+++ b/db/migrations/010_clickup_ingestion.sql
@@ -1,0 +1,109 @@
+-- Migration 010: ClickUp ingestion (IIDS-AI4UI space)
+--
+-- Read-side of the Sprint 3b ClickUp wiring (see ADR 0003). Stores data
+-- synced from the IIDS-AI4UI ClickUp space: per-project status narrative
+-- and ROI (from each project list's "Project Notes" task), and the scored
+-- intake backlog (from the "AI4UI New Project Requests" list).
+--
+-- Deliberately NO foreign keys to `applications`: scripts/seed-portfolio.ts
+-- does `TRUNCATE applications RESTART IDENTITY CASCADE` on every re-seed,
+-- and a CASCADE FK here would silently wipe synced data. The join to a
+-- portfolio slug happens at read time via the typed map in
+-- lib/clickup-map.ts, so seed and sync are order-independent and each
+-- individually idempotent.
+
+BEGIN;
+
+-- One row per ClickUp project list in the IIDS-AI4UI space. Fields come
+-- from the list's "Project Notes" task (task type "Project Detail",
+-- custom_item_id 1007).
+CREATE TABLE IF NOT EXISTS clickup_projects (
+  clickup_list_id       TEXT PRIMARY KEY,
+  name                  TEXT NOT NULL,
+  -- Task id of the "Project Notes" task the fields below came from.
+  notes_task_id         TEXT,
+  -- Estimated capacity returned, in FTE (ClickUp "ROI-FTE" number field).
+  roi_fte               NUMERIC,
+  roi_explanation       TEXT,
+  -- Arrays of { "name": string, "email": string | null }.
+  leads                 JSONB NOT NULL DEFAULT '[]',
+  pocs                  JSONB NOT NULL DEFAULT '[]',
+  stakeholders          JSONB NOT NULL DEFAULT '[]',
+  repo_url              TEXT,
+  projected_completion  DATE,
+  scope                 TEXT,
+  business_unit         TEXT,
+  synced_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Dated narrative status updates: the comments on each "Project Notes"
+-- task. Soft reference to clickup_projects via clickup_list_id.
+CREATE TABLE IF NOT EXISTS clickup_status_updates (
+  comment_id        TEXT PRIMARY KEY,
+  clickup_list_id   TEXT NOT NULL,
+  author            TEXT,
+  posted_at         TIMESTAMPTZ NOT NULL,
+  body_text         TEXT NOT NULL,
+  synced_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Timeline rendering reads newest-first per project.
+CREATE INDEX IF NOT EXISTS idx_clickup_status_updates_list
+  ON clickup_status_updates (clickup_list_id, posted_at DESC);
+
+-- The scored intake backlog ("AI4UI New Project Requests" form responses).
+-- The 11 rubric criteria are a fixed instrument defined by the ClickUp
+-- form; explicit columns keep the read layer typed end-to-end and make a
+-- rubric change a visible migration instead of silent JSONB drift.
+CREATE TABLE IF NOT EXISTS clickup_requests (
+  clickup_task_id  TEXT PRIMARY KEY,
+  name             TEXT NOT NULL,
+  -- Raw ClickUp status text ("to be reviewed", "active", "rejected",
+  -- "complete"). Normalized to a typed union at read time so upstream
+  -- renames degrade loudly instead of corrupting stored data.
+  status           TEXT NOT NULL,
+  description      TEXT,
+  unit             TEXT,
+  submitter        TEXT,
+  category         TEXT,
+  feasibility      TEXT,
+  -- A: strategy/impact (weight 0.1 each)
+  rubric_a1        NUMERIC,
+  rubric_a2        NUMERIC,
+  rubric_a3        NUMERIC,
+  rubric_a4        NUMERIC,
+  -- B: feasibility/effort (weight 0.075 each)
+  rubric_b1        NUMERIC,
+  rubric_b2        NUMERIC,
+  rubric_b3        NUMERIC,
+  rubric_b4        NUMERIC,
+  -- C: urgency/buy-in (weight 0.1 each)
+  rubric_c1        NUMERIC,
+  rubric_c2        NUMERIC,
+  rubric_c3        NUMERIC,
+  -- ClickUp's "Weighted Score" formula value; when the API omits it and
+  -- all 11 rubric values are present, the sync computes the same formula
+  -- and marks score_source = 'computed'.
+  weighted_score   NUMERIC,
+  score_source     TEXT NOT NULL DEFAULT 'clickup'
+                   CHECK (score_source IN ('clickup', 'computed')),
+  date_created     TIMESTAMPTZ,
+  date_updated     TIMESTAMPTZ,
+  synced_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per sync run (script cron or /internal button). Powers the
+-- freshness stamps on the public surfaces and the button's feedback.
+CREATE TABLE IF NOT EXISTS clickup_sync_runs (
+  id           BIGSERIAL PRIMARY KEY,
+  started_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at  TIMESTAMPTZ,
+  ok           BOOLEAN,
+  trigger      TEXT NOT NULL CHECK (trigger IN ('cron', 'manual')),
+  -- Counts per table plus any warnings, e.g. a list missing its
+  -- "Project Notes" task.
+  summary      JSONB,
+  error        TEXT
+);
+
+COMMIT;

--- a/db/migrations/010_clickup_ingestion.sql
+++ b/db/migrations/010_clickup_ingestion.sql
@@ -1,6 +1,6 @@
 -- Migration 010: ClickUp ingestion (IIDS-AI4UI space)
 --
--- Read-side of the Sprint 3b ClickUp wiring (see ADR 0003). Stores data
+-- Read-side of the Sprint 3b ClickUp wiring (see ADR 0004). Stores data
 -- synced from the IIDS-AI4UI ClickUp space: per-project status narrative
 -- and ROI (from each project list's "Project Notes" task), and the scored
 -- intake backlog (from the "AI4UI New Project Requests" list).

--- a/db/migrations/011_clickup_status_summary.sql
+++ b/db/migrations/011_clickup_status_summary.sql
@@ -3,7 +3,7 @@
 -- Colin's call (July 2026): the raw status-update comments are internal
 -- notes and should NOT be published verbatim. The public site shows a
 -- short generated summary instead; the full comment timeline stays on
--- the auth-gated /internal view. See ADR 0003 (amended).
+-- the auth-gated /internal view. See ADR 0004 (amended).
 --
 -- The sync generates the summary via MindRouter only when the comment
 -- stream has changed since the last summarization (tracked by

--- a/db/migrations/011_clickup_status_summary.sql
+++ b/db/migrations/011_clickup_status_summary.sql
@@ -1,0 +1,19 @@
+-- Migration 011: public status summaries for ClickUp projects
+--
+-- Colin's call (July 2026): the raw status-update comments are internal
+-- notes and should NOT be published verbatim. The public site shows a
+-- short generated summary instead; the full comment timeline stays on
+-- the auth-gated /internal view. See ADR 0003 (amended).
+--
+-- The sync generates the summary via MindRouter only when the comment
+-- stream has changed since the last summarization (tracked by
+-- status_summary_source, the newest comment id at summarization time).
+
+BEGIN;
+
+ALTER TABLE clickup_projects
+  ADD COLUMN IF NOT EXISTS status_summary        TEXT,
+  ADD COLUMN IF NOT EXISTS status_summary_at     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS status_summary_source TEXT;
+
+COMMIT;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
         condition: service_healthy
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      CLICKUP_API_TOKEN: ${CLICKUP_API_TOKEN:-}
       DATABASE_URL: postgresql://${POSTGRES_USER:-aispeg}:${POSTGRES_PASSWORD:-aispeg_secret}@10.10.9.10:5432/${POSTGRES_DB:-aispeg}
       MINDROUTER_API_KEY: ${MINDROUTER_API_KEY:-}
       MINDROUTER_BASE_URL: ${MINDROUTER_BASE_URL:-https://mindrouter.uidaho.edu}
@@ -90,6 +91,7 @@ services:
         condition: service_healthy
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      CLICKUP_API_TOKEN: ${CLICKUP_API_TOKEN:-}
       DATABASE_URL: postgresql://${POSTGRES_USER:-aispeg}:${POSTGRES_PASSWORD:-aispeg_secret}@10.10.9.11:5432/${POSTGRES_DB:-aispeg_dev}
       MINDROUTER_API_KEY: ${MINDROUTER_API_KEY:-}
       MINDROUTER_BASE_URL: ${MINDROUTER_BASE_URL:-https://mindrouter.uidaho.edu}

--- a/docs/adr/0003-clickup-ingestion-boundary.md
+++ b/docs/adr/0003-clickup-ingestion-boundary.md
@@ -23,7 +23,7 @@ The site should publish three things from that system: current status of active 
 | From ClickUp | Into | Surfaced at |
 |---|---|---|
 | "Project Notes" task fields per project list: ROI-FTE, ROI-Explanation, Lead(s), POC(s), Stakeholders, repo link, projected completion, scope, business unit | `clickup_projects` | Project detail pages (ROI line), internal views |
-| Comments on each "Project Notes" task | `clickup_status_updates` | "Status updates" timeline on project detail pages; latest-update line on portfolio cards |
+| Comments on each "Project Notes" task | `clickup_status_updates` | **Public:** a generated summary (`clickup_projects.status_summary`) on detail pages and cards. **Internal:** the full dated timeline. See "Accepted risk" below — amended July 2026. |
 | Backlog request tasks: name, status, description, unit, submitter, category, feasibility, 11 rubric values, weighted score | `clickup_requests` | `/portfolio/pipeline` |
 
 ### What does not flow
@@ -61,11 +61,15 @@ The Postgres instance lives on the on-prem docker host; GitHub runners can't rea
 
 Both triggers call the same `runSync()` in `lib/clickup-sync.ts`.
 
-## Accepted risk: internal-voice comments become public copy
+## Accepted risk: internal-voice comments become public copy — *amended July 2026*
 
-Status-update comments were written in ClickUp as internal notes. Publishing them verbatim is the point (evidence-forward, owner-named) but carries tone/content risk.
+Status-update comments were written in ClickUp as internal notes. The original decision published them verbatim; Colin revised it: **the public site never renders the comment corpus.** Instead:
 
-**Launch gate:** a one-time read-through of the synced comment corpus with Colin before the first production sync. **Ongoing:** the site is a projection of ClickUp — comment hygiene in ClickUp is now a public-facing practice (this extends the "ClickUp data hygiene" risk REFACTOR.md already names).
+- The sync generates a 2–4 sentence public summary per project via MindRouter (migration 011: `status_summary`, `status_summary_at`, `status_summary_source`), regenerated only when the comment stream changes. The prompt forbids email addresses, meeting links, and internal asides, and forbids inventing details.
+- The full dated timeline renders only on the auth-gated `/internal` view.
+- If MindRouter is unavailable, the previous summary is kept (stale beats missing) and the sync run records a warning; a project with no summary yet simply shows nothing publicly.
+
+**Ongoing:** the site remains a projection of ClickUp — comment hygiene still matters because the summarizer can only be as accurate as its inputs, and `/internal` shows the notes verbatim (this extends the "ClickUp data hygiene" risk REFACTOR.md already names). Spot-checking generated summaries after significant comment activity is part of the sync-review habit.
 
 ## Consequences
 

--- a/docs/adr/0003-clickup-ingestion-boundary.md
+++ b/docs/adr/0003-clickup-ingestion-boundary.md
@@ -1,0 +1,75 @@
+# ADR 0003 — ClickUp Ingestion Boundary
+
+**Status:** Accepted
+**Date:** 2026-07-10
+**Deciders:** Colin Addington
+**Related:** [REFACTOR.md](../../REFACTOR.md) ("ClickUp ↔ Postgres boundary", Sprint 3b), [ADR 0001](./0001-product-lifecycle-taxonomy.md) (lifecycle taxonomy the new portfolio entries must satisfy), Migration 010
+
+## Context
+
+REFACTOR.md drew the source-of-truth boundary in Sprint 2: *"Project status, blockers, daily workflow — ClickUp. Where Colin already lives."* The wiring itself (Sprint 3b) was deferred. Meanwhile the IIDS-AI4UI ClickUp space matured into a real operational system:
+
+- **Each active AI4UI project is a ClickUp list** (14 as of July 2026). Each list carries a "Project Notes" task (task type "Project Detail") whose **comments are the dated status narrative**, and whose custom fields carry **ROI-FTE / ROI-Explanation**, leads, POCs, stakeholders, repo link, and projected completion.
+- **The intake backlog is a list of form responses** ("AI4UI New Project Requests"), each scored on an 11-criterion rubric (A1–A4 strategy/impact ×0.1, B1–B4 feasibility/effort ×0.075, C1–C3 urgency/buy-in ×0.1, sum ×20) with a ClickUp formula field computing the weighted score.
+
+The site should publish three things from that system: current status of active projects, their ROI estimations, and the scored request backlog. Colin decided **all three are public**.
+
+## Decision
+
+**Pull-only ingestion, ClickUp → Postgres, on a cron + manual trigger.** No write-back to ClickUp in this feature (the Sprint 3b write side — new submissions creating ClickUp tasks — remains future work).
+
+### What flows
+
+| From ClickUp | Into | Surfaced at |
+|---|---|---|
+| "Project Notes" task fields per project list: ROI-FTE, ROI-Explanation, Lead(s), POC(s), Stakeholders, repo link, projected completion, scope, business unit | `clickup_projects` | Project detail pages (ROI line), internal views |
+| Comments on each "Project Notes" task | `clickup_status_updates` | "Status updates" timeline on project detail pages; latest-update line on portfolio cards |
+| Backlog request tasks: name, status, description, unit, submitter, category, feasibility, 11 rubric values, weighted score | `clickup_requests` | `/portfolio/pipeline` |
+
+### What does not flow
+
+Ordinary work tasks, assignees, checklists, attachments, time tracking, chat, and every other list in the workspace. The sync reads exactly the lists named in `lib/clickup-map.ts` and nothing else.
+
+## Sub-decisions resolved
+
+### 1. Synced tables carry no foreign keys to `applications`
+
+`scripts/seed-portfolio.ts` re-seeds with `TRUNCATE applications RESTART IDENTITY CASCADE`. A CASCADE FK from synced tables would silently wipe ClickUp data on every re-seed. Instead, synced rows are keyed by ClickUp ids (list id, comment id, task id) and join to portfolio slugs **at read time** via the typed map in `lib/clickup-map.ts`. Seed and sync are order-independent; each is individually idempotent.
+
+### 2. List/space ids are code; only the token is config
+
+Workspace, space, and list ids are stable structured data — they live in `lib/clickup-map.ts` where tsc checks every consumer (CLAUDE.md rule 9). `CLICKUP_API_TOKEN` is the only environment variable.
+
+### 3. Rubric criteria are explicit columns, not JSONB
+
+The rubric is a fixed 11-field instrument defined by the ClickUp form. Explicit `rubric_a1..rubric_c3` columns keep the read layer typed end-to-end and make a rubric change a visible migration rather than silent blob drift. If ClickUp's formula value is missing, the sync computes the same formula locally and marks `score_source = 'computed'` — the site never silently invents a number.
+
+### 4. Sync failure posture: stale beats missing
+
+Rows for a list are deleted (to mirror ClickUp deletions) only after that list fetched successfully, per list. A mid-run failure leaves previously synced data intact and records the failure in `clickup_sync_runs`. Lists missing their "Project Notes" task are warned about and skipped, never a hard failure. Every surface that renders synced data shows a freshness stamp from `clickup_sync_runs`.
+
+### 5. Trigger: script + authed route, not GitHub Actions
+
+The Postgres instance lives on the on-prem docker host; GitHub runners can't reach it. So:
+
+- `npm run sync:clickup` — tsx script for local/dev/one-off runs.
+- `POST /internal/sync` — route handler behind the existing `/internal` Basic-auth middleware, used by the "Sync now" button on `/internal` and by the host cron:
+
+```
+17 6,12,18 * * *  curl -s -u "$BASIC_AUTH_USER:$BASIC_AUTH_PASS" -X POST https://aispeg.insight.uidaho.edu/internal/sync
+```
+
+Both triggers call the same `runSync()` in `lib/clickup-sync.ts`.
+
+## Accepted risk: internal-voice comments become public copy
+
+Status-update comments were written in ClickUp as internal notes. Publishing them verbatim is the point (evidence-forward, owner-named) but carries tone/content risk.
+
+**Launch gate:** a one-time read-through of the synced comment corpus with Colin before the first production sync. **Ongoing:** the site is a projection of ClickUp — comment hygiene in ClickUp is now a public-facing practice (this extends the "ClickUp data hygiene" risk REFACTOR.md already names).
+
+## Consequences
+
+- `/portfolio` project pages gain a dated, human-authored status timeline and an ROI line — the site's evidence-forward claim gets primary-source backing.
+- `/portfolio/pipeline` makes the intake rubric public: units can see how requests are scored and where theirs stands.
+- The nine AI4UI projects that existed only in ClickUp join `lib/portfolio.ts` (and the public site) as first-class entries, verified by ADR 0001 rules.
+- ClickUp data-entry discipline (notes-task fields, comment cadence) now directly determines public-site quality.

--- a/docs/adr/0004-clickup-ingestion-boundary.md
+++ b/docs/adr/0004-clickup-ingestion-boundary.md
@@ -1,4 +1,4 @@
-# ADR 0003 — ClickUp Ingestion Boundary
+# ADR 0004 — ClickUp Ingestion Boundary
 
 **Status:** Accepted
 **Date:** 2026-07-10

--- a/lib/clickup-map.ts
+++ b/lib/clickup-map.ts
@@ -1,0 +1,57 @@
+// lib/clickup-map.ts
+//
+// Typed map between the IIDS-AI4UI ClickUp space and the portfolio.
+// Each active AI4UI project is a ClickUp *list*; this module pins the
+// list ids to portfolio slugs so synced rows (keyed by ClickUp ids —
+// see migration 010) join to `applications` rows at read time.
+//
+// These ids are structured data, not secrets — keeping them here (not
+// in env vars) lets tsc check every consumer. Only the API token lives
+// in the environment (CLICKUP_API_TOKEN).
+//
+// Maintenance: when a new project list is created in the IIDS-AI4UI
+// space, add a row here AND a matching entry in lib/portfolio.ts with
+// the same slug. Unknown lists encountered during sync are logged as
+// warnings and skipped, never synced blind.
+
+export const CLICKUP_WORKSPACE_ID = "9017952524";
+
+/** IIDS-AI4UI space. */
+export const CLICKUP_SPACE_ID = "90175778958";
+
+/** "AI4UI New Project Requests" — the scored intake backlog. */
+export const CLICKUP_BACKLOG_LIST_ID = "901713962270";
+
+export interface ClickUpProjectMapping {
+  /** ClickUp list id (each project is a list in the space). */
+  listId: string;
+  /** List name as it reads in ClickUp — for sync logs only. */
+  listName: string;
+  /** Matching lib/portfolio.ts slug. */
+  slug: string;
+}
+
+export const CLICKUP_PROJECT_LISTS: readonly ClickUpProjectMapping[] = [
+  { listId: "901713962364", listName: "Invoice Processing", slug: "invoice-processing" },
+  { listId: "901713962399", listName: "MindRouter 2.0", slug: "mindrouter" },
+  { listId: "901713962269", listName: "OpenERA", slug: "openera" },
+  { listId: "901713962298", listName: "Nexus", slug: "nexus" },
+  { listId: "901713962384", listName: "Water Law Database", slug: "water-law-database" },
+  { listId: "901714480073", listName: "EO Compliance Tool", slug: "execord" },
+  { listId: "901713962400", listName: "Daily Register/MyUI", slug: "ucm-daily-register" },
+  { listId: "901713962362", listName: "Historical Contracts", slug: "historical-contracts" },
+  { listId: "901713962291", listName: "Ongoing Contracts", slug: "ongoing-contracts" },
+  { listId: "901713962380", listName: "Out of State Tax Tracking", slug: "out-of-state-tax-tracking" },
+  { listId: "901713962365", listName: "BLS & CUPA Code Prediction", slug: "bls-cupa-code-prediction" },
+  { listId: "901713962307", listName: "Retroactive Payment Requests", slug: "retroactive-payment-requests" },
+  { listId: "901713962350", listName: "Document Review - Bid Waivers", slug: "bid-waiver-document-review" },
+  { listId: "901713962295", listName: "Data Infrastructure Pilot", slug: "data-infrastructure-pilot" },
+] as const;
+
+export function slugForListId(listId: string): string | null {
+  return CLICKUP_PROJECT_LISTS.find((m) => m.listId === listId)?.slug ?? null;
+}
+
+export function listIdForSlug(slug: string): string | null {
+  return CLICKUP_PROJECT_LISTS.find((m) => m.slug === slug)?.listId ?? null;
+}

--- a/lib/clickup-sync.ts
+++ b/lib/clickup-sync.ts
@@ -1,6 +1,6 @@
 // lib/clickup-sync.ts
 //
-// The ClickUp → Postgres sync engine (read side of Sprint 3b, ADR 0003).
+// The ClickUp → Postgres sync engine (read side of Sprint 3b, ADR 0004).
 // Shared by scripts/sync-clickup.ts (cron/local) and the /internal/sync
 // route handler ("Sync now" button), so both triggers exercise the same
 // code path.
@@ -141,7 +141,7 @@ async function syncProjectList(
 }
 
 /**
- * Public status summary (ADR 0003, amended July 2026): the raw comments
+ * Public status summary (ADR 0004, amended July 2026): the raw comments
  * are internal notes, so the public site renders a short MindRouter-
  * generated summary instead of the corpus. Regenerated only when the
  * comment stream changed since the last summarization; on MindRouter

--- a/lib/clickup-sync.ts
+++ b/lib/clickup-sync.ts
@@ -1,0 +1,285 @@
+// lib/clickup-sync.ts
+//
+// The ClickUp → Postgres sync engine (read side of Sprint 3b, ADR 0003).
+// Shared by scripts/sync-clickup.ts (cron/local) and the /internal/sync
+// route handler ("Sync now" button), so both triggers exercise the same
+// code path.
+//
+// Per project list: find the "Project Notes" task, upsert its ROI/people
+// fields into clickup_projects, then upsert its comments (the dated
+// status narrative) into clickup_status_updates. Then the backlog list:
+// upsert every request task with its rubric values and weighted score.
+//
+// Failure posture: a list that fails to fetch aborts the run before its
+// delete phase — stale data beats missing data. Lists without a notes
+// task are warned about and skipped, never a hard failure.
+
+import { query, queryOne } from "./db";
+import {
+  CLICKUP_BACKLOG_LIST_ID,
+  CLICKUP_PROJECT_LISTS,
+} from "./clickup-map";
+import {
+  commentBodyText,
+  computeWeightedScore,
+  getDateField,
+  getDropdownField,
+  getFormulaField,
+  getListTasks,
+  getNumberField,
+  getTaskComments,
+  getTextField,
+  getUrlField,
+  getUsersField,
+  PROJECT_FIELDS,
+  PROJECT_NOTES_CUSTOM_ITEM_ID,
+  RUBRIC_FIELDS,
+  type ClickUpTask,
+} from "./clickup";
+
+export interface SyncSummary {
+  runId: number;
+  startedAt: string;
+  finishedAt: string;
+  projects: number;
+  statusUpdates: number;
+  requests: number;
+  warnings: string[];
+}
+
+function msEpochToIso(ms: string): string {
+  return new Date(Number(ms)).toISOString();
+}
+
+function findNotesTask(tasks: ClickUpTask[]): ClickUpTask | null {
+  return (
+    tasks.find((t) => t.custom_item_id === PROJECT_NOTES_CUSTOM_ITEM_ID) ??
+    tasks.find((t) => /project notes/i.test(t.name)) ??
+    null
+  );
+}
+
+async function syncProjectList(
+  listId: string,
+  listName: string,
+  warnings: string[]
+): Promise<{ updates: number; synced: boolean }> {
+  const tasks = await getListTasks(listId);
+  const notes = findNotesTask(tasks);
+  if (!notes) {
+    warnings.push(`${listName} (${listId}): no "Project Notes" task — skipped`);
+    return { updates: 0, synced: false };
+  }
+
+  await query(
+    `INSERT INTO clickup_projects (
+       clickup_list_id, name, notes_task_id, roi_fte, roi_explanation,
+       leads, pocs, stakeholders, repo_url, projected_completion,
+       scope, business_unit, synced_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,now())
+     ON CONFLICT (clickup_list_id) DO UPDATE SET
+       name = EXCLUDED.name,
+       notes_task_id = EXCLUDED.notes_task_id,
+       roi_fte = EXCLUDED.roi_fte,
+       roi_explanation = EXCLUDED.roi_explanation,
+       leads = EXCLUDED.leads,
+       pocs = EXCLUDED.pocs,
+       stakeholders = EXCLUDED.stakeholders,
+       repo_url = EXCLUDED.repo_url,
+       projected_completion = EXCLUDED.projected_completion,
+       scope = EXCLUDED.scope,
+       business_unit = EXCLUDED.business_unit,
+       synced_at = now()`,
+    [
+      listId,
+      listName,
+      notes.id,
+      getNumberField(notes, PROJECT_FIELDS.roiFte),
+      getTextField(notes, PROJECT_FIELDS.roiExplanation),
+      JSON.stringify(getUsersField(notes, PROJECT_FIELDS.leads)),
+      JSON.stringify(getUsersField(notes, PROJECT_FIELDS.pocs)),
+      JSON.stringify(getUsersField(notes, PROJECT_FIELDS.stakeholders)),
+      getUrlField(notes, PROJECT_FIELDS.repoUrl),
+      getDateField(notes, PROJECT_FIELDS.projectedCompletion),
+      getTextField(notes, PROJECT_FIELDS.scope),
+      getDropdownField(notes, PROJECT_FIELDS.businessUnit),
+    ]
+  );
+
+  const comments = await getTaskComments(notes.id);
+  const seenCommentIds: string[] = [];
+  for (const comment of comments) {
+    const body = commentBodyText(comment);
+    if (!body) continue; // empty after mention-stripping — nothing to show
+    seenCommentIds.push(comment.id);
+    await query(
+      `INSERT INTO clickup_status_updates (
+         comment_id, clickup_list_id, author, posted_at, body_text, synced_at
+       ) VALUES ($1,$2,$3,$4,$5,now())
+       ON CONFLICT (comment_id) DO UPDATE SET
+         author = EXCLUDED.author,
+         posted_at = EXCLUDED.posted_at,
+         body_text = EXCLUDED.body_text,
+         synced_at = now()`,
+      [comment.id, listId, comment.user?.username ?? null, msEpochToIso(comment.date), body]
+    );
+  }
+
+  // Deletes run only after this list fetched successfully, and only for
+  // this list — comments deleted in ClickUp disappear from the site.
+  await query(
+    `DELETE FROM clickup_status_updates
+     WHERE clickup_list_id = $1 AND NOT (comment_id = ANY($2::text[]))`,
+    [listId, seenCommentIds]
+  );
+
+  return { updates: seenCommentIds.length, synced: true };
+}
+
+async function syncBacklog(warnings: string[]): Promise<number> {
+  const tasks = await getListTasks(CLICKUP_BACKLOG_LIST_ID, { includeClosed: true });
+  const seenTaskIds: string[] = [];
+
+  for (const task of tasks) {
+    const rubric = {
+      a1: getNumberField(task, RUBRIC_FIELDS.a1),
+      a2: getNumberField(task, RUBRIC_FIELDS.a2),
+      a3: getNumberField(task, RUBRIC_FIELDS.a3),
+      a4: getNumberField(task, RUBRIC_FIELDS.a4),
+      b1: getNumberField(task, RUBRIC_FIELDS.b1),
+      b2: getNumberField(task, RUBRIC_FIELDS.b2),
+      b3: getNumberField(task, RUBRIC_FIELDS.b3),
+      b4: getNumberField(task, RUBRIC_FIELDS.b4),
+      c1: getNumberField(task, RUBRIC_FIELDS.c1),
+      c2: getNumberField(task, RUBRIC_FIELDS.c2),
+      c3: getNumberField(task, RUBRIC_FIELDS.c3),
+    };
+
+    let weightedScore = getFormulaField(task, RUBRIC_FIELDS.weightedScore);
+    let scoreSource: "clickup" | "computed" = "clickup";
+    if (weightedScore === null) {
+      const values = Object.values(rubric);
+      if (values.every((v) => v !== null)) {
+        weightedScore = computeWeightedScore(
+          rubric as Record<keyof typeof rubric, number>
+        );
+        scoreSource = "computed";
+        warnings.push(`${task.name} (${task.id}): weighted score computed locally (formula value missing)`);
+      }
+    }
+
+    seenTaskIds.push(task.id);
+    await query(
+      `INSERT INTO clickup_requests (
+         clickup_task_id, name, status, description, unit, submitter,
+         category, feasibility,
+         rubric_a1, rubric_a2, rubric_a3, rubric_a4,
+         rubric_b1, rubric_b2, rubric_b3, rubric_b4,
+         rubric_c1, rubric_c2, rubric_c3,
+         weighted_score, score_source, date_created, date_updated, synced_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,now())
+       ON CONFLICT (clickup_task_id) DO UPDATE SET
+         name = EXCLUDED.name,
+         status = EXCLUDED.status,
+         description = EXCLUDED.description,
+         unit = EXCLUDED.unit,
+         submitter = EXCLUDED.submitter,
+         category = EXCLUDED.category,
+         feasibility = EXCLUDED.feasibility,
+         rubric_a1 = EXCLUDED.rubric_a1, rubric_a2 = EXCLUDED.rubric_a2,
+         rubric_a3 = EXCLUDED.rubric_a3, rubric_a4 = EXCLUDED.rubric_a4,
+         rubric_b1 = EXCLUDED.rubric_b1, rubric_b2 = EXCLUDED.rubric_b2,
+         rubric_b3 = EXCLUDED.rubric_b3, rubric_b4 = EXCLUDED.rubric_b4,
+         rubric_c1 = EXCLUDED.rubric_c1, rubric_c2 = EXCLUDED.rubric_c2,
+         rubric_c3 = EXCLUDED.rubric_c3,
+         weighted_score = EXCLUDED.weighted_score,
+         score_source = EXCLUDED.score_source,
+         date_created = EXCLUDED.date_created,
+         date_updated = EXCLUDED.date_updated,
+         synced_at = now()`,
+      [
+        task.id,
+        task.name,
+        task.status.status,
+        task.text_content?.trim() || null,
+        getTextField(task, RUBRIC_FIELDS.unit),
+        getTextField(task, RUBRIC_FIELDS.submitter),
+        getDropdownField(task, RUBRIC_FIELDS.category),
+        getDropdownField(task, RUBRIC_FIELDS.feasibility),
+        rubric.a1, rubric.a2, rubric.a3, rubric.a4,
+        rubric.b1, rubric.b2, rubric.b3, rubric.b4,
+        rubric.c1, rubric.c2, rubric.c3,
+        weightedScore,
+        scoreSource,
+        msEpochToIso(task.date_created),
+        msEpochToIso(task.date_updated),
+      ]
+    );
+  }
+
+  await query(
+    `DELETE FROM clickup_requests WHERE NOT (clickup_task_id = ANY($1::text[]))`,
+    [seenTaskIds]
+  );
+
+  return seenTaskIds.length;
+}
+
+export async function runSync(trigger: "cron" | "manual"): Promise<SyncSummary> {
+  const run = await queryOne<{ id: number; started_at: string }>(
+    `INSERT INTO clickup_sync_runs (trigger) VALUES ($1) RETURNING id, started_at`,
+    [trigger]
+  );
+  if (!run) throw new Error("failed to record sync run");
+
+  const warnings: string[] = [];
+  let projects = 0;
+  let statusUpdates = 0;
+  let requests = 0;
+
+  try {
+    for (const mapping of CLICKUP_PROJECT_LISTS) {
+      const result = await syncProjectList(mapping.listId, mapping.listName, warnings);
+      if (result.synced) {
+        projects += 1;
+        statusUpdates += result.updates;
+      }
+      console.log(
+        `  ${result.synced ? "↳" : "!"} ${mapping.listName.padEnd(32)} ${
+          result.synced ? `${result.updates} update${result.updates === 1 ? "" : "s"}` : "skipped"
+        }`
+      );
+    }
+
+    requests = await syncBacklog(warnings);
+    console.log(`  ↳ ${"AI4UI New Project Requests".padEnd(32)} ${requests} requests`);
+
+    const summary = { projects, statusUpdates, requests, warnings };
+    const finished = await queryOne<{ finished_at: string }>(
+      `UPDATE clickup_sync_runs
+       SET finished_at = now(), ok = true, summary = $2
+       WHERE id = $1 RETURNING finished_at`,
+      [run.id, JSON.stringify(summary)]
+    );
+
+    return {
+      runId: run.id,
+      startedAt: new Date(run.started_at).toISOString(),
+      finishedAt: finished ? new Date(finished.finished_at).toISOString() : new Date().toISOString(),
+      projects,
+      statusUpdates,
+      requests,
+      warnings,
+    };
+  } catch (err) {
+    await query(
+      `UPDATE clickup_sync_runs
+       SET finished_at = now(), ok = false, error = $2
+       WHERE id = $1`,
+      [run.id, err instanceof Error ? err.message : String(err)]
+    ).catch(() => {
+      // recording the failure must not mask the original error
+    });
+    throw err;
+  }
+}

--- a/lib/clickup-sync.ts
+++ b/lib/clickup-sync.ts
@@ -15,6 +15,7 @@
 // task are warned about and skipped, never a hard failure.
 
 import { query, queryOne } from "./db";
+import { chatCompletion } from "./mindrouter";
 import {
   CLICKUP_BACKLOG_LIST_ID,
   CLICKUP_PROJECT_LISTS,
@@ -34,6 +35,7 @@ import {
   PROJECT_FIELDS,
   PROJECT_NOTES_CUSTOM_ITEM_ID,
   RUBRIC_FIELDS,
+  type ClickUpComment,
   type ClickUpTask,
 } from "./clickup";
 
@@ -133,7 +135,77 @@ async function syncProjectList(
     [listId, seenCommentIds]
   );
 
+  await refreshStatusSummary(listId, listName, comments, warnings);
+
   return { updates: seenCommentIds.length, synced: true };
+}
+
+/**
+ * Public status summary (ADR 0003, amended July 2026): the raw comments
+ * are internal notes, so the public site renders a short MindRouter-
+ * generated summary instead of the corpus. Regenerated only when the
+ * comment stream changed since the last summarization; on MindRouter
+ * failure the previous summary is kept (stale beats missing) and a
+ * warning is surfaced in the run summary.
+ */
+async function refreshStatusSummary(
+  listId: string,
+  listName: string,
+  comments: ClickUpComment[],
+  warnings: string[]
+): Promise<void> {
+  if (comments.length === 0) return;
+
+  // Comments arrive newest-first; the newest id fingerprints the stream.
+  const newestId = comments[0]!.id;
+  const existing = await queryOne<{ status_summary_source: string | null }>(
+    `SELECT status_summary_source FROM clickup_projects WHERE clickup_list_id = $1`,
+    [listId]
+  );
+  if (existing?.status_summary_source === newestId) return; // unchanged
+
+  const recent = comments.slice(0, 12);
+  const corpus = recent
+    .map((c) => {
+      const date = new Date(Number(c.date)).toISOString().slice(0, 10);
+      const body = commentBodyText(c);
+      return `[${date}] ${body}`;
+    })
+    .join("\n\n")
+    .slice(0, 8000);
+
+  const systemPrompt =
+    "You write status summaries for a University of Idaho public website about institutional AI projects. Given internal status-update notes, write 2-4 plain sentences describing where the project stands: current state, recent progress, and the next step if one is stated. Factual, no hype. Each note is prefixed with its date; if the newest note is months old, describe it as the last reported state (e.g. \"As of March 2026, ...\") rather than implying it is current. Do not include email addresses, meeting links, scheduling chatter, or anything that reads as an internal aside. Do not invent details that are not in the notes. Output only the summary text.";
+  const userPrompt = `Today is ${new Date().toISOString().slice(0, 10)}.\nProject: ${listName}\n\nInternal status-update notes, newest first:\n\n${corpus}\n\nWrite the public status summary now.`;
+
+  try {
+    let summary = "";
+    // qwen3.6 is a thinking model: with a small max_tokens the reasoning
+    // stream can exhaust the budget before any visible content is
+    // emitted, yielding empty content with finish_reason "length". Give
+    // it room, and retry once on an empty result.
+    for (let attempt = 0; attempt < 2 && !summary; attempt++) {
+      const res = await chatCompletion({
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        max_tokens: 8192,
+      });
+      summary = (res.choices[0]?.message?.content ?? "").trim();
+    }
+    if (!summary) throw new Error("empty summary returned");
+    await query(
+      `UPDATE clickup_projects
+       SET status_summary = $2, status_summary_at = now(), status_summary_source = $3
+       WHERE clickup_list_id = $1`,
+      [listId, summary, newestId]
+    );
+  } catch (err) {
+    warnings.push(
+      `${listName} (${listId}): status summary not refreshed (${err instanceof Error ? err.message : String(err)}) — keeping previous summary`
+    );
+  }
 }
 
 async function syncBacklog(warnings: string[]): Promise<number> {

--- a/lib/clickup.ts
+++ b/lib/clickup.ts
@@ -2,7 +2,7 @@
 //
 // Minimal typed client for the ClickUp REST API (v2), scoped to what the
 // ingestion sync needs: list tasks (with custom fields) and task comments.
-// Pull-only — this module never writes to ClickUp. See ADR 0003.
+// Pull-only — this module never writes to ClickUp. See ADR 0004.
 //
 // Auth: CLICKUP_API_TOKEN env var (a personal API token with read access
 // to the IIDS-AI4UI space). Field ids below were captured from the live

--- a/lib/clickup.ts
+++ b/lib/clickup.ts
@@ -1,0 +1,317 @@
+// lib/clickup.ts
+//
+// Minimal typed client for the ClickUp REST API (v2), scoped to what the
+// ingestion sync needs: list tasks (with custom fields) and task comments.
+// Pull-only — this module never writes to ClickUp. See ADR 0003.
+//
+// Auth: CLICKUP_API_TOKEN env var (a personal API token with read access
+// to the IIDS-AI4UI space). Field ids below were captured from the live
+// space; they are stable identifiers, not secrets.
+//
+// Not marked "server-only" because scripts/sync-clickup.ts imports it
+// from tsx. Never import from a client component.
+
+const BASE = "https://api.clickup.com/api/v2";
+
+export class ClickUpError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ClickUpError";
+    this.status = status;
+  }
+}
+
+function token(): string {
+  const value = process.env.CLICKUP_API_TOKEN;
+  if (!value) {
+    throw new Error(
+      "CLICKUP_API_TOKEN is not set. Add a ClickUp personal API token with read access to the IIDS-AI4UI space (see .env.example)."
+    );
+  }
+  return value;
+}
+
+// Small courtesy delay between requests keeps a full sync (~35 requests)
+// far below ClickUp's ~100 req/min per-token limit.
+const INTER_REQUEST_DELAY_MS = 150;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function cuFetch<T>(path: string, attempt = 0): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { Authorization: token() },
+  });
+
+  if (res.status === 429 && attempt === 0) {
+    const retryAfter = Number(res.headers.get("Retry-After")) || 60;
+    console.warn(`  ! ClickUp 429 — waiting ${retryAfter}s before retry`);
+    await sleep(retryAfter * 1000);
+    return cuFetch<T>(path, attempt + 1);
+  }
+  if (res.status >= 500 && attempt === 0) {
+    await sleep(2000);
+    return cuFetch<T>(path, attempt + 1);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ClickUpError(
+      `ClickUp GET ${path} failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+      res.status
+    );
+  }
+
+  await sleep(INTER_REQUEST_DELAY_MS);
+  return (await res.json()) as T;
+}
+
+// ---------------------------------------------------------------------------
+// API shapes (only the parts the sync reads)
+// ---------------------------------------------------------------------------
+
+export interface ClickUpDropdownOption {
+  id: string;
+  name?: string;
+  label?: string; // "labels"-type fields use `label` instead of `name`
+  orderindex?: number;
+}
+
+export interface ClickUpCustomField {
+  id: string;
+  name: string;
+  type: string;
+  type_config?: { options?: ClickUpDropdownOption[] };
+  value?: unknown;
+}
+
+export interface ClickUpTask {
+  id: string;
+  name: string;
+  custom_item_id: number | null;
+  status: { status: string };
+  date_created: string; // ms epoch as string
+  date_updated: string;
+  date_closed: string | null;
+  description?: string | null;
+  text_content?: string | null;
+  creator?: { username: string | null };
+  custom_fields?: ClickUpCustomField[];
+}
+
+export interface ClickUpCommentSegment {
+  type?: string;
+  text?: string;
+  user?: { username?: string | null; email?: string | null };
+}
+
+export interface ClickUpComment {
+  id: string;
+  comment: ClickUpCommentSegment[];
+  comment_text: string;
+  user: { username: string | null; email?: string | null };
+  date: string; // ms epoch as string
+}
+
+// ---------------------------------------------------------------------------
+// Fetchers
+// ---------------------------------------------------------------------------
+
+/**
+ * All top-level tasks in a list, paginated. Custom fields are included in
+ * the response.
+ */
+export async function getListTasks(
+  listId: string,
+  opts: { includeClosed?: boolean } = {}
+): Promise<ClickUpTask[]> {
+  const tasks: ClickUpTask[] = [];
+  for (let page = 0; ; page++) {
+    const params = new URLSearchParams({
+      page: String(page),
+      subtasks: "false",
+      include_closed: opts.includeClosed ? "true" : "false",
+    });
+    const data = await cuFetch<{ tasks: ClickUpTask[]; last_page?: boolean }>(
+      `/list/${listId}/task?${params}`
+    );
+    tasks.push(...data.tasks);
+    if (data.last_page || data.tasks.length === 0) break;
+  }
+  return tasks;
+}
+
+/**
+ * All comments on a task, oldest page last. The API returns up to 25 per
+ * page, newest first; older pages are fetched with start + start_id.
+ */
+export async function getTaskComments(taskId: string): Promise<ClickUpComment[]> {
+  const comments: ClickUpComment[] = [];
+  let cursor: { start: string; startId: string } | null = null;
+  for (;;) {
+    const params = new URLSearchParams();
+    if (cursor) {
+      params.set("start", cursor.start);
+      params.set("start_id", cursor.startId);
+    }
+    const qs = params.toString();
+    const data = await cuFetch<{ comments: ClickUpComment[] }>(
+      `/task/${taskId}/comment${qs ? `?${qs}` : ""}`
+    );
+    comments.push(...data.comments);
+    if (data.comments.length < 25) break;
+    const oldest = data.comments[data.comments.length - 1]!;
+    cursor = { start: oldest.date, startId: oldest.id };
+  }
+  return comments;
+}
+
+// ---------------------------------------------------------------------------
+// Custom-field extraction
+// ---------------------------------------------------------------------------
+
+function field(task: ClickUpTask, fieldId: string): ClickUpCustomField | null {
+  return task.custom_fields?.find((f) => f.id === fieldId) ?? null;
+}
+
+/** Number fields arrive as strings ("3") or numbers. Null when unset. */
+export function getNumberField(task: ClickUpTask, fieldId: string): number | null {
+  const value = field(task, fieldId)?.value;
+  if (value === undefined || value === null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function getTextField(task: ClickUpTask, fieldId: string): string | null {
+  const value = field(task, fieldId)?.value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Dropdown values arrive either as the option's orderindex (number) or its
+ * uuid (string). Resolve to the option's display name.
+ */
+export function getDropdownField(task: ClickUpTask, fieldId: string): string | null {
+  const f = field(task, fieldId);
+  if (!f || f.value === undefined || f.value === null) return null;
+  const options = f.type_config?.options ?? [];
+  const match =
+    typeof f.value === "number"
+      ? options.find((o) => o.orderindex === f.value)
+      : options.find((o) => o.id === f.value);
+  return match?.name ?? match?.label ?? null;
+}
+
+export interface ClickUpPerson {
+  name: string;
+  email: string | null;
+}
+
+/** Users fields hold arrays of member objects; username may be null for guests. */
+export function getUsersField(task: ClickUpTask, fieldId: string): ClickUpPerson[] {
+  const value = field(task, fieldId)?.value;
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((u) => {
+      const user = u as { username?: string | null; email?: string | null };
+      const name = user.username ?? user.email ?? null;
+      if (!name) return null;
+      return { name, email: user.email ?? null };
+    })
+    .filter((p): p is ClickUpPerson => p !== null);
+}
+
+/** Date fields arrive as ms-epoch strings. Returns "YYYY-MM-DD" or null. */
+export function getDateField(task: ClickUpTask, fieldId: string): string | null {
+  const value = field(task, fieldId)?.value;
+  if (value === undefined || value === null || value === "") return null;
+  const ms = Number(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export function getUrlField(task: ClickUpTask, fieldId: string): string | null {
+  return getTextField(task, fieldId);
+}
+
+/** Formula values arrive as strings ("64") when computed, absent otherwise. */
+export function getFormulaField(task: ClickUpTask, fieldId: string): number | null {
+  return getNumberField(task, fieldId);
+}
+
+/**
+ * Plain-text comment body from the structured segment array: text segments
+ * verbatim, user-mention segments as display names. Falls back to
+ * comment_text when segments are missing.
+ */
+export function commentBodyText(comment: ClickUpComment): string {
+  if (!Array.isArray(comment.comment) || comment.comment.length === 0) {
+    return comment.comment_text ?? "";
+  }
+  return comment.comment
+    .map((segment) => {
+      if (segment.user) return segment.user.username ?? segment.user.email ?? "";
+      return segment.text ?? "";
+    })
+    .join("")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Field ids (captured from the live IIDS-AI4UI space)
+// ---------------------------------------------------------------------------
+
+/** ClickUp task type ("Project Detail") used for each list's notes task. */
+export const PROJECT_NOTES_CUSTOM_ITEM_ID = 1007;
+
+/** Fields read from each project list's "Project Notes" task. */
+export const PROJECT_FIELDS = {
+  roiFte: "cf9b0bf9-32fb-4a93-a5aa-3f6c51f1e166",
+  roiExplanation: "36e11677-6f75-4dce-8cbb-fbd4538c4ac8",
+  leads: "24af91a5-9373-4d48-afa2-e6f3f9bddeef",
+  pocs: "8afcbe58-f717-4b09-8270-1038a575f8e9",
+  stakeholders: "e080713b-6508-4602-9897-4dff1688bfba",
+  repoUrl: "e935db95-fb1c-460b-98b5-e079a00bae70", // "Github Repo/Website Link"
+  projectedCompletion: "41912eac-3597-4382-82e9-3a7f4d37a7e2",
+  scope: "1db86409-581a-4c30-95fd-939ae02ce48a",
+  businessUnit: "42d71c8b-9673-4faf-b319-4b8dfc66a271", // "Business Unit Customer"
+} as const;
+
+/** Fields read from the "AI4UI New Project Requests" backlog tasks. */
+export const RUBRIC_FIELDS = {
+  a1: "432f1cea-01da-464b-905e-e9306e80afca", // A1 Alignment with University Strategic Plan
+  a2: "cddc28c1-8e62-445f-932e-65f864521e50", // A2 Financial Impact (Savings/Revenue)
+  a3: "999c0f52-da35-4491-8dd2-2a6c1818bacf", // A3 Breadth of Impact/Transferability
+  a4: "18f76174-b417-4317-acca-58822180f911", // A4 Reputational Benefit & Visibility
+  b1: "e5cf0686-d9ae-49be-b06c-fcbaeef33ce5", // B1 Technical Complexity
+  b2: "bbae29f9-9e83-457d-ba68-08c70f98fb82", // B2 Data Availability & Quality
+  b3: "0bb1bad6-0b4e-4fc7-a945-e42a73590016", // B3 Time to Deliver MVP
+  b4: "97f3a818-85b1-4a56-a665-f4f2c9a63eaf", // B4 Technical Load/Maintenance
+  c1: "e8b1de19-3a23-4c43-b802-8ee8b4282eb1", // C1 Urgency & Pain Point Severity
+  c2: "2b16094c-46a3-4964-b4ca-bcf780eb4b77", // C2 Depth of Impact (Improvement per User)
+  c3: "b58b22d1-3249-4cdc-997d-4d61770c1476", // C3 Champion & Departmental Buy-in
+  weightedScore: "a2d8f53a-7ed4-4efd-8736-7addb93321cb",
+  feasibility: "adea2188-0b91-41ef-8de6-824bb8543569",
+  unit: "4afdb82c-c5ed-4ba8-9a83-064df923f6a9",
+  category: "b5e9c05d-a178-460c-b4db-928d5060ff6d", // "Project Category"
+  submitter: "a47ad6ec-9fe5-4886-b5ce-6fc5333d404b", // "Your Name"
+} as const;
+
+/**
+ * The published rubric weights, mirrored from the ClickUp "Weighted Score"
+ * formula: (A1..A4 × 0.1 + B1..B4 × 0.075 + C1..C3 × 0.1) × 20.
+ * Used only as a fallback when the API omits the formula value.
+ */
+export function computeWeightedScore(rubric: {
+  a1: number; a2: number; a3: number; a4: number;
+  b1: number; b2: number; b3: number; b4: number;
+  c1: number; c2: number; c3: number;
+}): number {
+  const a = (rubric.a1 + rubric.a2 + rubric.a3 + rubric.a4) * 0.1;
+  const b = (rubric.b1 + rubric.b2 + rubric.b3 + rubric.b4) * 0.075;
+  const c = (rubric.c1 + rubric.c2 + rubric.c3) * 0.1;
+  return (a + b + c) * 20;
+}

--- a/lib/clickup.ts
+++ b/lib/clickup.ts
@@ -270,7 +270,7 @@ export const PROJECT_NOTES_CUSTOM_ITEM_ID = 1007;
 /** Fields read from each project list's "Project Notes" task. */
 export const PROJECT_FIELDS = {
   roiFte: "cf9b0bf9-32fb-4a93-a5aa-3f6c51f1e166",
-  roiExplanation: "36e11677-6f75-4dce-8cbb-fbd4538c4ac8",
+  roiExplanation: "36e11677-c07a-44df-8c16-a63f52e8110c",
   leads: "24af91a5-9373-4d48-afa2-e6f3f9bddeef",
   pocs: "8afcbe58-f717-4b09-8270-1038a575f8e9",
   stakeholders: "e080713b-6508-4602-9897-4dff1688bfba",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "seed:portfolio": "tsx --env-file=.env.local scripts/seed-portfolio.ts",
     "verify:portfolio": "tsx scripts/verify-portfolio.ts",
     "refresh:commit-dates": "tsx scripts/refresh-commit-dates.ts",
+    "sync:clickup": "tsx --env-file=.env.local scripts/sync-clickup.ts",
     "eval:agent": "NODE_OPTIONS='--conditions=react-server' tsx --env-file=.env.local --tsconfig tsconfig.json evals/agent/run.ts"
   },
   "dependencies": {

--- a/scripts/sync-clickup.ts
+++ b/scripts/sync-clickup.ts
@@ -1,0 +1,49 @@
+// scripts/sync-clickup.ts
+//
+// Pulls the IIDS-AI4UI ClickUp space into Postgres: per-project status
+// updates + ROI (clickup_projects, clickup_status_updates) and the scored
+// intake backlog (clickup_requests). Read-only against ClickUp; upserts
+// keyed by ClickUp ids so re-runs are idempotent. See ADR 0003.
+//
+// Env:
+//   DATABASE_URL       — required
+//   CLICKUP_API_TOKEN  — required (personal token with read access to the
+//                        IIDS-AI4UI space)
+//
+// Usage:
+//   npm run sync:clickup
+//
+// In production the same engine runs via POST /internal/sync (Basic auth),
+// which the host cron curls — see ADR 0003.
+
+import { pool } from "../lib/db.js";
+import { runSync } from "../lib/clickup-sync.js";
+
+async function main(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+  if (!process.env.CLICKUP_API_TOKEN) {
+    console.error("CLICKUP_API_TOKEN is not set (see .env.example).");
+    process.exit(1);
+  }
+
+  console.log("Syncing ClickUp (IIDS-AI4UI space) → Postgres ...\n");
+  const summary = await runSync("cron");
+
+  console.log(
+    `\nSynced ${summary.projects} projects, ${summary.statusUpdates} status updates, ${summary.requests} requests (run #${summary.runId}).`
+  );
+  if (summary.warnings.length > 0) {
+    console.warn(`\n${summary.warnings.length} warning(s):`);
+    for (const warning of summary.warnings) console.warn(`  ! ${warning}`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("sync-clickup failed:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/scripts/sync-clickup.ts
+++ b/scripts/sync-clickup.ts
@@ -6,9 +6,12 @@
 // keyed by ClickUp ids so re-runs are idempotent. See ADR 0003.
 //
 // Env:
-//   DATABASE_URL       — required
-//   CLICKUP_API_TOKEN  — required (personal token with read access to the
-//                        IIDS-AI4UI space)
+//   DATABASE_URL        — required
+//   CLICKUP_API_TOKEN   — required (personal token with read access to the
+//                         IIDS-AI4UI space)
+//   MINDROUTER_API_KEY  — optional; generates the public status summaries
+//                         (without it, sync still runs and summaries keep
+//                         their previous value, with a warning per project)
 //
 // Usage:
 //   npm run sync:clickup

--- a/scripts/sync-clickup.ts
+++ b/scripts/sync-clickup.ts
@@ -3,7 +3,7 @@
 // Pulls the IIDS-AI4UI ClickUp space into Postgres: per-project status
 // updates + ROI (clickup_projects, clickup_status_updates) and the scored
 // intake backlog (clickup_requests). Read-only against ClickUp; upserts
-// keyed by ClickUp ids so re-runs are idempotent. See ADR 0003.
+// keyed by ClickUp ids so re-runs are idempotent. See ADR 0004.
 //
 // Env:
 //   DATABASE_URL        — required
@@ -17,7 +17,7 @@
 //   npm run sync:clickup
 //
 // In production the same engine runs via POST /internal/sync (Basic auth),
-// which the host cron curls — see ADR 0003.
+// which the host cron curls — see ADR 0004.
 
 import { pool } from "../lib/db.js";
 import { runSync } from "../lib/clickup-sync.js";


### PR DESCRIPTION
## Summary

First of four PRs wiring the IIDS-AI4UI ClickUp space into the site (Sprint 3b read side, per new [ADR 0003](docs/adr/0003-clickup-ingestion-boundary.md)):

- **Migration 010** — `clickup_projects` (per-list ROI + people fields from each "Project Notes" task), `clickup_status_updates` (the notes-task comments = dated status narrative), `clickup_requests` (intake backlog with 11 rubric columns + weighted score), `clickup_sync_runs` (freshness/audit). **No FKs to `applications`** — `seed:portfolio`'s `TRUNCATE … CASCADE` can't wipe synced data; slug joins happen at read time via `lib/clickup-map.ts`.
- **`lib/clickup.ts`** — minimal ClickUp REST v2 client (429/5xx retry, pagination) + typed custom-field extractors; field UUIDs captured from the live space.
- **`lib/clickup-sync.ts`** — `runSync()` shared by `npm run sync:clickup` (this PR) and the `/internal/sync` route (PR 4). Deletes-per-list only after a successful fetch (stale beats missing); missing formula values fall back to locally computed weighted scores flagged `score_source='computed'`.
- `.env.example` + docker-compose gain `CLICKUP_API_TOKEN` (only the token is config; ids are typed code).

## Verification

- `npm run migrate` applies 010 cleanly (dev DB)
- `npm run build` green
- `npm run seed:portfolio` re-run leaves `clickup_*` tables intact (the truncate-cascade gotcha this schema designs around)
- Script fails fast with a clear message when `CLICKUP_API_TOKEN` is unset
- Live sync run pending a ClickUp API token (launch gate in ADR 0003 also requires a content read-through before first prod sync)

Follow-ups: PR 2 (nine new portfolio entries), PR 3 (read layer + project-page UI), PR 4 (`/portfolio/pipeline` + Sync-now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)