### PR TITLE
OIT Pathway: align /standards with the May–June 2026 AI governance documents

### DIFF
--- a/app/standards/oit-pathway/page.tsx
+++ b/app/standards/oit-pathway/page.tsx
@@ -79,8 +79,11 @@ export default function OitPathwayPage() {
           </span>{" "}
           sets the process for teams outside OIT who want their applications
           hosted, supported, and maintained on OIT-managed infrastructure.
-          This page covers the second track: the lifecycle, the gates, the
-          rules, and where our projects stand in it.
+          The platform both documents describe is what our inventory tracks
+          as <Link href="/portfolio/nexus">Nexus</Link> — the OIT-managed
+          application platform built collaboratively by OIT and IIDS. This
+          page covers the second track: the lifecycle, the gates, the rules,
+          and where our projects stand in it.
         </p>
       </header>
 
@@ -235,9 +238,9 @@ export default function OitPathwayPage() {
           </h2>
           <p className="mt-1 text-sm text-ink-muted">
             Two IIDS-built applications are moving from IIDS staging toward
-            OIT-hosted deployment. For each: why it is in scope, where it
-            stands, what is already true of it, and what the intake and
-            security gates will examine.
+            deployment on <Link href="/portfolio/nexus">Nexus</Link>. For
+            each: why it is in scope, where it stands, what is already true
+            of it, and what the intake and security gates will examine.
           </p>
         </div>
         <div className="grid gap-4">

--- a/app/standards/oit-pathway/page.tsx
+++ b/app/standards/oit-pathway/page.tsx
@@ -1,0 +1,308 @@
+import Link from "next/link";
+import {
+  OIT_SOURCE_DOCS,
+  PATHWAY_STAGES,
+  PATHWAY_RULES,
+  IN_SCOPE_TRIGGERS,
+  OUT_OF_SCOPE_EXAMPLES,
+  PATHWAY_PROJECTS,
+  type PathwayStage,
+  type StageLead,
+} from "@/lib/oit-pathway";
+
+export const metadata = {
+  title: "OIT Pathway — Standards",
+  description:
+    "How teams outside OIT build and deploy AI applications on OIT-managed infrastructure: the two governing documents, the six-stage lifecycle with gates, the six rules, and where our projects sit.",
+};
+
+const LEAD_STYLE: Record<StageLead, string> = {
+  Builder: "bg-surface-alt text-brand-black border-hairline",
+  Collaborative: "bg-brand-lupine/10 text-brand-huckleberry border-brand-lupine/30",
+  OIT: "bg-brand-clearwater/10 text-brand-clearwater border-brand-clearwater/30",
+};
+
+function LeadChip({ lead }: { lead: StageLead }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold ${LEAD_STYLE[lead]}`}
+    >
+      {lead === "OIT" ? "OIT-led" : lead === "Builder" ? "Builder-led" : "Collaborative"}
+    </span>
+  );
+}
+
+function StageRow({ stage }: { stage: PathwayStage }) {
+  return (
+    <li className="relative pl-12">
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-0 flex h-8 w-8 items-center justify-center rounded-full bg-brand-black font-mono text-sm font-bold text-white"
+      >
+        {stage.number}
+      </span>
+      <div className="flex flex-wrap items-center gap-2.5">
+        <h3 className="text-base font-bold tracking-tight text-brand-black">
+          {stage.name}
+        </h3>
+        <LeadChip lead={stage.ledBy} />
+      </div>
+      <p className="mt-1.5 text-sm leading-relaxed text-ink-muted">
+        {stage.summary}
+      </p>
+      {stage.gate && (
+        <p className="mt-2 border-l-2 border-hairline pl-3 text-sm text-brand-black">
+          <span className="font-semibold">Gate.</span> {stage.gate}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export default function OitPathwayPage() {
+  return (
+    <div className="space-y-12">
+      <header className="max-w-3xl">
+        <h1 className="text-3xl font-black tracking-tight text-brand-black sm:text-4xl">
+          Building on OIT infrastructure
+        </h1>
+        <p className="mt-4 text-base leading-relaxed text-ink-muted">
+          OIT&rsquo;s AI governance now runs on two tracks. The{" "}
+          <span className="font-semibold text-brand-black">
+            Enterprise AI Development Framework
+          </span>{" "}
+          sets the technology standards &mdash; the approved stack, the hosted
+          environment, data classification &mdash; and is tracked ask-by-ask on
+          the <Link href="/standards">Standards ledger</Link>. The{" "}
+          <span className="font-semibold text-brand-black">
+            AI-Assisted Builder Guide
+          </span>{" "}
+          sets the process for teams outside OIT who want their applications
+          hosted, supported, and maintained on OIT-managed infrastructure.
+          This page covers the second track: the lifecycle, the gates, the
+          rules, and where our projects stand in it.
+        </p>
+      </header>
+
+      {/* Source documents */}
+      <section aria-labelledby="sources-heading" className="space-y-3">
+        <p
+          id="sources-heading"
+          className="text-[11px] font-medium uppercase tracking-wider text-brand-silver"
+        >
+          Source documents
+        </p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {OIT_SOURCE_DOCS.map((doc) => (
+            <article
+              key={doc.href}
+              className="rounded-lg border border-hairline bg-white p-4"
+            >
+              <h2 className="text-sm font-bold tracking-tight text-brand-black">
+                <a href={doc.href} target="_blank" rel="noopener noreferrer">
+                  {doc.title}
+                </a>
+              </h2>
+              <p className="mt-1 text-xs text-ink-subtle">
+                Updated{" "}
+                {new Date(doc.updated + "T00:00:00Z").toLocaleDateString("en-US", {
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                  timeZone: "UTC",
+                })}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-ink-muted">
+                {doc.role}
+              </p>
+            </article>
+          ))}
+        </div>
+        <p className="text-xs text-ink-subtle">
+          Both governance documents remain discussion drafts; entries here
+          track the published wiki versions and update as OIT revises them.
+        </p>
+      </section>
+
+      {/* Scope */}
+      <section aria-labelledby="scope-heading" className="space-y-4">
+        <div className="max-w-3xl">
+          <h2
+            id="scope-heading"
+            className="text-xl font-black tracking-tight text-brand-black"
+          >
+            When the framework applies
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Any single trigger brings a project into scope &mdash; and
+            enterprise tooling is then required from day one of development,
+            not when institutional data first appears.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="rounded-lg border border-hairline bg-white p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-clearwater">
+              In scope — any one is sufficient
+            </p>
+            <ul className="mt-3 space-y-2">
+              {IN_SCOPE_TRIGGERS.map((t) => (
+                <li key={t} className="text-sm leading-relaxed text-brand-black">
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-lg border border-hairline bg-surface-alt p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              Out of scope
+            </p>
+            <ul className="mt-3 space-y-2">
+              {OUT_OF_SCOPE_EXAMPLES.map((t) => (
+                <li key={t} className="text-sm leading-relaxed text-ink-muted">
+                  {t}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 border-t border-hairline pt-3 text-xs text-ink-subtle">
+              If scope changes and enterprise deployment is later pursued, the
+              project enters at Stage 1 and existing code is reviewed at the
+              Stage 3 security gate.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Lifecycle */}
+      <section aria-labelledby="lifecycle-heading" className="space-y-6">
+        <div className="max-w-3xl">
+          <h2
+            id="lifecycle-heading"
+            className="text-xl font-black tracking-tight text-brand-black"
+          >
+            The six-stage lifecycle
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Builders lead early, OIT leads the gates, and operation is shared.
+            Gates close stages 1, 3, 4, and 5; the Stage 3 security review is
+            a hard gate with no bypass process.
+          </p>
+        </div>
+        <ol className="space-y-7">
+          {PATHWAY_STAGES.map((stage) => (
+            <StageRow key={stage.number} stage={stage} />
+          ))}
+        </ol>
+      </section>
+
+      {/* Six rules */}
+      <section aria-labelledby="rules-heading" className="space-y-4">
+        <div className="max-w-3xl">
+          <h2
+            id="rules-heading"
+            className="text-xl font-black tracking-tight text-brand-black"
+          >
+            Six rules for every in-scope application
+          </h2>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {PATHWAY_RULES.map((rule, i) => (
+            <article
+              key={rule.title}
+              className="rounded-lg border border-hairline bg-white p-4"
+            >
+              <p className="font-mono text-xs font-medium text-brand-silver">
+                {String(i + 1).padStart(2, "0")}
+              </p>
+              <h3 className="mt-1 text-sm font-bold tracking-tight text-brand-black">
+                {rule.title}
+              </h3>
+              <p className="mt-1.5 text-xs leading-relaxed text-ink-muted">
+                {rule.detail}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Our projects in the pathway */}
+      <section aria-labelledby="projects-heading" className="space-y-4">
+        <div className="max-w-3xl">
+          <h2
+            id="projects-heading"
+            className="text-xl font-black tracking-tight text-brand-black"
+          >
+            Our projects entering the pathway
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Two IIDS-built applications are moving from IIDS staging toward
+            OIT-hosted deployment. For each: why it is in scope, where it
+            stands, what is already true of it, and what the intake and
+            security gates will examine.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          {PATHWAY_PROJECTS.map((p) => (
+            <article
+              key={p.slug}
+              className="rounded-lg border border-hairline bg-white p-6"
+            >
+              <header className="flex flex-wrap items-start justify-between gap-3 border-b border-hairline pb-4">
+                <div>
+                  <h3 className="text-xl font-black tracking-tight text-brand-black">
+                    <Link
+                      href={`/portfolio/${p.slug}`}
+                      className="unstyled hover:text-brand-clearwater"
+                    >
+                      {p.name}
+                    </Link>
+                  </h3>
+                  <p className="mt-1 max-w-2xl text-sm text-ink-muted">
+                    {p.scopeTrigger}
+                  </p>
+                </div>
+                <span className="inline-flex shrink-0 items-center rounded-full border border-brand-huckleberry/30 bg-brand-huckleberry/10 px-2.5 py-0.5 text-[11px] font-semibold text-brand-huckleberry">
+                  Stage 1 — Idea &amp; Scoping
+                </span>
+              </header>
+              <div className="mt-4 grid gap-6 sm:grid-cols-2">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+                    Where it starts from
+                  </p>
+                  <ul className="mt-2 space-y-1.5">
+                    {p.standingFacts.map((f) => (
+                      <li
+                        key={f}
+                        className="text-sm leading-relaxed text-brand-black"
+                      >
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+                    What the gates will examine
+                  </p>
+                  <ul className="mt-2 space-y-1.5">
+                    {p.gateQuestions.map((q) => (
+                      <li
+                        key={q}
+                        className="text-sm leading-relaxed text-ink-muted"
+                      >
+                        {q}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+              <p className="mt-4 border-t border-hairline pt-3 text-xs text-ink-subtle">
+                {p.position}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   standardsWatch,
   summary,
@@ -143,30 +144,51 @@ export default function StandardsWatchPage() {
           Active sources
         </p>
         <h2 className="mt-2 text-lg font-black tracking-tight text-brand-black">
-          OIT Enterprise AI Development Framework
+          OIT&rsquo;s AI governance runs on two tracks
         </h2>
         <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
-          OIT (Kali Armitage) is circulating a discussion draft of the
-          Enterprise AI Development Framework, dated April 2026. It
-          proposes a paved-road model — a catalog of pre-approved tools,
-          patterns, and infrastructure so teams can build within safe
-          boundaries without per-project review — alongside a two-zone
-          hosted environment (OIT-operated platform plus per-team
-          Kubernetes namespace), APM 30.11 data classification, and a
-          required pre-deploy artifact set. Several decisions remain
-          open, including the AI model gateway, model-registry
-          ownership, local AI tooling policy, and long-term application
-          ownership.
+          The joint IIDS/OIT &ldquo;AI for UI&rdquo; effort (OIT delivery
+          lead: Kali Armitage) is drafting two companion documents. The{" "}
+          <span className="font-semibold text-brand-black">
+            Enterprise AI Development Framework
+          </span>{" "}
+          (discussion draft, updated June 2026) sets the technology
+          standards — a paved road of pre-approved tools, a two-zone
+          hosted environment, APM 30.11 data classification, and a
+          required pre-deploy artifact set. The{" "}
+          <span className="font-semibold text-brand-black">
+            AI-Assisted Builder Guide
+          </span>{" "}
+          (May 2026) sets the process for teams outside OIT deploying on
+          OIT infrastructure — a six-stage lifecycle with gates and six
+          rules for every in-scope application. Open decisions include
+          the AI model gateway (MindRouter is the named candidate),
+          model-registry ownership, local AI tooling policy, and
+          long-term application ownership.
         </p>
-        <p className="mt-3 text-sm">
+        <p className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm">
           <a
             href="https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19540/Enterprise-AI-Development-Framework"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2"
           >
-            Read the draft on the Azure DevOps wiki &rarr;
+            Framework draft &rarr;
           </a>
+          <a
+            href="https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19581/AI-Assisted-Builder-Guide"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2"
+          >
+            Builder Guide &rarr;
+          </a>
+          <Link
+            href="/standards/oit-pathway"
+            className="font-medium text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2"
+          >
+            The pathway, and where our projects sit &rarr;
+          </Link>
         </p>
         <p className="mt-3 text-xs text-ink-subtle">
           Entries below tagged{" "}
@@ -177,7 +199,7 @@ export default function StandardsWatchPage() {
           <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800">
             In discussion
           </span>{" "}
-          are addressed in part or whole by this source.
+          are addressed in part or whole by these sources.
         </p>
       </section>
 

--- a/components/StandardsSubNav.tsx
+++ b/components/StandardsSubNav.tsx
@@ -9,6 +9,7 @@ const subNavItems = [
   { href: "/standards/strategic-plan", label: "Strategic Plan" },
   { href: "/standards/strategic-plan/map", label: "Map" },
   { href: "/standards/intake-crosswalk", label: "Intake Crosswalk" },
+  { href: "/standards/oit-pathway", label: "OIT Pathway" },
   { href: "/standards/operational-excellence", label: "Op Excellence Survey" },
 ];
 

--- a/lib/oit-pathway.ts
+++ b/lib/oit-pathway.ts
@@ -1,0 +1,225 @@
+// OIT builder pathway — typed representation of the OIT "AI for UI"
+// governance documents as they apply to teams outside OIT deploying on
+// OIT-managed infrastructure. Source documents live on the Azure DevOps
+// Development wiki (links below); this module tracks the published
+// drafts so /standards/oit-pathway can render the lifecycle, the rules,
+// and where our projects sit — and so tsc catches drift when a stage or
+// rule is renamed.
+//
+// Two tracks, two documents:
+//   - Enterprise AI Development Framework — the TECH standards (approved
+//     stack, two-zone hosted environment, APM 30.11 classification,
+//     required pre-deploy artifacts). Tracked ask-by-ask in
+//     lib/standards-watch.ts.
+//   - AI-Assisted Builder Guide — the PROCESS for builders outside OIT
+//     (six-stage lifecycle with gates, enterprise tooling from day one,
+//     six binding rules). Modeled here.
+
+export interface OitSourceDoc {
+  title: string;
+  href: string;
+  updated: string; // ISO date of the wiki page's last update
+  role: string; // one-line description of what this document governs
+}
+
+export const OIT_SOURCE_DOCS: OitSourceDoc[] = [
+  {
+    title: "Enterprise AI Development Framework",
+    href: "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19540/Enterprise-AI-Development-Framework",
+    updated: "2026-06-10",
+    role: "The technology standards: approved stack, two-zone hosted environment, APM 30.11 data classification, and the artifact set required before deployment.",
+  },
+  {
+    title: "AI-Assisted Builder Guide",
+    href: "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19581/AI-Assisted-Builder-Guide",
+    updated: "2026-05-20",
+    role: "The process for builders outside OIT: a six-stage lifecycle with gates, enterprise tooling from day one, and six rules every in-scope application follows.",
+  },
+  {
+    title: "AI Development (AI for UI)",
+    href: "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19582/AI-Development",
+    updated: "2026-05-20",
+    role: "The joint IIDS/OIT effort behind both documents, with the named delivery, security, IAM, infrastructure, and development contacts.",
+  },
+];
+
+// ---- Six-stage lifecycle (AI-Assisted Builder Guide, May 2026) --------
+
+export type StageLead = "Builder" | "Collaborative" | "OIT";
+
+export interface PathwayStage {
+  number: number;
+  name: string;
+  ledBy: StageLead;
+  summary: string;
+  // The gate or checkpoint that closes this stage, when the guide
+  // defines one. Stages 2 and 6 carry a checkpoint / annual review
+  // rather than a hard gate.
+  gate?: string;
+}
+
+export const PATHWAY_STAGES: PathwayStage[] = [
+  {
+    number: 1,
+    name: "Idea & Scoping",
+    ledBy: "Builder",
+    summary:
+      "Problem statement, every data source identified, a named departmental sponsor, and an OIT intake request. Student, HR, or research data triggers a data classification review at this stage, not later.",
+    gate: "OIT intake approval is required before any development begins.",
+  },
+  {
+    number: 2,
+    name: "Design & Build",
+    ledBy: "Collaborative",
+    summary:
+      "Builders lead development and engage OIT at defined milestones: intake, a design check-in before significant investment, and a pre-review handoff. Enterprise tooling (university-licensed Claude or GitHub Copilot, GitHub Enterprise) from day one; synthetic or anonymized test data only.",
+    gate: "Checkpoint: documentation and a working demo before requesting security review.",
+  },
+  {
+    number: 3,
+    name: "Security & Compliance Review",
+    ledBy: "OIT",
+    summary:
+      "OIT Security reviews authentication (university SSO via Entra ID required), data storage and retention, all third-party and AI API calls, dependency vulnerabilities, and FERPA/HIPAA compliance. Automatic blockers include data outside OIT-approved infrastructure, standalone auth, personal or free-tier AI accounts, and missing ownership.",
+    gate: "Hard gate — no bypass process. Remediation is required before re-review.",
+  },
+  {
+    number: 4,
+    name: "Staging & Testing",
+    ledBy: "Collaborative",
+    summary:
+      "OIT DevOps provisions staging. Structured user testing, explicit failure-condition testing for AI components, accessibility verification, audit-logging confirmation, and enterprise-integration validation in staging — never in production first.",
+    gate: "OIT DevOps and the OIT point of contact sign off on staging results before production deployment is scheduled.",
+  },
+  {
+    number: 5,
+    name: "Production Deployment",
+    ledBy: "OIT",
+    summary:
+      "OIT DevOps deploys to production (Azure, OCI, or on-prem Kubernetes) and configures DNS, SSL, and SSO. Builders do not deploy to production directly. Named owner, runbook, and a documented decommission path must be on file before go-live.",
+    gate: "Go-live: all gates cleared. The application is live, monitored, and registered in the university AI inventory.",
+  },
+  {
+    number: 6,
+    name: "Operate & Maintain",
+    ledBy: "Collaborative",
+    summary:
+      "Builders notify OIT before changes (updates follow the same review process), keep enterprise licenses current, and own AI-vendor API deprecation remediation. OIT monitors infrastructure, patches the platform, and re-reviews sensitive applications annually.",
+    gate: "Annual review: owner and OIT confirm compliance, ownership, and continued need.",
+  },
+];
+
+// ---- Six rules for every in-scope application -------------------------
+
+export interface PathwayRule {
+  title: string;
+  detail: string;
+}
+
+export const PATHWAY_RULES: PathwayRule[] = [
+  {
+    title: "Enterprise tooling from day one",
+    detail:
+      "University-licensed Claude or GitHub Copilot plus GitHub Enterprise, with university guardrails, from the first line of code. Personal accounts and free tiers are not permitted for in-scope projects.",
+  },
+  {
+    title: "Data classification first",
+    detail:
+      "Any application touching student, employee, or research data requires a formal data classification review before development begins.",
+  },
+  {
+    title: "AI inventory registration",
+    detail:
+      "All AI-generated or AI-assisted applications register in the university's AI application inventory, regardless of size or audience.",
+  },
+  {
+    title: "Approved infrastructure only",
+    detail:
+      "Deployments use OIT-approved platforms: Azure, OCI, or on-prem Kubernetes. Personal cloud accounts and free-tier services are not permitted.",
+  },
+  {
+    title: "University identity required",
+    detail:
+      "All applications authenticate through university SSO (Entra ID). Standalone username/password systems are not approved.",
+  },
+  {
+    title: "Named ownership required",
+    detail:
+      "Every application has a named individual owner responsible for maintenance, updates, and decommissioning. A department name is not sufficient.",
+  },
+];
+
+// ---- Scope triggers ----------------------------------------------------
+
+// Any single trigger brings a project into the framework's scope.
+export const IN_SCOPE_TRIGGERS: string[] = [
+  "Deployed to OIT-managed infrastructure and used by students, faculty, or staff",
+  "Integrates with university administrative systems (Banner, SSO, other institutional data sources)",
+  "Handles data classified under university policy (FERPA, HIPAA, other regulated types)",
+  "Requires OIT support, monitoring, or ongoing maintenance",
+];
+
+export const OUT_OF_SCOPE_EXAMPLES: string[] = [
+  "Personal projects with no institutional deployment intent",
+  "Open-source projects not hosted on OIT infrastructure (the guide's own examples: OpenERA, Vandalizer)",
+  "Research tools used solely by the developing researcher",
+  "Proof-of-concept experiments that will not seek enterprise deployment",
+];
+
+// ---- Projects entering the pathway ------------------------------------
+
+export interface PathwayProject {
+  slug: string; // portfolio slug — links to /portfolio/<slug>
+  name: string;
+  // Why this project is (or is about to be) in scope for the framework.
+  scopeTrigger: string;
+  // Where the project stands against the six stages today.
+  position: string;
+  // Facts the intake conversation starts from — what is already true
+  // of the project. Kept factual; portfolio entries are the source.
+  standingFacts: string[];
+  // What the Stage 1 intake and Stage 3 security gate will examine.
+  // Framed as the questions the pathway asks, not as asserted status.
+  gateQuestions: string[];
+}
+
+export const PATHWAY_PROJECTS: PathwayProject[] = [
+  {
+    slug: "openera",
+    name: "OpenERA",
+    scopeTrigger:
+      "The Builder Guide names OpenERA as an out-of-scope example while it runs open-source off OIT infrastructure. Pursuing OIT-hosted deployment flips that: the project enters the framework at Stage 1, and the existing codebase is reviewed at the Stage 3 security gate.",
+    position:
+      "Entering Stage 1 — Idea & Scoping. Existing code will be reviewed at the Stage 3 security gate per the guide's scope-change rule.",
+    standingFacts: [
+      "Built on FastAPI, React, TypeScript, SQLAlchemy 2.0, and PostgreSQL 16 — the core of the framework's approved stack",
+      "Named UI implementation owner: Sarah Martonick (Office of Research and Economic Development)",
+      "Currently staged on IIDS infrastructure at openera.insight.uidaho.edu",
+      "AI4RA Core dual-destiny project (NSF GRANTED) — the open-source distribution remains out of the framework's scope",
+    ],
+    gateQuestions: [
+      "Data classification under APM 30.11 — sponsored-research administration data spans multiple regulated types",
+      "Authentication path to university SSO (Entra ID)",
+      "Source-control and CI/CD placement — the framework lists ADO with GitHub Enterprise and GitHub Actions under review",
+      "Observability stack (OpenTelemetry, Prometheus, Jaeger, Splunk) and pre-deploy artifact set",
+    ],
+  },
+  {
+    slug: "ucm-daily-register",
+    name: "UCM Daily Register",
+    scopeTrigger:
+      "Seeking deployment to OIT-managed infrastructure for daily use by University Communications and Marketing staff — the framework's first scope trigger.",
+    position: "Entering Stage 1 — Idea & Scoping.",
+    standingFacts: [
+      "Built on React, FastAPI, and SQLAlchemy 2.0, with AI editing routed through MindRouter — aligned with the framework's approved stack and its named gateway candidate",
+      "Named operational owners: Joy Bauer, Leigh Cooper, and Jodi Walker (University Communications and Marketing)",
+      "Currently staged on IIDS infrastructure at ucmnews.insight.uidaho.edu",
+    ],
+    gateQuestions: [
+      "Data classification under APM 30.11 — editorial submissions are institutional content; classification review will confirm the tier",
+      "Authentication path to university SSO (Entra ID)",
+      "AI API posture — MindRouter is on-prem and named in the framework's stack table; the approved-models list is still TBD",
+      "Named individual owner for the Stage 5 go-live requirement (runbook and decommission path on file)",
+    ],
+  },
+];

--- a/lib/oit-pathway.ts
+++ b/lib/oit-pathway.ts
@@ -14,6 +14,13 @@
 //   - AI-Assisted Builder Guide — the PROCESS for builders outside OIT
 //     (six-stage lifecycle with gates, enterprise tooling from day one,
 //     six binding rules). Modeled here.
+//
+// The hosted environment these documents describe is what the project
+// inventory tracks as Nexus (lib/portfolio.ts, slug "nexus") — the
+// OIT-managed application platform built collaboratively by OIT and
+// IIDS. The wiki drafts describe the platform without using the name;
+// this module makes the connection explicit so the pathway page can
+// link the standards to the inventory entry.
 
 export interface OitSourceDoc {
   title: string;
@@ -188,9 +195,9 @@ export const PATHWAY_PROJECTS: PathwayProject[] = [
     slug: "openera",
     name: "OpenERA",
     scopeTrigger:
-      "The Builder Guide names OpenERA as an out-of-scope example while it runs open-source off OIT infrastructure. Pursuing OIT-hosted deployment flips that: the project enters the framework at Stage 1, and the existing codebase is reviewed at the Stage 3 security gate.",
+      "The Builder Guide names OpenERA as an out-of-scope example while it runs open-source off OIT infrastructure. Pursuing deployment onto Nexus flips that: the project enters the framework at Stage 1, and the existing codebase is reviewed at the Stage 3 security gate.",
     position:
-      "Entering Stage 1 — Idea & Scoping. Existing code will be reviewed at the Stage 3 security gate per the guide's scope-change rule.",
+      "Entering Stage 1 — Idea & Scoping, targeting Nexus deployment. Existing code will be reviewed at the Stage 3 security gate per the guide's scope-change rule.",
     standingFacts: [
       "Built on FastAPI, React, TypeScript, SQLAlchemy 2.0, and PostgreSQL 16 — the core of the framework's approved stack",
       "Named UI implementation owner: Sarah Martonick (Office of Research and Economic Development)",
@@ -208,8 +215,8 @@ export const PATHWAY_PROJECTS: PathwayProject[] = [
     slug: "ucm-daily-register",
     name: "UCM Daily Register",
     scopeTrigger:
-      "Seeking deployment to OIT-managed infrastructure for daily use by University Communications and Marketing staff — the framework's first scope trigger.",
-    position: "Entering Stage 1 — Idea & Scoping.",
+      "Seeking deployment onto Nexus for daily use by University Communications and Marketing staff — OIT-managed infrastructure used by staff is the framework's first scope trigger.",
+    position: "Entering Stage 1 — Idea & Scoping, targeting Nexus deployment.",
     standingFacts: [
       "Built on React, FastAPI, and SQLAlchemy 2.0, with AI editing routed through MindRouter — aligned with the framework's approved stack and its named gateway candidate",
       "Named operational owners: Joy Bauer, Leigh Cooper, and Jodi Walker (University Communications and Marketing)",

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -422,7 +422,7 @@ export const projects: Project[] = [
     operationalExcellenceOutcome:
       "Faster newsletter turnaround. Enforces AP + UI style consistently across issues. Reduces manual editorial burden per issue.",
     tech: ["React 19", "FastAPI", "SQLAlchemy 2.0", "MindRouter"],
-    relatedSlugs: ["mindrouter"],
+    relatedSlugs: ["mindrouter", "nexus"],
     workCategories: ["documents", "process"],
     strategicPlanAlignment: ["E.2"],
   },
@@ -517,7 +517,7 @@ export const projects: Project[] = [
     operationalExcellenceOutcome:
       "On-prem, UDM-aligned ERA system with shared data semantics across ORED tooling. Enables AI features (extraction, lookup, classification) on research-admin data without third-party data egress. Reference deployment for AI4RA partners.",
     tech: ["React", "TypeScript", "Tailwind CSS", "FastAPI", "SQLAlchemy 2.0", "PostgreSQL 16"],
-    relatedSlugs: ["vandalizer", "processmapping"],
+    relatedSlugs: ["vandalizer", "processmapping", "nexus"],
     workCategories: ["research-admin"],
     strategicPlanAlignment: ["D.2", "E.2"],
   },
@@ -798,7 +798,7 @@ export const projects: Project[] = [
     tagline:
       "OIT-managed application platform where UI application modules are deployed.",
     description:
-      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone.",
+      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT's Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT); OpenERA and UCM Daily Register are the first IIDS-built applications entering that pathway.",
     homeUnits: ["Office of Information Technology"],
     operationalOwners: [
       { name: "Kali Armitage" },
@@ -815,7 +815,7 @@ export const projects: Project[] = [
       "Hosts UI application modules on OIT-managed secure infrastructure with a consistent runtime, identity, and security baseline. Target deployment surface for new UI apps that need institutional hosting.",
     operationalExcellenceOutcome:
       "Standardizes where institutional application modules live. Shared security posture, audit trail, and operational footprint across UI units. Reduces per-app hosting overhead and fragmentation.",
-    relatedSlugs: ["template-app"],
+    relatedSlugs: ["template-app", "openera", "ucm-daily-register"],
     workCategories: ["ai-infrastructure"],
     strategicPlanAlignment: ["E.1", "E.4"],
   },

--- a/lib/standards-watch.ts
+++ b/lib/standards-watch.ts
@@ -29,11 +29,16 @@ export interface StandardsWatchItem {
   responseNote?: string;
 }
 
-// Shared response URL for items addressed by the OIT Enterprise AI
-// Development Framework discussion draft (April 2026). Per-item
-// responseNote captures what the draft provides for each ask.
+// Shared response URLs for items addressed by the OIT "AI for UI"
+// documents. The Enterprise AI Development Framework (discussion draft
+// April 2026, wiki page last updated June 10, 2026) carries the tech
+// standards; the AI-Assisted Builder Guide (May 2026) carries the
+// lifecycle/process standards for teams outside OIT. Per-item
+// responseNote captures what each draft provides for the ask.
 const OIT_FRAMEWORK_URL =
   "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19540/Enterprise-AI-Development-Framework";
+const OIT_BUILDER_GUIDE_URL =
+  "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19581/AI-Assisted-Builder-Guide";
 
 const PLACEHOLDER_DATE = "2026-02-15"; // mid-February — when these items first surfaced; refine per-entry as needed
 
@@ -55,7 +60,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "OIT Enterprise AI Development Framework (Apr 2026 discussion draft) defines a two-zone hosted environment (OIT-operated platform + per-team K8s namespace on OCI OKE / on-prem), API-first design via FastAPI, identity through Microsoft Entra ID, and a binding approved tech stack. Architecture-diagram and data-flow-diagram artifacts are required pre-deploy.",
+      "OIT Enterprise AI Development Framework (discussion draft; wiki updated Jun 2026) defines a two-zone hosted environment (OIT-operated platform + per-team K8s namespace on OCI OKE / on-prem), API-first design via FastAPI, identity through Microsoft Entra ID, and a binding approved tech stack. MindRouter is now listed in the stack table as the AI model gateway candidate (others TBD; approved-models list TBD). Architecture-diagram and data-flow-diagram artifacts are required pre-deploy.",
   },
   {
     id: "i-2",
@@ -92,7 +97,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework adopts APM 30.11 (Low / Moderate / High) as the binding classification scheme and specifies PostgreSQL + pgaudit for audit logging. Prompt and completion logs inherit the classification of underlying data. Canonical data models, retention, lineage, and DR standards are not yet specified.",
+      "Framework adopts APM 30.11 (Low / Moderate / High) as the binding classification scheme and specifies PostgreSQL with pgvector, pgaudit, and pgsodium (containerized, per application) — pgaudit covering audit logging. Prompt and completion logs inherit the classification of underlying data. The draft notes dev and test environments currently house production data. Canonical data models, retention, lineage, and DR standards are not yet specified.",
   },
   {
     id: "i-4",
@@ -129,7 +134,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework defines OCI OKE + on-prem Kubernetes as the approved hosting environments, Azure Pipelines as the CI/CD pipeline (GitHub Actions under review), ArgoCD + Kustomize for GitOps deployment, and per-team K8s namespaces with no direct cluster access in test/prod. Each team gets a starter deployment repository. Specific environment-structure rules and IaC standards beyond Kustomize are not yet specified.",
+      "Framework defines OCI OKE + on-prem Kubernetes as the approved hosting environments (the Builder Guide adds Azure for production deployment), Azure Pipelines as the CI/CD pipeline (GitHub Actions under review), ADO as source control (GitHub Enterprise under review), ArgoCD + Kustomize for GitOps deployment, and per-team K8s namespaces with no direct cluster access in test/prod. Each team gets a starter deployment repository. Specific environment-structure rules and IaC standards beyond Kustomize are not yet specified.",
   },
   {
     id: "i-6",
@@ -144,10 +149,10 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Change management requirements",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "in-discussion",
-    responseUrl: OIT_FRAMEWORK_URL,
+    status: "in-draft",
+    responseUrl: OIT_BUILDER_GUIDE_URL,
     responseNote:
-      "Framework names the required pre-deploy artifacts (systems architecture diagram, per-module data-flow diagrams, risk assessment, runbook covering deployment/rollback/incident response/alerting/ownership, EAR if new tech, VASA if new vendor). Long-term application ownership and support model is an explicit open question in the draft — options range from full product-team ownership to OIT-assumed long-term support; decision affects how applications are scoped, staffed, and funded.",
+      "The AI-Assisted Builder Guide (May 2026) now drafts the lifecycle end-to-end: a six-stage pathway with gates at stages 1, 3, 4, and 5, a hard security gate with no bypass, named-individual ownership (a department is not sufficient), and a runbook + documented decommission path on file before go-live, plus an annual ownership confirmation. The Framework separately names the pre-deploy artifact set (architecture diagram, data-flow diagrams, risk assessment, runbook, EAR, VASA). Long-term support responsibility remains an explicit open question — options range from full product-team ownership to OIT-assumed support.",
   },
   {
     id: "i-7",
@@ -194,7 +199,10 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Communication expectations for breaking changes",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "not-started",
+    status: "in-discussion",
+    responseUrl: OIT_BUILDER_GUIDE_URL,
+    responseNote:
+      "The AI-Assisted Builder Guide's Stage 6 (Operate & Maintain) starts on this: builders notify OIT before any change, all updates follow the same review process as the original build, AI-vendor API deprecation remediation is the builder's responsibility, and an annual review confirms compliance, ownership, and continued need. Version-upgrade cadence, backward-compatibility rules, and breaking-change communication are not yet specified.",
   },
   {
     id: "i-10",


### PR DESCRIPTION
## What

OIT's "AI for UI" governance now runs on two tracks, and the standards surface reflects both:

1. **Enterprise AI Development Framework** (wiki updated Jun 10, 2026) — the *tech* standards. Ledger response notes refreshed: MindRouter now appears in the approved-stack table as the AI model gateway candidate; PostgreSQL extensions (pgvector, pgaudit, pgsodium); ADO as source control with GitHub Enterprise + GitHub Actions under review; Azure added as a production deployment target via the Builder Guide.
2. **AI-Assisted Builder Guide** (May 20, 2026 — new document) — the *process* for teams outside OIT deploying on OIT-managed infrastructure: six-stage lifecycle with gates at 1/3/4/5, enterprise tooling from day one, six binding rules.

## Changes

- **New `/standards/oit-pathway` sub-page** (+ StandardsSubNav row): source documents with dates, scope triggers, the six-stage lifecycle with gates, the six rules, and cards for **OpenERA** and **UCM Daily Register** as they enter Stage 1 — including the guide's scope-change rule (OpenERA is the guide's own out-of-scope example while off OIT infra; pursuing OIT deployment brings it in at Stage 1 with existing code reviewed at the Stage 3 hard gate).
- **New typed module `lib/oit-pathway.ts`** backing the page.
- **Ledger updates in `lib/standards-watch.ts`**: I.1/I.3/I.5 notes refreshed per the June update; **I.6 Application Lifecycle & Handoff → in-draft** (the Builder Guide now drafts it end-to-end); **I.9 Upgrade & Change Management → in-discussion** (Stage 6 covers change-review, vendor-deprecation responsibility, annual review).
- **`/standards` Active sources block** rewritten as the two-track framing with links to both drafts and the new pathway page.

Verified: `npm run build` passes; both pages render on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)