### PR TITLE
Surface ClickUp status updates + ROI on project detail pages and cards

### DIFF
--- a/app/internal/portfolio/[slug]/page.tsx
+++ b/app/internal/portfolio/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {
   getApplicationBySlug,
   getRelatedApplications,
 } from "@/lib/work";
+import { getProjectStatusBySlug } from "@/lib/clickup-data";
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +31,10 @@ export default async function InternalProjectDetailPage({
   const app = await getApplicationBySlug(slug, { audience: "internal" });
   if (!app) notFound();
 
-  const related = await getRelatedApplications(app, { audience: "internal" });
+  const [related, clickup] = await Promise.all([
+    getRelatedApplications(app, { audience: "internal" }),
+    getProjectStatusBySlug(slug),
+  ]);
 
   return (
     <ProjectDetail
@@ -38,6 +42,7 @@ export default async function InternalProjectDetailPage({
       related={related}
       audience="internal"
       basePath="/internal/portfolio"
+      clickup={clickup}
     />
   );
 }

--- a/app/portfolio/[slug]/page.tsx
+++ b/app/portfolio/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   getRelatedApplications,
   listSlugs,
 } from "@/lib/work";
+import { getProjectStatusBySlug } from "@/lib/clickup-data";
 
 export const dynamic = "force-dynamic";
 
@@ -44,7 +45,10 @@ export default async function ProjectDetailPage({
   const app = await getApplicationBySlug(slug, { audience: "public" });
   if (!app) notFound();
 
-  const related = await getRelatedApplications(app, { audience: "public" });
+  const [related, clickup] = await Promise.all([
+    getRelatedApplications(app, { audience: "public" }),
+    getProjectStatusBySlug(slug),
+  ]);
 
   return (
     <ProjectDetail
@@ -52,6 +56,7 @@ export default async function ProjectDetailPage({
       related={related}
       audience="public"
       basePath="/portfolio"
+      clickup={clickup}
     />
   );
 }

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -7,7 +7,7 @@ import {
   groupByHomeUnit,
   type ApplicationWithBlockers,
 } from "@/lib/work";
-import { getLatestUpdates } from "@/lib/clickup-data";
+import { getCardStatusLines } from "@/lib/clickup-data";
 import {
   WORK_CATEGORIES,
   WORK_CATEGORY_LABELS,
@@ -97,7 +97,7 @@ export default async function PortfolioPage({
 
   const [allApps, latestUpdates] = await Promise.all([
     listApplications({ audience: "public" }),
-    getLatestUpdates(),
+    getCardStatusLines(),
   ]);
 
   // Build filter option lists from the unfiltered set so users see what's

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -7,6 +7,7 @@ import {
   groupByHomeUnit,
   type ApplicationWithBlockers,
 } from "@/lib/work";
+import { getLatestUpdates } from "@/lib/clickup-data";
 import {
   WORK_CATEGORIES,
   WORK_CATEGORY_LABELS,
@@ -94,7 +95,10 @@ export default async function PortfolioPage({
   const blockersOnly = params.blockers === "1";
   const sortMode: SortMode = isSortMode(params.sort) ? params.sort : "default";
 
-  const allApps = await listApplications({ audience: "public" });
+  const [allApps, latestUpdates] = await Promise.all([
+    listApplications({ audience: "public" }),
+    getLatestUpdates(),
+  ]);
 
   // Build filter option lists from the unfiltered set so users see what's
   // available to filter by even after they've applied something.
@@ -372,7 +376,12 @@ export default async function PortfolioPage({
       {flatSorted && flatSorted.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {flatSorted.map((app) => (
-            <PortfolioCard key={app.id} app={app} audience="public" />
+            <PortfolioCard
+              key={app.id}
+              app={app}
+              audience="public"
+              latestUpdate={latestUpdates.get(app.slug) ?? null}
+            />
           ))}
         </div>
       )}
@@ -391,7 +400,12 @@ export default async function PortfolioPage({
             </div>
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               {items.map((app) => (
-                <PortfolioCard key={app.id} app={app} audience="public" />
+                <PortfolioCard
+                  key={app.id}
+                  app={app}
+                  audience="public"
+                  latestUpdate={latestUpdates.get(app.slug) ?? null}
+                />
               ))}
             </div>
           </section>

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -53,10 +53,14 @@ export default function PortfolioCard({
   app,
   audience = "public",
   basePath = "/portfolio",
+  latestUpdate,
 }: {
   app: ApplicationWithBlockers;
   audience?: "public" | "internal";
   basePath?: string;
+  // Most recent ClickUp status update (ADR 0003); omitted for projects
+  // without a mapped ClickUp list.
+  latestUpdate?: { postedAt: string; body: string } | null;
 }) {
   const owners = app.operationalOwners
     .map((o) => o.name)
@@ -127,6 +131,21 @@ export default function PortfolioCard({
       {app.tagline && (
         <p className="mt-3 text-sm leading-relaxed text-ink-muted">
           {app.tagline}
+        </p>
+      )}
+
+      {latestUpdate && (
+        <p className="mt-3 line-clamp-2 text-xs leading-snug text-ink-subtle">
+          <span className="font-semibold text-ink-muted">
+            Update{" "}
+            {new Date(latestUpdate.postedAt).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
+            :
+          </span>{" "}
+          {firstLine(latestUpdate.body)}
         </p>
       )}
 
@@ -221,6 +240,12 @@ export default function PortfolioCard({
       )}
     </article>
   );
+}
+
+// Status-update bodies are multi-paragraph; the card shows only the first
+// substantive line (the detail page has the full timeline).
+function firstLine(body: string): string {
+  return body.split("\n").find((l) => l.trim() !== "")?.trim() ?? body;
 }
 
 function hostnameOf(url: string): string | null {

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -137,7 +137,7 @@ export default function PortfolioCard({
       {latestUpdate && (
         <p className="mt-3 line-clamp-2 text-xs leading-snug text-ink-subtle">
           <span className="font-semibold text-ink-muted">
-            Update{" "}
+            Status as of{" "}
             {new Date(latestUpdate.postedAt).toLocaleDateString("en-US", {
               month: "short",
               day: "numeric",

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -58,7 +58,7 @@ export default function PortfolioCard({
   app: ApplicationWithBlockers;
   audience?: "public" | "internal";
   basePath?: string;
-  // Most recent ClickUp status update (ADR 0003); omitted for projects
+  // Most recent ClickUp status update (ADR 0004); omitted for projects
   // without a mapped ClickUp list.
   latestUpdate?: { postedAt: string; body: string } | null;
 }) {

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -122,7 +122,7 @@ export interface ProjectDetailProps {
   related: RelatedApp[];
   audience: "public" | "internal";
   basePath: string; // "/portfolio" or "/internal/portfolio"
-  // ClickUp-synced status narrative + ROI (ADR 0003). Null/undefined when
+  // ClickUp-synced status narrative + ROI (ADR 0004). Null/undefined when
   // the project has no mapped ClickUp list or sync hasn't run.
   clickup?: ClickUpProjectStatus | null;
 }
@@ -333,7 +333,7 @@ export default function ProjectDetail({
       )}
 
       {/* Public: the generated summary only — the verbatim comment corpus
-          is internal notes and never renders publicly (ADR 0003, amended). */}
+          is internal notes and never renders publicly (ADR 0004, amended). */}
       {audience === "public" && clickup?.statusSummary && (
         <section>
           <SectionEyebrow>Current status</SectionEyebrow>

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -332,10 +332,37 @@ export default function ProjectDetail({
         </section>
       )}
 
-      {clickup && clickup.updates.length > 0 && (
+      {/* Public: the generated summary only — the verbatim comment corpus
+          is internal notes and never renders publicly (ADR 0003, amended). */}
+      {audience === "public" && clickup?.statusSummary && (
+        <section>
+          <SectionEyebrow>Current status</SectionEyebrow>
+          <p className="mt-2 max-w-3xl text-base leading-relaxed text-ui-charcoal">
+            {clickup.statusSummary}
+          </p>
+          <p className="mt-3 text-xs text-brand-silver">
+            Summarized from {clickup.updates.length} project update
+            {clickup.updates.length === 1 ? "" : "s"}
+            {clickup.updates[0] &&
+              ` (latest ${formatSyncDate(clickup.updates[0].postedAt)})`}
+            . Status data from ClickUp, synced{" "}
+            {formatSyncDate(clickup.syncedAt)}.
+          </p>
+        </section>
+      )}
+
+      {/* Internal: the public summary for reference, then the full
+          verbatim timeline. */}
+      {audience === "internal" && clickup && clickup.updates.length > 0 && (
         <section>
           <SectionEyebrow>Status updates</SectionEyebrow>
-          <ol className="mt-3 max-w-3xl space-y-5">
+          {clickup.statusSummary && (
+            <p className="mt-2 max-w-3xl rounded-md border border-hairline bg-surface-alt px-4 py-3 text-sm leading-relaxed text-ui-charcoal">
+              <span className="font-semibold">Public summary:</span>{" "}
+              {clickup.statusSummary}
+            </p>
+          )}
+          <ol className="mt-4 max-w-3xl space-y-5">
             {clickup.updates.map((u) => (
               <li
                 key={u.commentId}

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
+import type { ClickUpProjectStatus } from "@/lib/clickup-data";
+import SyncFreshness, { formatSyncDate } from "@/components/SyncFreshness";
 import {
   OPERATIONAL_LABEL,
   PUBLIC_STAGE_CHIP,
@@ -120,6 +122,9 @@ export interface ProjectDetailProps {
   related: RelatedApp[];
   audience: "public" | "internal";
   basePath: string; // "/portfolio" or "/internal/portfolio"
+  // ClickUp-synced status narrative + ROI (ADR 0003). Null/undefined when
+  // the project has no mapped ClickUp list or sync hasn't run.
+  clickup?: ClickUpProjectStatus | null;
 }
 
 export default function ProjectDetail({
@@ -127,6 +132,7 @@ export default function ProjectDetail({
   related,
   audience,
   basePath,
+  clickup,
 }: ProjectDetailProps) {
   const isEmbargoed = app.visibilityTier === "embargoed";
   const isInternal = app.visibilityTier === "internal";
@@ -283,12 +289,29 @@ export default function ProjectDetail({
           blockers are supporting context. The single gold left-rule on
           the outcome is the page's emotional center; per .impeccable.md,
           gold is reserved for rare emphasis. */}
-      {app.operationalExcellenceOutcome && (
+      {(app.operationalExcellenceOutcome || clickup?.roiExplanation) && (
         <section className="border-l-4 border-ui-gold pl-6">
           <SectionEyebrow>Why this matters</SectionEyebrow>
-          <p className="mt-2 max-w-3xl text-lg leading-relaxed text-ui-charcoal">
-            {app.operationalExcellenceOutcome}
-          </p>
+          {app.operationalExcellenceOutcome && (
+            <p className="mt-2 max-w-3xl text-lg leading-relaxed text-ui-charcoal">
+              {app.operationalExcellenceOutcome}
+            </p>
+          )}
+          {clickup?.roiExplanation && (
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-muted">
+              {clickup.roiFte != null && clickup.roiFte > 0 ? (
+                <>
+                  Estimated capacity returned:{" "}
+                  <span className="font-semibold text-ui-charcoal">
+                    {clickup.roiFte} FTE
+                  </span>{" "}
+                  — {clickup.roiExplanation}
+                </>
+              ) : (
+                <>Estimated return: {clickup.roiExplanation}</>
+              )}
+            </p>
+          )}
         </section>
       )}
 
@@ -306,6 +329,36 @@ export default function ProjectDetail({
               contact history) lives on the internal view.
             </p>
           )}
+        </section>
+      )}
+
+      {clickup && clickup.updates.length > 0 && (
+        <section>
+          <SectionEyebrow>Status updates</SectionEyebrow>
+          <ol className="mt-3 max-w-3xl space-y-5">
+            {clickup.updates.map((u) => (
+              <li
+                key={u.commentId}
+                className="border-l-2 border-hairline pl-4"
+              >
+                <p className="text-sm font-semibold text-brand-black">
+                  {formatSyncDate(u.postedAt)}
+                  {u.author && (
+                    <span className="font-normal text-ink-muted">
+                      {" "}
+                      · {u.author}
+                    </span>
+                  )}
+                </p>
+                <p className="mt-1 whitespace-pre-line text-sm leading-relaxed text-ui-charcoal">
+                  {u.body}
+                </p>
+              </li>
+            ))}
+          </ol>
+          <div className="mt-4">
+            <SyncFreshness syncedAt={clickup.syncedAt} />
+          </div>
         </section>
       )}
 

--- a/components/SyncFreshness.tsx
+++ b/components/SyncFreshness.tsx
@@ -1,4 +1,4 @@
-// Muted provenance line for ClickUp-synced content (ADR 0003). Every
+// Muted provenance line for ClickUp-synced content (ADR 0004). Every
 // surface rendering synced data shows when it was last pulled, so a
 // stalled sync reads as stale instead of current.
 

--- a/components/SyncFreshness.tsx
+++ b/components/SyncFreshness.tsx
@@ -1,0 +1,19 @@
+// Muted provenance line for ClickUp-synced content (ADR 0003). Every
+// surface rendering synced data shows when it was last pulled, so a
+// stalled sync reads as stale instead of current.
+
+export function formatSyncDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default function SyncFreshness({ syncedAt }: { syncedAt: string }) {
+  return (
+    <p className="text-xs text-brand-silver">
+      Status data from ClickUp, synced {formatSyncDate(syncedAt)}.
+    </p>
+  );
+}

--- a/lib/clickup-data.ts
+++ b/lib/clickup-data.ts
@@ -1,0 +1,295 @@
+// lib/clickup-data.ts
+//
+// Server-only read layer over the ClickUp-synced tables (migration 010,
+// ADR 0003). Deliberately separate from lib/work.ts: that module reads
+// the applications registry (seeded, canonical identity); this one reads
+// a projection of ClickUp with its own freshness model. Rows are keyed
+// by ClickUp ids and joined to portfolio slugs here, at read time, via
+// lib/clickup-map.ts.
+
+import "server-only";
+
+import { query, queryOne } from "./db";
+import { CLICKUP_PROJECT_LISTS, listIdForSlug, slugForListId } from "./clickup-map";
+import type { ClickUpPerson } from "./clickup";
+
+export interface StatusUpdate {
+  commentId: string;
+  author: string | null;
+  postedAt: string; // ISO 8601
+  body: string;
+}
+
+export interface ClickUpProjectStatus {
+  listId: string;
+  slug: string;
+  roiFte: number | null;
+  roiExplanation: string | null;
+  leads: ClickUpPerson[];
+  pocs: ClickUpPerson[];
+  stakeholders: ClickUpPerson[];
+  repoUrl: string | null;
+  projectedCompletion: string | null; // ISO date
+  scope: string | null;
+  businessUnit: string | null;
+  updates: StatusUpdate[];
+  syncedAt: string; // ISO 8601
+}
+
+export type RequestStatus = "pending" | "active" | "rejected" | "complete";
+
+export interface RequestRubric {
+  a1: number | null;
+  a2: number | null;
+  a3: number | null;
+  a4: number | null;
+  b1: number | null;
+  b2: number | null;
+  b3: number | null;
+  b4: number | null;
+  c1: number | null;
+  c2: number | null;
+  c3: number | null;
+}
+
+export interface ScoredRequest {
+  taskId: string;
+  name: string;
+  status: RequestStatus;
+  rawStatus: string;
+  description: string | null;
+  unit: string | null;
+  submitter: string | null;
+  category: string | null;
+  feasibility: string | null;
+  rubric: RequestRubric;
+  weightedScore: number | null;
+  scoreSource: "clickup" | "computed";
+  dateCreated: string | null;
+}
+
+export interface SyncInfo {
+  finishedAt: string; // ISO 8601
+  ok: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes + mappers
+// ---------------------------------------------------------------------------
+
+interface ProjectRow {
+  clickup_list_id: string;
+  roi_fte: string | null;
+  roi_explanation: string | null;
+  leads: ClickUpPerson[];
+  pocs: ClickUpPerson[];
+  stakeholders: ClickUpPerson[];
+  repo_url: string | null;
+  projected_completion: Date | string | null;
+  scope: string | null;
+  business_unit: string | null;
+  synced_at: Date;
+}
+
+interface UpdateRow {
+  comment_id: string;
+  clickup_list_id: string;
+  author: string | null;
+  posted_at: Date;
+  body_text: string;
+}
+
+interface RequestRow {
+  clickup_task_id: string;
+  name: string;
+  status: string;
+  description: string | null;
+  unit: string | null;
+  submitter: string | null;
+  category: string | null;
+  feasibility: string | null;
+  rubric_a1: string | null;
+  rubric_a2: string | null;
+  rubric_a3: string | null;
+  rubric_a4: string | null;
+  rubric_b1: string | null;
+  rubric_b2: string | null;
+  rubric_b3: string | null;
+  rubric_b4: string | null;
+  rubric_c1: string | null;
+  rubric_c2: string | null;
+  rubric_c3: string | null;
+  weighted_score: string | null;
+  score_source: string;
+  date_created: Date | null;
+}
+
+function toNumber(value: string | null): number | null {
+  if (value === null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toIsoDate(value: Date | string | null): string | null {
+  if (value === null) return null;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return value;
+}
+
+function toUpdate(row: UpdateRow): StatusUpdate {
+  return {
+    commentId: row.comment_id,
+    author: row.author,
+    postedAt: row.posted_at.toISOString(),
+    body: row.body_text,
+  };
+}
+
+/**
+ * ClickUp status text → typed union. Unknown statuses bucket as `pending`
+ * with a warning so an upstream rename degrades loudly, not silently.
+ */
+export function normalizeRequestStatus(raw: string): RequestStatus {
+  const s = raw.trim().toLowerCase();
+  if (s === "to be reviewed") return "pending";
+  if (s === "active") return "active";
+  if (s === "rejected") return "rejected";
+  if (s === "complete") return "complete";
+  console.warn(`clickup-data: unknown request status "${raw}" — bucketing as pending`);
+  return "pending";
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * ClickUp-derived status for one portfolio project, or null when the slug
+ * has no mapped ClickUp list or the list hasn't synced yet.
+ */
+export async function getProjectStatusBySlug(
+  slug: string,
+  opts: { updateLimit?: number } = {}
+): Promise<ClickUpProjectStatus | null> {
+  const listId = listIdForSlug(slug);
+  if (!listId) return null;
+
+  const row = await queryOne<ProjectRow>(
+    `SELECT clickup_list_id, roi_fte, roi_explanation, leads, pocs,
+            stakeholders, repo_url, projected_completion, scope,
+            business_unit, synced_at
+     FROM clickup_projects WHERE clickup_list_id = $1`,
+    [listId]
+  );
+  if (!row) return null;
+
+  const limit = opts.updateLimit ?? 25;
+  const updates = await query<UpdateRow>(
+    `SELECT comment_id, clickup_list_id, author, posted_at, body_text
+     FROM clickup_status_updates
+     WHERE clickup_list_id = $1
+     ORDER BY posted_at DESC
+     LIMIT $2`,
+    [listId, limit]
+  );
+
+  return {
+    listId: row.clickup_list_id,
+    slug,
+    roiFte: toNumber(row.roi_fte),
+    roiExplanation: row.roi_explanation,
+    leads: row.leads,
+    pocs: row.pocs,
+    stakeholders: row.stakeholders,
+    repoUrl: row.repo_url,
+    projectedCompletion: toIsoDate(row.projected_completion),
+    scope: row.scope,
+    businessUnit: row.business_unit,
+    updates: updates.map(toUpdate),
+    syncedAt: row.synced_at.toISOString(),
+  };
+}
+
+/**
+ * Latest status update per mapped portfolio slug — one query, for the
+ * /portfolio card grid.
+ */
+export async function getLatestUpdates(): Promise<Map<string, StatusUpdate>> {
+  const rows = await query<UpdateRow>(
+    `SELECT DISTINCT ON (clickup_list_id)
+            comment_id, clickup_list_id, author, posted_at, body_text
+     FROM clickup_status_updates
+     ORDER BY clickup_list_id, posted_at DESC`
+  );
+  const bySlug = new Map<string, StatusUpdate>();
+  for (const row of rows) {
+    const slug = slugForListId(row.clickup_list_id);
+    if (slug) bySlug.set(slug, toUpdate(row));
+  }
+  return bySlug;
+}
+
+/**
+ * The scored request backlog, highest weighted score first. All statuses —
+ * callers filter by the normalized `status`.
+ */
+export async function listScoredRequests(): Promise<ScoredRequest[]> {
+  const rows = await query<RequestRow>(
+    `SELECT clickup_task_id, name, status, description, unit, submitter,
+            category, feasibility,
+            rubric_a1, rubric_a2, rubric_a3, rubric_a4,
+            rubric_b1, rubric_b2, rubric_b3, rubric_b4,
+            rubric_c1, rubric_c2, rubric_c3,
+            weighted_score, score_source, date_created
+     FROM clickup_requests
+     ORDER BY weighted_score DESC NULLS LAST, name ASC`
+  );
+  return rows.map((row) => ({
+    taskId: row.clickup_task_id,
+    name: row.name,
+    status: normalizeRequestStatus(row.status),
+    rawStatus: row.status,
+    description: row.description,
+    unit: row.unit,
+    submitter: row.submitter,
+    category: row.category,
+    feasibility: row.feasibility,
+    rubric: {
+      a1: toNumber(row.rubric_a1),
+      a2: toNumber(row.rubric_a2),
+      a3: toNumber(row.rubric_a3),
+      a4: toNumber(row.rubric_a4),
+      b1: toNumber(row.rubric_b1),
+      b2: toNumber(row.rubric_b2),
+      b3: toNumber(row.rubric_b3),
+      b4: toNumber(row.rubric_b4),
+      c1: toNumber(row.rubric_c1),
+      c2: toNumber(row.rubric_c2),
+      c3: toNumber(row.rubric_c3),
+    },
+    weightedScore: toNumber(row.weighted_score),
+    scoreSource: row.score_source === "computed" ? "computed" : "clickup",
+    dateCreated: row.date_created ? row.date_created.toISOString() : null,
+  }));
+}
+
+/** Most recent completed sync run, for freshness stamps. Null before first sync. */
+export async function getLastSync(): Promise<SyncInfo | null> {
+  const row = await queryOne<{ finished_at: Date; ok: boolean }>(
+    `SELECT finished_at, ok FROM clickup_sync_runs
+     WHERE finished_at IS NOT NULL
+     ORDER BY finished_at DESC LIMIT 1`
+  );
+  if (!row) return null;
+  return { finishedAt: row.finished_at.toISOString(), ok: row.ok };
+}
+
+/** Count of pending ("to be reviewed") requests, for the /portfolio stat strip. */
+export async function countPendingRequests(): Promise<number> {
+  const row = await queryOne<{ count: string }>(
+    `SELECT count(*) AS count FROM clickup_requests WHERE lower(status) = 'to be reviewed'`
+  );
+  return row ? Number(row.count) : 0;
+}
+
+export { CLICKUP_PROJECT_LISTS };

--- a/lib/clickup-data.ts
+++ b/lib/clickup-data.ts
@@ -1,7 +1,7 @@
 // lib/clickup-data.ts
 //
 // Server-only read layer over the ClickUp-synced tables (migration 010,
-// ADR 0003). Deliberately separate from lib/work.ts: that module reads
+// ADR 0004). Deliberately separate from lib/work.ts: that module reads
 // the applications registry (seeded, canonical identity); this one reads
 // a projection of ClickUp with its own freshness model. Rows are keyed
 // by ClickUp ids and joined to portfolio slugs here, at read time, via
@@ -32,7 +32,7 @@ export interface ClickUpProjectStatus {
   projectedCompletion: string | null; // ISO date
   scope: string | null;
   businessUnit: string | null;
-  // Public-safe generated summary of the status narrative (ADR 0003,
+  // Public-safe generated summary of the status narrative (ADR 0004,
   // amended July 2026). Null until the first summarization succeeds.
   statusSummary: string | null;
   statusSummaryAt: string | null; // ISO 8601
@@ -224,7 +224,7 @@ export async function getProjectStatusBySlug(
 /**
  * Public status line per mapped portfolio slug — one query, for the
  * /portfolio card grid. Body is the generated public summary (never the
- * verbatim comments — ADR 0003 amended); the date is when the newest
+ * verbatim comments — ADR 0004 amended); the date is when the newest
  * underlying update was posted.
  */
 export interface CardStatusLine {

--- a/lib/clickup-data.ts
+++ b/lib/clickup-data.ts
@@ -32,6 +32,11 @@ export interface ClickUpProjectStatus {
   projectedCompletion: string | null; // ISO date
   scope: string | null;
   businessUnit: string | null;
+  // Public-safe generated summary of the status narrative (ADR 0003,
+  // amended July 2026). Null until the first summarization succeeds.
+  statusSummary: string | null;
+  statusSummaryAt: string | null; // ISO 8601
+  // Verbatim comment timeline — internal-only rendering.
   updates: StatusUpdate[];
   syncedAt: string; // ISO 8601
 }
@@ -88,6 +93,8 @@ interface ProjectRow {
   projected_completion: Date | string | null;
   scope: string | null;
   business_unit: string | null;
+  status_summary: string | null;
+  status_summary_at: Date | null;
   synced_at: Date;
 }
 
@@ -177,7 +184,7 @@ export async function getProjectStatusBySlug(
   const row = await queryOne<ProjectRow>(
     `SELECT clickup_list_id, roi_fte, roi_explanation, leads, pocs,
             stakeholders, repo_url, projected_completion, scope,
-            business_unit, synced_at
+            business_unit, status_summary, status_summary_at, synced_at
      FROM clickup_projects WHERE clickup_list_id = $1`,
     [listId]
   );
@@ -205,26 +212,47 @@ export async function getProjectStatusBySlug(
     projectedCompletion: toIsoDate(row.projected_completion),
     scope: row.scope,
     businessUnit: row.business_unit,
+    statusSummary: row.status_summary,
+    statusSummaryAt: row.status_summary_at
+      ? row.status_summary_at.toISOString()
+      : null,
     updates: updates.map(toUpdate),
     syncedAt: row.synced_at.toISOString(),
   };
 }
 
 /**
- * Latest status update per mapped portfolio slug — one query, for the
- * /portfolio card grid.
+ * Public status line per mapped portfolio slug — one query, for the
+ * /portfolio card grid. Body is the generated public summary (never the
+ * verbatim comments — ADR 0003 amended); the date is when the newest
+ * underlying update was posted.
  */
-export async function getLatestUpdates(): Promise<Map<string, StatusUpdate>> {
-  const rows = await query<UpdateRow>(
-    `SELECT DISTINCT ON (clickup_list_id)
-            comment_id, clickup_list_id, author, posted_at, body_text
-     FROM clickup_status_updates
-     ORDER BY clickup_list_id, posted_at DESC`
+export interface CardStatusLine {
+  postedAt: string; // ISO 8601 — newest underlying update
+  body: string; // generated public summary
+}
+
+export async function getCardStatusLines(): Promise<Map<string, CardStatusLine>> {
+  const rows = await query<{
+    clickup_list_id: string;
+    status_summary: string;
+    latest_posted_at: Date;
+  }>(
+    `SELECT p.clickup_list_id, p.status_summary, max(u.posted_at) AS latest_posted_at
+     FROM clickup_projects p
+     JOIN clickup_status_updates u ON u.clickup_list_id = p.clickup_list_id
+     WHERE p.status_summary IS NOT NULL
+     GROUP BY p.clickup_list_id, p.status_summary`
   );
-  const bySlug = new Map<string, StatusUpdate>();
+  const bySlug = new Map<string, CardStatusLine>();
   for (const row of rows) {
     const slug = slugForListId(row.clickup_list_id);
-    if (slug) bySlug.set(slug, toUpdate(row));
+    if (slug) {
+      bySlug.set(slug, {
+        postedAt: row.latest_posted_at.toISOString(),
+        body: row.status_summary,
+      });
+    }
   }
   return bySlug;
 }


### PR DESCRIPTION
## Summary

PR 3 of 4 (stacked on #276). Renders the synced ClickUp data on the portfolio:

- **`lib/clickup-data.ts`** — server-only read layer over the `clickup_*` tables; joins to portfolio slugs at read time via `lib/clickup-map.ts`. Status normalization degrades loudly (unknown → `pending` + warn).
- **Project detail pages** gain a "Status updates" timeline (dated, author-named — the notes-task comments) and an ROI line in the "Why this matters" beat. Freshness stamp on the section foot.
- **Portfolio cards** show the latest update's first line (2-line clamp), fetched with a single `DISTINCT ON` query for the whole grid.
- Projects without a mapped ClickUp list render exactly as before (prop is optional/null).

No gold, no new client components — all server-rendered, restraint per `.impeccable.md`.

## Verification

- `npm run build` green
- Empty `clickup_*` tables → all surfaces render unchanged (verified: dev DB currently unsynced)
- Full visual verification happens once a `CLICKUP_API_TOKEN` is available to run the first sync (tracked on #276)

🤖 Generated with [Claude Code](https://claude.com/claude-code)