### PR TITLE
Candidate projects: survey demand → potential-projects inventory (phase 2)

### DIFF
--- a/app/standards/operational-excellence/page.tsx
+++ b/app/standards/operational-excellence/page.tsx
@@ -1,5 +1,10 @@
 import Link from "next/link";
-import type { SurveyAudience, SurveyClusterKey, SurveyResponse } from "@/lib/surveys/types";
+import type {
+  CandidateProject,
+  SurveyAudience,
+  SurveyClusterKey,
+  SurveyResponse,
+} from "@/lib/surveys/types";
 import {
   OPERATIONAL_EXCELLENCE_META,
   clustersFor,
@@ -10,6 +15,13 @@ import {
   allResponses,
   totalResponseCount,
 } from "@/lib/surveys/operational-excellence";
+import {
+  candidateProjectsByCoverage,
+  candidatesForCluster,
+  CANDIDATE_COVERAGE_LABEL,
+} from "@/lib/surveys/candidate-projects";
+import { getWorkCategoryLabel } from "@/lib/work-categories";
+import { getProjectBySlug } from "@/lib/portfolio";
 
 export const metadata = {
   title: "Operational Excellence Survey — Standards",
@@ -18,7 +30,7 @@ export const metadata = {
 };
 
 const BASE = "/standards/operational-excellence";
-type ViewMode = "themes" | "explore";
+type ViewMode = "themes" | "explore" | "candidates";
 
 // ── URL param handling ───────────────────────────────────────
 interface Params {
@@ -32,7 +44,8 @@ function normalize(
   raw: { view?: string; audience?: string; cluster?: string; q?: string },
 ): Params {
   const audience: SurveyAudience = raw.audience === "student" ? "student" : "faculty";
-  const view: ViewMode = raw.view === "explore" ? "explore" : "themes";
+  const view: ViewMode =
+    raw.view === "explore" ? "explore" : raw.view === "candidates" ? "candidates" : "themes";
   const q = (raw.q ?? "").trim();
   // A cluster is only valid within its audience.
   const cluster =
@@ -152,6 +165,24 @@ function ThemesView({ audience }: { audience: SurveyAudience }) {
                 Read all {total} {c.label.toLowerCase()} responses &rarr;
               </Link>
             </p>
+
+            {(() => {
+              const candidates = candidatesForCluster(audience, c.key);
+              if (candidates.length === 0) return null;
+              return (
+                <p className="mt-1 text-sm text-ink-subtle">
+                  Feeds:{" "}
+                  {candidates.map((cp, i) => (
+                    <span key={cp.id}>
+                      {i > 0 && ", "}
+                      <Link href={`${href({ view: "candidates" })}#${cp.id}`}>
+                        {cp.title}
+                      </Link>
+                    </span>
+                  ))}
+                </p>
+              );
+            })()}
           </article>
         );
       })}
@@ -246,7 +277,8 @@ function ExploreView({
           return (
             <li
               key={r.id}
-              className="rounded-md border border-hairline bg-white p-4"
+              id={r.id}
+              className="scroll-mt-24 rounded-md border border-hairline bg-white p-4 target:border-ui-gold target:bg-ui-gold/5"
             >
               <div className="mb-1.5 flex flex-wrap items-center gap-2">
                 <span className="text-xs font-semibold uppercase tracking-wide text-brand-silver">
@@ -270,6 +302,144 @@ function ExploreView({
           <Link href={href({ view: "explore", audience, cluster })}>clear the search</Link>.
         </p>
       )}
+    </div>
+  );
+}
+
+// ── Candidate projects view ──────────────────────────────────
+const AUDIENCE_LABEL: Record<SurveyAudience, string> = {
+  faculty: "Faculty & staff",
+  student: "Students",
+};
+
+function CoverageChip({ coverage }: { coverage: CandidateProject["coverage"] }) {
+  const styles: Record<CandidateProject["coverage"], string> = {
+    gap: "border-hairline bg-surface-alt text-ink-muted",
+    partial: "border-brand-huckleberry/30 bg-brand-huckleberry/5 text-brand-huckleberry",
+    covered: "border-brand-clearwater/30 bg-brand-clearwater/5 text-brand-clearwater",
+  };
+  return (
+    <span
+      className={`whitespace-nowrap rounded-full border px-2.5 py-0.5 text-xs font-semibold ${styles[coverage]}`}
+    >
+      {CANDIDATE_COVERAGE_LABEL[coverage]}
+    </span>
+  );
+}
+
+function CandidateCard({ c }: { c: CandidateProject }) {
+  const related = (c.relatedProjectSlugs ?? [])
+    .map((s) => getProjectBySlug(s))
+    .filter((p): p is NonNullable<typeof p> => Boolean(p));
+  return (
+    <article
+      id={c.id}
+      className="scroll-mt-24 rounded-lg border border-hairline bg-white p-6 target:border-ui-gold"
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <h3 className="text-xl font-black tracking-tight text-brand-black">
+          {c.title}
+        </h3>
+        <CoverageChip coverage={c.coverage} />
+      </header>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <span className="rounded-full border border-hairline bg-surface-alt px-2.5 py-0.5 text-xs font-medium text-ink-muted">
+          {getWorkCategoryLabel(c.workCategory)}
+        </span>
+        <span className="text-xs font-semibold uppercase tracking-wide text-brand-silver">
+          {c.audiences.map((a) => AUDIENCE_LABEL[a]).join(" · ")}
+        </span>
+      </div>
+
+      <p className="mt-4 max-w-3xl text-base text-brand-black">{c.problem}</p>
+      <p className="mt-2 max-w-3xl text-sm text-ink-muted">{c.shape}</p>
+      {c.note && (
+        <p className="mt-2 max-w-3xl text-sm italic text-ink-subtle">{c.note}</p>
+      )}
+
+      <div className="mt-5 flex flex-col gap-4 border-t border-hairline pt-4 sm:flex-row sm:gap-10">
+        {related.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
+              Related projects
+            </p>
+            <p className="mt-1 text-sm">
+              {related.map((p, i) => (
+                <span key={p.slug}>
+                  {i > 0 && " · "}
+                  <Link href={`/portfolio/${p.slug}`}>{p.name}</Link>
+                </span>
+              ))}
+            </p>
+          </div>
+        )}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
+            Evidence
+          </p>
+          <p className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            {c.clusters.map((cl) => {
+              const cluster = getCluster(cl.audience, cl.cluster);
+              const anchor = (c.evidenceResponseIds ?? []).find(
+                (id) => id.startsWith(cl.audience[0]) && id.endsWith(`-${cl.cluster}`),
+              );
+              const to =
+                href({ view: "explore", audience: cl.audience, cluster: cl.cluster }) +
+                (anchor ? `#${anchor}` : "");
+              return (
+                <Link key={`${cl.audience}-${cl.cluster}`} href={to}>
+                  {AUDIENCE_LABEL[cl.audience]}: {cluster?.label} &rarr;
+                </Link>
+              );
+            })}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function CandidatesView() {
+  const items = candidateProjectsByCoverage();
+  const groups: { coverage: CandidateProject["coverage"]; heading: string }[] = [
+    { coverage: "gap", heading: "Gaps — no current project" },
+    { coverage: "partial", heading: "Partially covered by existing work" },
+    { coverage: "covered", heading: "Already addressed" },
+  ];
+  const count = (cov: CandidateProject["coverage"]) =>
+    items.filter((c) => c.coverage === cov).length;
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-lg border border-hairline bg-surface-alt p-5">
+        <p className="max-w-3xl text-sm text-ink-muted">
+          Where the survey&rsquo;s demand signal points, cross-referenced against
+          what the portfolio already runs. These are proposals for the Chief AI
+          &amp; Data Science Officer&rsquo;s office and IIDS to triage &mdash;
+          grounded in the responses, not commitments. No owners, dates, or ROI are
+          asserted here; those are decided in intake.
+        </p>
+        <p className="mt-3 border-t border-hairline pt-3 text-sm font-semibold text-brand-black">
+          {count("gap")} gaps · {count("partial")} partially covered ·{" "}
+          {count("covered")} already addressed
+        </p>
+      </section>
+
+      {groups.map((g) => {
+        const inGroup = items.filter((c) => c.coverage === g.coverage);
+        if (inGroup.length === 0) return null;
+        return (
+          <section key={g.coverage} className="space-y-4">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
+              {g.heading}
+            </h2>
+            {inGroup.map((c) => (
+              <CandidateCard key={c.id} c={c} />
+            ))}
+          </section>
+        );
+      })}
     </div>
   );
 }
@@ -327,39 +497,45 @@ export default async function OperationalExcellenceSurveyPage({
 
       {/* View + audience controls */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <SegToggle
-          ariaLabel="Audience"
-          options={audienceOptions}
-        />
+        {view === "candidates" ? (
+          <span aria-hidden className="hidden sm:block" />
+        ) : (
+          <SegToggle ariaLabel="Audience" options={audienceOptions} />
+        )}
         <SegToggle
           ariaLabel="View"
           options={[
             { label: "Themes", to: href({ view: "themes", audience }), active: view === "themes" },
             { label: "Explore responses", to: href({ view: "explore", audience }), active: view === "explore" },
+            { label: "Candidate projects", to: href({ view: "candidates" }), active: view === "candidates" },
           ]}
         />
       </div>
 
       {view === "themes" ? (
         <ThemesView audience={audience} />
-      ) : (
+      ) : view === "explore" ? (
         <ExploreView audience={audience} cluster={cluster} q={q} />
+      ) : (
+        <CandidatesView />
       )}
 
-      {/* Phase-2 framing */}
-      <section className="rounded-lg border border-hairline bg-white p-5">
-        <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
-          What happens next
-        </p>
-        <p className="mt-2 max-w-3xl text-sm text-ink-muted">
-          These themes are demand signal, not yet a project list. Promising
-          patterns become candidate projects in the University&rsquo;s
-          potential-projects inventory &mdash; that mapping is in progress and
-          will link back to the{" "}
-          <Link href="/standards/intake-crosswalk">intake crosswalk</Link> and{" "}
-          <Link href="/portfolio">project inventory</Link>.
-        </p>
-      </section>
+      {/* Pointer to the candidate-projects inventory */}
+      {view !== "candidates" && (
+        <section className="rounded-lg border border-hairline bg-white p-5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
+            From signal to projects
+          </p>
+          <p className="mt-2 max-w-3xl text-sm text-ink-muted">
+            These themes are demand signal. The{" "}
+            <Link href={href({ view: "candidates" })}>Candidate projects</Link>{" "}
+            view turns the strongest patterns into proposals &mdash;
+            cross-referenced against what is already running &mdash; for the{" "}
+            <Link href="/standards/intake-crosswalk">intake crosswalk</Link> and{" "}
+            <Link href="/portfolio">project inventory</Link> to triage.
+          </p>
+        </section>
+      )}
     </div>
   );
 }

--- a/lib/surveys/candidate-projects.ts
+++ b/lib/surveys/candidate-projects.ts
@@ -1,0 +1,199 @@
+// ============================================================
+// Candidate projects — the Operational Excellence survey's demand
+// signal, ingested into a potential/requested-projects inventory.
+// ============================================================
+// Phase 2 of the survey ingest. Each candidate is a proposal derived
+// from the survey, grounded in specific verbatims and cross-referenced
+// against what the portfolio already runs, so we surface real gaps
+// rather than duplicate existing work.
+//
+// These are proposals for the CADSO office and IIDS to triage — not
+// commitments. No owners, dates, or ROI are asserted here; those are
+// decided in intake, not inferred from a survey.
+//
+// Editorial note: the demand-to-project mapping is a judgment call.
+// Edit this list as triage sharpens it. `relatedProjectSlugs` must
+// match slugs in lib/portfolio.ts; `workCategory` must be a slug in
+// lib/work-categories.ts (tsc enforces the latter).
+// ============================================================
+
+import type { CandidateProject } from "./types";
+
+export const CANDIDATE_PROJECTS: CandidateProject[] = [
+  {
+    id: "reimbursement-status-tracker",
+    title: "Reimbursement & payment status tracker",
+    problem:
+      "Travel and Accounts Payable reimbursements take weeks to months, and employees have no visibility into where a request is stuck or why — one respondent reported a 41-day Chrome River AP review and out-of-pocket bank fees.",
+    shape:
+      "A status view that shows an employee and approvers exactly where a reimbursement, invoice, or payment sits and what is blocking it — the same direct-register pattern already used for the intake status page, applied to finance workflows.",
+    audiences: ["faculty"],
+    clusters: [
+      { audience: "faculty", cluster: "processes" },
+      { audience: "faculty", cluster: "data-tools" },
+    ],
+    evidenceResponseIds: ["f19-processes", "f64-processes", "f93-processes", "f39-processes"],
+    workCategory: "process",
+    coverage: "partial",
+    relatedProjectSlugs: ["invoice-processing"],
+    note: "Invoice Processing already works the AP invoice side; the gap is the employee- and approver-facing status visibility.",
+  },
+  {
+    id: "onboarding-access-automation",
+    title: "Onboarding & access automation",
+    problem:
+      "New employee and TA onboarding — I-9 → EPAF → email → system access — is a multi-office, multi-day scavenger hunt that leaves new teaching staff without their systems until classes have already started.",
+    shape:
+      "A guided onboarding flow where approval of the I-9 automatically triggers the downstream steps (EPAF, email creation, Banner entry, Bridge/FERPA), with a checklist the new hire and their admin can both see.",
+    audiences: ["faculty"],
+    clusters: [{ audience: "faculty", cluster: "processes" }],
+    evidenceResponseIds: ["f37-processes", "f3-processes", "f73-processes"],
+    workCategory: "process",
+    coverage: "gap",
+  },
+  {
+    id: "policy-knowledge-search",
+    title: "Institutional knowledge & policy search",
+    problem:
+      "The 2025 website/intranet migration broke findability: staff and students can't locate policies (APMs), forms, mileage rates, and how-tos that used to be a click away.",
+    shape:
+      "A retrieval-augmented search over policies, APMs, forms, and how-to documentation that answers a plain-language question with a cited source — the same pattern already proven on the Water Law Database.",
+    audiences: ["faculty", "student"],
+    clusters: [
+      { audience: "faculty", cluster: "processes" },
+      { audience: "faculty", cluster: "data-tools" },
+      { audience: "student", cluster: "data-access" },
+    ],
+    evidenceResponseIds: ["f65-processes", "f22-processes", "f53-data-tools", "s44-data-access"],
+    workCategory: "knowledge-retrieval",
+    coverage: "partial",
+    relatedProjectSlugs: ["water-law-database"],
+    note: "The RAG retrieval pattern is proven on legal documents; applying it to institutional policy and how-to content is the open work.",
+  },
+  {
+    id: "repetitive-query-assistant",
+    title: "Repetitive-query response assistant",
+    problem:
+      "Front-line offices — financial aid especially — answer the same questions hundreds of times, while students cite slow email response as their top communication frustration.",
+    shape:
+      "An assistant that drafts a first response to high-volume, repetitive inbound questions for staff to review and send, cutting turnaround without removing the human. Runs on the existing MindRouter gateway.",
+    audiences: ["faculty", "student"],
+    clusters: [
+      { audience: "faculty", cluster: "processes" },
+      { audience: "student", cluster: "collaboration" },
+    ],
+    evidenceResponseIds: ["f56-processes", "s9-collaboration", "s7-collaboration"],
+    workCategory: "knowledge-retrieval",
+    coverage: "partial",
+    relatedProjectSlugs: ["mindrouter"],
+    note: "One financial-aid respondent proposed exactly this. MindRouter is the platform; the drafting assistant is the build.",
+  },
+  {
+    id: "unit-budget-view",
+    title: "Self-serve unit budget view",
+    problem:
+      "Directors and chairs can't see index/fund balances in real time and fall back on manually maintained spreadsheets; different tools give different numbers.",
+    shape:
+      "A self-serve dashboard showing current balances and transactions per index/fund — 'like looking at a bank account' — instead of days of human effort to assemble a picture.",
+    audiences: ["faculty"],
+    clusters: [
+      { audience: "faculty", cluster: "data-tools" },
+      { audience: "faculty", cluster: "processes" },
+    ],
+    evidenceResponseIds: ["f82-data-tools", "f88-data-tools", "f60-processes", "f21-processes"],
+    workCategory: "executive-analytics",
+    coverage: "partial",
+    relatedProjectSlugs: ["audit-dashboard", "rfd-career", "oit-data-modernization"],
+    note: "The dashboard pattern exists at the executive level; a unit-level, self-serve budget view is the gap, and overlaps the Huron data-modernization work.",
+  },
+  {
+    id: "student-resource-navigator",
+    title: "Student resource navigator",
+    problem:
+      "Students bounce across offices to answer simple questions and routinely find out about resources too late; many ask for a way to be pointed to the right place.",
+    shape:
+      "A secure, opt-in student assistant that routes a question to the right office or resource and answers routine 'how do I…' queries. Runs on MindRouter.",
+    audiences: ["student"],
+    clusters: [
+      { audience: "student", cluster: "technology" },
+      { audience: "student", cluster: "processes" },
+      { audience: "student", cluster: "additional" },
+    ],
+    evidenceResponseIds: ["s53-technology", "s48-technology", "s16-additional", "s42-data-access"],
+    workCategory: "knowledge-retrieval",
+    coverage: "gap",
+    relatedProjectSlugs: ["mindrouter"],
+    note: "A vocal share of students are AI-skeptical; this must be opt-in, transparent about limits, and always offer a human path — or it will bounce the very audience it serves.",
+  },
+  {
+    id: "grants-research-admin",
+    title: "Grants & research-administration tooling",
+    problem:
+      "Grant submission through VERAS is duplicative (the same figures entered in multiple places) and contract approval runs long with PIs left out of the loop.",
+    shape:
+      "Not a new build — this demand is largely met by existing research-administration projects. The residual gap is VERAS data-entry duplication specifically.",
+    audiences: ["faculty"],
+    clusters: [
+      { audience: "faculty", cluster: "processes" },
+      { audience: "faculty", cluster: "data-tools" },
+    ],
+    evidenceResponseIds: ["f6-processes", "f32-processes", "f40-processes", "f92-data-tools"],
+    workCategory: "research-admin",
+    coverage: "covered",
+    relatedProjectSlugs: ["openera", "vandalizer", "processmapping", "universo"],
+    note: "OpenERA, Vandalizer, ProcessMapping, and UniVerso already address research-administration workload; surface them to this audience rather than starting over.",
+  },
+  {
+    id: "sanctioned-ai-enablement",
+    title: "Sanctioned AI access & literacy",
+    problem:
+      "Faculty and staff want approved AI tools and guidance on which are sanctioned; students are divided, with a pro camp asking for a secure, sanctioned option and AI literacy.",
+    shape:
+      "Not a new build — MindRouter is the sanctioned, on-prem AI gateway that answers the access question. The open work is enablement: publishing which tools are approved and how to use them well.",
+    audiences: ["faculty", "student"],
+    clusters: [
+      { audience: "faculty", cluster: "data-tools" },
+      { audience: "faculty", cluster: "additional" },
+      { audience: "student", cluster: "technology" },
+    ],
+    evidenceResponseIds: ["f15-data-tools", "f9-data-tools", "f88-additional", "s48-technology"],
+    workCategory: "ai-infrastructure",
+    coverage: "covered",
+    relatedProjectSlugs: ["mindrouter"],
+    note: "The demand is met by MindRouter; the remaining gap is communication and AI literacy, not a platform.",
+  },
+];
+
+// ── Ordering + accessors ─────────────────────────────────────
+
+/** Gaps first (most actionable), then partial, then already-covered. */
+const COVERAGE_ORDER: Record<CandidateProject["coverage"], number> = {
+  gap: 0,
+  partial: 1,
+  covered: 2,
+};
+
+export function candidateProjectsByCoverage(): CandidateProject[] {
+  return [...CANDIDATE_PROJECTS].sort(
+    (a, b) => COVERAGE_ORDER[a.coverage] - COVERAGE_ORDER[b.coverage],
+  );
+}
+
+/** Candidates whose evidence includes a given survey cluster. */
+export function candidatesForCluster(
+  audience: CandidateProject["audiences"][number],
+  cluster: CandidateProject["clusters"][number]["cluster"],
+): CandidateProject[] {
+  return CANDIDATE_PROJECTS.filter((c) =>
+    c.clusters.some((cl) => cl.audience === audience && cl.cluster === cluster),
+  );
+}
+
+export const CANDIDATE_COVERAGE_LABEL: Record<
+  CandidateProject["coverage"],
+  string
+> = {
+  gap: "No current project",
+  partial: "Partially covered",
+  covered: "Already addressed",
+};

--- a/lib/surveys/types.ts
+++ b/lib/surveys/types.ts
@@ -5,6 +5,8 @@
 // Typed so a second survey can reuse the same explorer surface.
 // ============================================================
 
+import type { WorkCategory } from "../work-categories";
+
 /** Who answered. Faculty export also includes staff respondents. */
 export type SurveyAudience = "faculty" | "student";
 
@@ -46,15 +48,35 @@ export interface SubTheme {
   description: string;
 }
 
+/** How well the current portfolio already answers a demand signal. */
+export type CandidateCoverage = "gap" | "partial" | "covered";
+
 /**
- * Phase-2 hook (deferred): once a cluster or sub-theme is promoted into
- * the potential/requested-projects inventory, link it here. Left unset
- * until the ingest-into-projects work lands.
+ * A potential/requested project derived from the survey's demand signal
+ * (phase 2). Evidence-forward: each one names the survey clusters (and a
+ * few illustrative verbatims) that motivate it, and is honest about what
+ * the current portfolio already covers. These are proposals for triage,
+ * not commitments — so no owners, dates, or ROI are asserted.
  */
-export interface CandidateProjectLink {
-  /** Portfolio slug or intake reference this demand signal maps to. */
-  ref: string;
-  label: string;
+export interface CandidateProject {
+  id: string;
+  title: string;
+  /** The demand it answers, in plain operational language. */
+  problem: string;
+  /** What the project would be — one or two sentences, no hype. */
+  shape: string;
+  audiences: SurveyAudience[];
+  /** Survey clusters that evidence this demand. */
+  clusters: { audience: SurveyAudience; cluster: SurveyClusterKey }[];
+  /** A few illustrative response ids (deep-linked on the surface). */
+  evidenceResponseIds?: string[];
+  /** The "by problem" category this would sit under, per work-categories. */
+  workCategory: WorkCategory;
+  coverage: CandidateCoverage;
+  /** Existing portfolio slugs this relates to (covers / partially covers). */
+  relatedProjectSlugs?: string[];
+  /** Honest scope, feasibility, or sensitivity caveat. */
+  note?: string;
 }
 
 /** A question-cluster: the question asked plus its summarized themes. */
@@ -68,8 +90,6 @@ export interface SurveyCluster {
   /** One- or two-sentence stakeholder-facing summary of the cluster. */
   summary: string;
   subThemes: SubTheme[];
-  /** Deferred phase-2 links; empty for now. */
-  candidateProjects?: CandidateProjectLink[];
 }
 
 /** Survey-level metadata for the explorer header. */


### PR DESCRIPTION
Phase 2 of the Operational Excellence survey ingest (phase 1 was #281). Turns the survey's demand signal into a **potential/requested-projects inventory** — a third view on the survey tab: `/standards/operational-excellence?view=candidates`.

## What's here

**8 candidate projects** derived from the corpus, each grounded in specific verbatims and **cross-referenced against the existing 22-project portfolio** so the view surfaces real gaps instead of duplicating work:

| Coverage | Candidates |
|---|---|
| **Gap** (2) | Onboarding & access automation · Student resource navigator |
| **Partially covered** (4) | Reimbursement & payment status tracker · Institutional knowledge & policy search · Repetitive-query response assistant · Self-serve unit budget view |
| **Already addressed** (2) | Grants & research admin → OpenERA/Vandalizer/ProcessMapping/UniVerso · Sanctioned AI access → MindRouter |

Framed explicitly as **proposals for the CADSO office and IIDS to triage, not commitments** — no owners, dates, or ROI asserted (those are decided in intake). Each card shows the demand, the shape, an honest coverage status, related existing projects (linked to `/portfolio`), and evidence links that **deep-link into the Explore view at the exact motivating response** (`:target` highlight).

## Changes

- `lib/surveys/candidate-projects.ts` — typed `CandidateProject` list + coverage ordering/accessors. `workCategory` is tsc-checked against `lib/work-categories`; every `relatedProjectSlug` and `evidenceResponseId` verified to resolve.
- `lib/surveys/types.ts` — replaces the phase-1 `CandidateProjectLink` placeholder with the real `CandidateProject` model.
- `app/standards/operational-excellence/page.tsx` — third view toggle (audience toggle hidden within it); Themes cluster cards now show which candidates they feed; response anchors added to the Explore list; "what happens next" now points at the Candidate projects view. Still a server component, no client JS.

## Editorial note

The demand→project mapping is a **judgment call** — the module header says so, and it's a typed list meant to be edited as triage sharpens it. It deliberately does *not* propose duplicates of research-admin or sanctioned-AI work that already exists; those appear as "already addressed" with links to the running projects.

## Verification

- `npm run build` clean.
- In-browser: all three views, coverage grouping + chip tints, related-project links, evidence deep-links (confirmed `:target` gold highlight lands on the exact verbatim, e.g. the 41-day Chrome River reimbursement for the reimbursement-tracker candidate), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)