### PR TITLE
Public /portfolio/pipeline rubric page + Sync-now trigger on /internal

### DIFF
--- a/app/internal/page.tsx
+++ b/app/internal/page.tsx
@@ -1,10 +1,15 @@
 import Link from "next/link";
 import { listApplications } from "@/lib/work";
+import { getLastSync } from "@/lib/clickup-data";
+import SyncNowButton from "@/components/SyncNowButton";
 
 export const dynamic = "force-dynamic";
 
 export default async function InternalHome() {
-  const apps = await listApplications({ audience: "internal" });
+  const [apps, lastSync] = await Promise.all([
+    listApplications({ audience: "internal" }),
+    getLastSync(),
+  ]);
   const blockerCount = apps.reduce((sum, a) => sum + a.activeBlockers.length, 0);
   const internalOnly = apps.filter((a) => a.visibilityTier === "internal").length;
   const embargoed = apps.filter((a) => a.visibilityTier === "embargoed").length;
@@ -79,12 +84,26 @@ export default async function InternalHome() {
         </Link>
       </section>
 
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-base font-semibold text-ui-charcoal">
+          ClickUp sync
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Pulls project status updates, ROI, and the scored request backlog
+          from the IIDS-AI4UI space (ADR 0004). Runs on a host cron;
+          trigger manually after editing in ClickUp.
+        </p>
+        <div className="mt-4">
+          <SyncNowButton lastSyncedAt={lastSync?.finishedAt ?? null} />
+        </div>
+      </section>
+
       <section className="rounded-xl border border-dashed border-gray-300 bg-white/50 p-6">
         <h2 className="text-base font-semibold text-ui-charcoal">
           Coming in Sprint 3
         </h2>
         <ul className="mt-3 space-y-1 text-sm text-gray-600">
-          <li>&bull; ClickUp wiring — status and blocker data sync from ClickUp tasks</li>
+          <li>&bull; ClickUp write-side — new submissions create ClickUp tasks</li>
           <li>&bull; Submitter status pages (<code>/intake/[token]</code>)</li>
           <li>&bull; Submission similarity surfaced live during the assessment</li>
           <li>&bull; Named-SLA acknowledgment email on intake</li>

--- a/app/internal/sync/route.ts
+++ b/app/internal/sync/route.ts
@@ -1,0 +1,44 @@
+// POST /internal/sync — manual ClickUp sync trigger (ADR 0004).
+//
+// Lives under /internal so the existing Basic-auth middleware covers it
+// (fails closed 503 when credentials are unset). Used by the "Sync now"
+// button on /internal and by the host cron:
+//
+//   curl -s -u "$BASIC_AUTH_USER:$BASIC_AUTH_PASS" -X POST \
+//     https://aispeg.insight.uidaho.edu/internal/sync
+
+import { NextResponse } from "next/server";
+import { runSync } from "@/lib/clickup-sync";
+
+// A sync takes ~30-60s of sequential ClickUp calls; overlapping runs
+// would double-write and burn rate limit for nothing. One at a time.
+let syncInFlight = false;
+
+export async function POST() {
+  if (!process.env.CLICKUP_API_TOKEN) {
+    return NextResponse.json(
+      { error: "CLICKUP_API_TOKEN is not configured on this deployment." },
+      { status: 503 }
+    );
+  }
+  if (syncInFlight) {
+    return NextResponse.json(
+      { error: "A sync is already running." },
+      { status: 409 }
+    );
+  }
+
+  syncInFlight = true;
+  try {
+    const summary = await runSync("manual");
+    return NextResponse.json(summary);
+  } catch (err) {
+    console.error("POST /internal/sync failed:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Sync failed." },
+      { status: 500 }
+    );
+  } finally {
+    syncInFlight = false;
+  }
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -7,7 +7,7 @@ import {
   groupByHomeUnit,
   type ApplicationWithBlockers,
 } from "@/lib/work";
-import { getCardStatusLines } from "@/lib/clickup-data";
+import { getCardStatusLines, countPendingRequests } from "@/lib/clickup-data";
 import {
   WORK_CATEGORIES,
   WORK_CATEGORY_LABELS,
@@ -95,9 +95,10 @@ export default async function PortfolioPage({
   const blockersOnly = params.blockers === "1";
   const sortMode: SortMode = isSortMode(params.sort) ? params.sort : "default";
 
-  const [allApps, latestUpdates] = await Promise.all([
+  const [allApps, latestUpdates, pendingRequestCount] = await Promise.all([
     listApplications({ audience: "public" }),
     getCardStatusLines(),
+    countPendingRequests(),
   ]);
 
   // Build filter option lists from the unfiltered set so users see what's
@@ -221,6 +222,22 @@ export default async function PortfolioPage({
                 <span className="ml-1.5 text-amber-700">
                   active blocker{blockerCount === 1 ? "" : "s"}
                 </span>
+              </span>
+            )}
+            {pendingRequestCount > 0 && (
+              <span className="inline-flex items-baseline">
+                <span aria-hidden className="mr-2 text-brand-silver">
+                  ·
+                </span>
+                <span className="tabular-nums font-semibold text-brand-black">
+                  {pendingRequestCount}
+                </span>
+                <Link
+                  href="/portfolio/pipeline"
+                  className="ml-1.5 underline decoration-hairline underline-offset-2 hover:text-brand-black"
+                >
+                  request{pendingRequestCount === 1 ? "" : "s"} in review
+                </Link>
               </span>
             )}
           </p>

--- a/app/portfolio/pipeline/page.tsx
+++ b/app/portfolio/pipeline/page.tsx
@@ -1,0 +1,345 @@
+import Link from "next/link";
+import SyncFreshness from "@/components/SyncFreshness";
+import {
+  listScoredRequests,
+  getLastSync,
+  type ScoredRequest,
+} from "@/lib/clickup-data";
+import { listIdForSlug, CLICKUP_PROJECT_LISTS } from "@/lib/clickup-map";
+import { listApplications } from "@/lib/work";
+import {
+  RUBRIC_CRITERIA,
+  RUBRIC_FORMULA,
+  RUBRIC_GROUPS,
+} from "@/lib/rubric";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Project Pipeline · UI AI Portfolio",
+  description:
+    "How new AI project requests are scored and prioritized — the full rubric, weighted scores, and current review queue.",
+};
+
+function scoreCell(value: number | null): string {
+  return value === null ? "–" : String(value);
+}
+
+function PendingTable({ requests }: { requests: ScoredRequest[] }) {
+  const hasComputed = requests.some((r) => r.scoreSource === "computed");
+  return (
+    <div className="overflow-x-auto rounded-xl border border-hairline bg-white">
+      <table className="w-full min-w-[1000px] border-collapse text-left">
+        <thead>
+          <tr className="border-b border-hairline">
+            <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-ink-muted">
+              Request
+            </th>
+            <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-ink-muted">
+              Unit
+            </th>
+            <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-ink-muted">
+              Feasibility
+            </th>
+            {RUBRIC_CRITERIA.map((col) => (
+              <th
+                key={col.key}
+                title={`${col.name} (weight ${col.weight})`}
+                className="px-1.5 py-3 text-center text-xs font-semibold text-ink-muted"
+              >
+                {col.code}
+              </th>
+            ))}
+            <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-brand-black">
+              Score
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {requests.map((r) => (
+            <tr
+              key={r.taskId}
+              className="border-b border-hairline last:border-b-0"
+            >
+              <td className="px-4 py-2.5">
+                <p className="text-sm font-medium text-brand-black">{r.name}</p>
+                {r.category && (
+                  <p className="text-xs text-ink-subtle">{r.category}</p>
+                )}
+              </td>
+              <td className="px-3 py-2.5 text-xs text-ink-muted">
+                {r.unit ?? "–"}
+              </td>
+              <td className="px-3 py-2.5 text-xs text-ink-muted">
+                {r.feasibility ?? "–"}
+              </td>
+              {RUBRIC_CRITERIA.map((col) => (
+                <td
+                  key={col.key}
+                  className="px-1.5 py-2.5 text-center text-xs tabular-nums text-ui-charcoal"
+                >
+                  {scoreCell(r.rubric[col.key])}
+                </td>
+              ))}
+              <td className="px-4 py-2.5 text-right text-sm font-bold tabular-nums text-brand-black">
+                {r.weightedScore === null
+                  ? "–"
+                  : Math.round(r.weightedScore * 10) / 10}
+                {r.scoreSource === "computed" && (
+                  <span title="Computed from rubric values (formula value unavailable in ClickUp)">
+                    *
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {hasComputed && (
+        <p className="border-t border-hairline px-4 py-2 text-xs text-ink-subtle">
+          * Score computed from the rubric values; ClickUp&apos;s stored formula
+          value was unavailable.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function CompactRequestList({
+  requests,
+  slugByName,
+}: {
+  requests: ScoredRequest[];
+  slugByName: Map<string, string>;
+}) {
+  return (
+    <ul className="space-y-1.5">
+      {requests.map((r) => {
+        const slug = slugByName.get(r.name.toLowerCase());
+        return (
+          <li
+            key={r.taskId}
+            className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5 text-sm"
+          >
+            <span className="text-ui-charcoal">
+              {slug ? (
+                <Link
+                  href={`/portfolio/${slug}`}
+                  className="font-medium text-brand-black hover:underline"
+                >
+                  {r.name}
+                </Link>
+              ) : (
+                r.name
+              )}
+              {r.unit && (
+                <span className="text-xs text-ink-subtle"> · {r.unit}</span>
+              )}
+            </span>
+            {r.weightedScore !== null && (
+              <span className="text-xs tabular-nums text-ink-muted">
+                scored {Math.round(r.weightedScore * 10) / 10}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default async function PipelinePage() {
+  const [requests, lastSync, apps] = await Promise.all([
+    listScoredRequests(),
+    getLastSync(),
+    listApplications({ audience: "public" }).catch(() => []),
+  ]);
+
+  const pending = requests.filter((r) => r.status === "pending");
+  const promoted = requests.filter((r) => r.status === "active");
+  const notPursued = requests.filter((r) => r.status === "rejected");
+  const completed = requests.filter((r) => r.status === "complete");
+
+  // Best-effort link from a promoted request to its portfolio entry: the
+  // request name rarely matches the project name exactly, so map through
+  // the ClickUp list names too.
+  const slugByName = new Map<string, string>();
+  for (const app of apps) {
+    if (listIdForSlug(app.slug)) slugByName.set(app.name.toLowerCase(), app.slug);
+  }
+  for (const m of CLICKUP_PROJECT_LISTS) {
+    slugByName.set(m.listName.toLowerCase(), m.slug);
+  }
+
+  return (
+    <div className="space-y-10">
+      <nav className="text-sm text-gray-500">
+        <Link href="/portfolio" className="hover:text-brand-black">
+          Projects
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-ui-charcoal">Pipeline</span>
+      </nav>
+
+      <header>
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Projects · Pipeline
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
+          How new project requests are prioritized
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+          Every AI project request submitted to IIDS is scored by Colin
+          Addington on an 11-criterion rubric — strategic impact (A1–A4),
+          feasibility and effort (B1–B4), and urgency and buy-in (C1–C3) —
+          and prioritized by weighted score. This is the live review queue,
+          synced from the IIDS-AI4UI workspace.
+        </p>
+      </header>
+
+      {requests.length === 0 ? (
+        <div className="rounded-xl border border-hairline bg-surface-alt p-8 text-center">
+          <p className="text-sm font-medium text-ink-muted">
+            No synced request data yet. The queue appears here after the
+            first ClickUp sync runs.
+          </p>
+        </div>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <div className="flex items-baseline gap-3">
+              <h2 className="text-xl font-black tracking-tight text-brand-black">
+                In review
+              </h2>
+              <span className="text-sm text-ink-subtle">
+                {pending.length}{" "}
+                {pending.length === 1 ? "request" : "requests"}, highest
+                score first
+              </span>
+            </div>
+            <PendingTable requests={pending} />
+            <p className="text-xs text-ink-subtle">
+              Weighted score = {RUBRIC_FORMULA}, on a 0–100 scale. Criteria
+              are scored 1–5 — full definitions below. Hover a column header
+              for the criterion name.
+            </p>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-xl font-black tracking-tight text-brand-black">
+                The Project Prioritization Scorecard
+              </h2>
+              <p className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                Each criterion is scored on a scale of 1 (low) to 5 (high);
+                scores are multiplied by the category weight to produce the
+                priority score. Anchor definitions below are the published
+                scoring guide.
+              </p>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-3">
+              {RUBRIC_GROUPS.map((group) => (
+                <div
+                  key={group.code}
+                  className="rounded-xl border border-hairline bg-white p-5"
+                >
+                  <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+                    {group.code} · weight {group.weight}
+                  </p>
+                  <h3 className="mt-1 text-base font-semibold text-brand-black">
+                    {group.name}
+                  </h3>
+                  <p className="mt-1 text-xs italic leading-relaxed text-ink-muted">
+                    {group.description}
+                  </p>
+                  <dl className="mt-4 space-y-4">
+                    {RUBRIC_CRITERIA.filter(
+                      (c) => c.group === group.code
+                    ).map((c) => (
+                      <div key={c.code}>
+                        <dt className="text-sm font-medium text-ui-charcoal">
+                          <span className="font-mono text-xs font-semibold text-ink-muted">
+                            {c.code}
+                          </span>{" "}
+                          {c.name}
+                        </dt>
+                        <dd className="mt-1 space-y-0.5 text-xs leading-relaxed text-ink-muted">
+                          {c.anchors.map((a) => (
+                            <p key={a.score}>
+                              <span className="font-semibold tabular-nums">
+                                {a.score}
+                              </span>{" "}
+                              — {a.text}
+                            </p>
+                          ))}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {promoted.length > 0 && (
+            <section className="space-y-3">
+              <div className="flex items-baseline gap-3">
+                <h2 className="text-xl font-black tracking-tight text-brand-black">
+                  Promoted to active projects
+                </h2>
+                <span className="text-sm text-ink-subtle">
+                  {promoted.length}
+                </span>
+              </div>
+              <CompactRequestList requests={promoted} slugByName={slugByName} />
+            </section>
+          )}
+
+          {completed.length > 0 && (
+            <section className="space-y-3">
+              <div className="flex items-baseline gap-3">
+                <h2 className="text-xl font-black tracking-tight text-brand-black">
+                  Completed
+                </h2>
+                <span className="text-sm text-ink-subtle">
+                  {completed.length}
+                </span>
+              </div>
+              <CompactRequestList requests={completed} slugByName={slugByName} />
+            </section>
+          )}
+
+          {notPursued.length > 0 && (
+            <section className="space-y-3">
+              <div className="flex items-baseline gap-3">
+                <h2 className="text-xl font-black tracking-tight text-brand-black">
+                  Not pursued
+                </h2>
+                <span className="text-sm text-ink-subtle">
+                  {notPursued.length}
+                </span>
+              </div>
+              <CompactRequestList
+                requests={notPursued}
+                slugByName={slugByName}
+              />
+            </section>
+          )}
+        </>
+      )}
+
+      <footer className="space-y-2 border-t border-hairline pt-6">
+        {lastSync && <SyncFreshness syncedAt={lastSync.finishedAt} />}
+        <p className="text-xs text-brand-silver">
+          Have a process that could use this treatment?{" "}
+          <Link
+            href="/builder-guide"
+            className="font-medium text-brand-silver hover:text-brand-black"
+          >
+            Submit a project &rarr;
+          </Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/components/SyncNowButton.tsx
+++ b/components/SyncNowButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+// The one client component in the ClickUp ingestion feature: fires the
+// manual sync (POST /internal/sync) and reports the run summary inline.
+// Rendered only on /internal, so the request rides the Basic-auth
+// credentials the middleware already collected.
+
+import { useState } from "react";
+
+interface SyncSummary {
+  projects: number;
+  statusUpdates: number;
+  requests: number;
+  warnings: string[];
+}
+
+type SyncState =
+  | { phase: "idle" }
+  | { phase: "running" }
+  | { phase: "done"; summary: SyncSummary }
+  | { phase: "error"; message: string };
+
+export default function SyncNowButton({
+  lastSyncedAt,
+}: {
+  lastSyncedAt: string | null;
+}) {
+  const [state, setState] = useState<SyncState>({ phase: "idle" });
+
+  async function trigger() {
+    setState({ phase: "running" });
+    try {
+      const res = await fetch("/internal/sync", { method: "POST" });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setState({
+          phase: "error",
+          message: body?.error ?? `Sync failed (${res.status}).`,
+        });
+        return;
+      }
+      setState({ phase: "done", summary: body as SyncSummary });
+    } catch {
+      setState({ phase: "error", message: "Network error — sync may still be running." });
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={trigger}
+          disabled={state.phase === "running"}
+          className="inline-flex items-center gap-2 rounded-lg bg-ui-charcoal px-4 py-2 text-sm font-medium text-white hover:bg-ui-charcoal/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state.phase === "running" ? "Syncing… (~1 min)" : "Sync ClickUp now"}
+        </button>
+        {lastSyncedAt && state.phase === "idle" && (
+          <span className="text-xs text-ink-muted">
+            Last synced{" "}
+            {new Date(lastSyncedAt).toLocaleString("en-US", {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+          </span>
+        )}
+      </div>
+      {state.phase === "done" && (
+        <p className="text-xs text-ink-muted">
+          Synced {state.summary.projects} projects,{" "}
+          {state.summary.statusUpdates} status updates,{" "}
+          {state.summary.requests} requests.
+          {state.summary.warnings.length > 0 &&
+            ` ${state.summary.warnings.length} warning(s): ${state.summary.warnings.join("; ")}`}
+        </p>
+      )}
+      {state.phase === "error" && (
+        <p className="text-xs text-red-700">{state.message}</p>
+      )}
+    </div>
+  );
+}

--- a/lib/rubric.ts
+++ b/lib/rubric.ts
@@ -1,0 +1,219 @@
+// lib/rubric.ts
+//
+// The AI4UI Project Prioritization Scorecard, published on
+// /portfolio/pipeline. Content mirrors Colin Addington's "Prioritization
+// Rubric" document (July 2026); field ids for the matching ClickUp
+// instrument live in lib/clickup.ts RUBRIC_FIELDS.
+//
+// Each criterion is scored 1 (low) to 5 (high); scores are multiplied by
+// the category weight to produce the priority score. The ClickUp formula
+// is (A1–A4 × 0.10 + B1–B4 × 0.075 + C1–C3 × 0.10) × 20, on a 0–100
+// scale — equivalent to the document's category weights (A 40%, B 30%,
+// C 30%).
+
+export interface RubricAnchor {
+  /** The scored value the anchor defines (typically 1, 3, 5). */
+  score: number;
+  text: string;
+}
+
+export interface RubricCriterion {
+  /** Short code as used in ClickUp field names and table headers. */
+  code: string;
+  /** Key into ScoredRequest.rubric (lib/clickup-data.ts). */
+  key: "a1" | "a2" | "a3" | "a4" | "b1" | "b2" | "b3" | "b4" | "c1" | "c2" | "c3";
+  group: "A" | "B" | "C";
+  name: string;
+  weight: number;
+  /** Published scoring anchors from the rubric document. */
+  anchors: RubricAnchor[];
+}
+
+export interface RubricGroup {
+  code: "A" | "B" | "C";
+  name: string;
+  /** Category weight from the rubric document. */
+  weight: string;
+  /** The question the category answers, verbatim from the document. */
+  description: string;
+}
+
+export const RUBRIC_GROUPS: readonly RubricGroup[] = [
+  {
+    code: "A",
+    name: "Strategic Value & ROI",
+    weight: "40%",
+    description: "How much does this matter to the university as a whole?",
+  },
+  {
+    code: "B",
+    name: "Feasibility & Risk",
+    weight: "30%",
+    description: "Can we realistically build and deliver this?",
+  },
+  {
+    code: "C",
+    name: "User Value & Adoption",
+    weight: "30%",
+    description: "Will people use this and will it solve a real problem?",
+  },
+] as const;
+
+export const RUBRIC_CRITERIA: readonly RubricCriterion[] = [
+  {
+    code: "A1",
+    key: "a1",
+    group: "A",
+    weight: 0.1,
+    name: "Alignment with University Strategic Plan",
+    anchors: [
+      { score: 1, text: "No alignment." },
+      { score: 5, text: "Directly supports a core strategic priority." },
+    ],
+  },
+  {
+    code: "A2",
+    key: "a2",
+    group: "A",
+    weight: 0.1,
+    name: "Financial Impact (Savings/Revenue)",
+    anchors: [
+      { score: 1, text: "Minimal (<$10k/yr)." },
+      { score: 3, text: "Moderate ($50k/yr)." },
+      {
+        score: 5,
+        text: "Transformative (>$250k/yr or significant grant revenue enabled).",
+      },
+    ],
+  },
+  {
+    code: "A3",
+    key: "a3",
+    group: "A",
+    weight: 0.1,
+    name: "Breadth of Impact (Number of Users/Depts)",
+    anchors: [
+      { score: 1, text: "Impacts a single individual." },
+      { score: 3, text: "Impacts a whole department." },
+      { score: 5, text: "Impacts multiple divisions or the entire campus." },
+    ],
+  },
+  {
+    code: "A4",
+    key: "a4",
+    group: "A",
+    weight: 0.1,
+    name: "Reputational Benefit & Visibility",
+    anchors: [
+      { score: 1, text: "Purely internal." },
+      { score: 3, text: "Positive internal visibility." },
+      {
+        score: 5,
+        text: "Positions UI as a national leader in a specific area.",
+      },
+    ],
+  },
+  {
+    code: "B1",
+    key: "b1",
+    group: "B",
+    weight: 0.075,
+    name: "Technical Complexity",
+    anchors: [
+      { score: 1, text: "Requires novel R&D." },
+      { score: 3, text: "Uses established methods." },
+      {
+        score: 5,
+        text: "Simple application of existing IIDS software stacks.",
+      },
+    ],
+  },
+  {
+    code: "B2",
+    key: "b2",
+    group: "B",
+    weight: 0.075,
+    name: "Data Availability & Quality",
+    anchors: [
+      { score: 1, text: "Data does not exist or is unusable." },
+      { score: 3, text: "Data exists but requires significant cleaning." },
+      { score: 5, text: "Data is clean and accessible." },
+    ],
+  },
+  {
+    code: "B3",
+    key: "b3",
+    group: "B",
+    weight: 0.075,
+    name: "Time to Deliver MVP (Minimum Viable Product)",
+    anchors: [
+      { score: 1, text: "> 9 months." },
+      { score: 3, text: "4–6 months." },
+      { score: 5, text: "< 3 months." },
+    ],
+  },
+  {
+    code: "B4",
+    key: "b4",
+    group: "B",
+    weight: 0.075,
+    name: "Technical Load / Maintenance",
+    anchors: [
+      {
+        score: 1,
+        text: "Requires extensive ongoing maintenance or training.",
+      },
+      { score: 3, text: "Typical bug squashing and support." },
+      { score: 5, text: "One-time fix with no ongoing support." },
+    ],
+  },
+  {
+    code: "C1",
+    key: "c1",
+    group: "C",
+    weight: 0.1,
+    name: "Urgency & Pain Point Severity",
+    anchors: [
+      { score: 1, text: "“Nice to have.”" },
+      { score: 3, text: "Solves a known frustration." },
+      {
+        score: 5,
+        text: "Solves a critical compliance, security, or operational bottleneck.",
+      },
+    ],
+  },
+  {
+    code: "C2",
+    key: "c2",
+    group: "C",
+    weight: 0.1,
+    name: "Depth of Impact (Improvement per User)",
+    anchors: [
+      { score: 1, text: "Minor convenience." },
+      { score: 3, text: "Saves a user a few hours per month." },
+      {
+        score: 5,
+        text: "Automates a major, time-consuming part of a user's job.",
+      },
+    ],
+  },
+  {
+    code: "C3",
+    key: "c3",
+    group: "C",
+    weight: 0.1,
+    name: "Champion & Departmental Buy-in",
+    anchors: [
+      { score: 1, text: "No clear champion." },
+      { score: 3, text: "A department is interested." },
+      {
+        score: 5,
+        text: "A department head is actively advocating for the project.",
+      },
+    ],
+  },
+] as const;
+
+/** The published formula, for display. */
+export const RUBRIC_FORMULA =
+  "(A1–A4 × 0.10 + B1–B4 × 0.075 + C1–C3 × 0.10) × 20";


### PR DESCRIPTION
## Summary

PR 4 of 4 (stacked on #277). Completes the ClickUp ingestion feature:

- **`/portfolio/pipeline`** — the intake rubric made public: pending requests sorted by weighted score with all 11 criterion scores (A/B/C grouped, hover for full criterion names), the weighting formula in a footnote, and computed-score footnote markers. Promoted/completed/not-pursued requests listed compactly with links to portfolio entries. Honest empty state before first sync; freshness stamp in the footer. No sidebar change (Rule 11) — linked from the `/portfolio` stat strip ("N requests in review").
- **`POST /internal/sync`** — manual trigger behind the existing Basic-auth middleware (fails closed 503; 409 on concurrent runs). The host cron curls the same endpoint, so cron and button exercise one code path.
- **Sync-now button** on `/internal` (the feature's single `"use client"` component) with last-sync time and run summary; replaces the stale "Coming in Sprint 3 — ClickUp wiring" bullet.

## Verification

- `npm run build` green (`/portfolio/pipeline` registered dynamic)
- Browser-verified: pipeline empty state renders; `/portfolio` renders the new DFA section from seeded data; console clean
- `POST /internal/sync` unauthenticated → 503 (fail-closed, creds unset locally)
- Full data-path verification pending `CLICKUP_API_TOKEN` (tracked on #276)

🤖 Generated with [Claude Code](https://claude.com/claude-code)