### PR TITLE
Add Vandals Stats Pipeline to inventory

### DIFF
--- a/lib/portfolio-meta.ts
+++ b/lib/portfolio-meta.ts
@@ -21,6 +21,7 @@ export const portfolioMeta: Record<string, PortfolioMetaEntry> = {
   "processmapping": { lastCommitDate: "2026-06-30T06:54:37Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "rfd-career": { lastCommitDate: "2026-06-09T22:52:23Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "sem-experiential": { lastCommitDate: "2026-06-30T14:55:27Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
+  "sidearm-pipeline": { lastCommitDate: "2026-07-17T21:03:11Z", fetchedAt: "2026-07-21T19:51:04.000Z" },
   "stratplan": { lastCommitDate: "2026-05-05T09:35:03Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "template-app": { lastCommitDate: "2026-05-05T20:06:00Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "ucm-daily-register": { lastCommitDate: "2026-05-11T22:58:35Z", fetchedAt: "2026-07-09T20:33:00.770Z" },

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -629,6 +629,44 @@ export const projects: Project[] = [
   },
 
   // ============================================================
+  // Athletics
+  // ============================================================
+  {
+    slug: "sidearm-pipeline",
+    name: "Vandals Stats Pipeline",
+    tagline:
+      "Trusted athletics data warehouse and exploratory workspace for Sports Information Directors.",
+    description:
+      "Internal athletics data warehouse that ingests public Sidearm boxscores and season statistics, normalizes game and player history in PostgreSQL, preserves source provenance and coverage windows, and gives Sports Information Directors an evidence-backed workspace for record-book research, notable-achievement review, and downstream website-ready data. Release 1 is internal-SID-first; public website integration is deferred.",
+    homeUnits: ["Athletics"],
+    operationalOwners: [],
+    buildParticipants: ["IIDS"],
+    status: "building",
+    visibility: "Public",
+    proposedDeploymentEnvironment: "oit-hosted",
+    enterpriseSystemReplacement: { status: "no" },
+    ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    repoUrl: "https://github.com/ui-insight/sidearm-pipeline",
+    operationalFunction:
+      "Ingests and normalizes Sidearm boxscores and cumulative season statistics; maintains a provenance-aware athletics record book; and supports SID review, comparison, export, achievement suggestions, and governed natural-language questions over verified warehouse facts.",
+    operationalExcellenceOutcome:
+      "Turns fragmented public athletics statistics into a durable institutional record, reduces manual record-book research, and gives Athletics staff faster access to evidence they can confidently use in coverage and website publishing.",
+    tech: [
+      "React 19",
+      "TypeScript",
+      "Tailwind CSS",
+      "FastAPI",
+      "SQLAlchemy 2.0",
+      "PostgreSQL 16",
+      "Docker",
+    ],
+    relatedSlugs: ["template-app", "mindrouter", "nexus"],
+    workCategories: ["knowledge-retrieval", "process"],
+    strategicPlanAlignment: ["E.1", "E.2"],
+  },
+
+  // ============================================================
   // Research Faculty Development (ORED)
   // ============================================================
   {
@@ -962,6 +1000,7 @@ export const HOME_UNIT_GROUP_ORDER = [
   "UI Library",
   "Division of Financial Affairs",
   "Strategic Enrollment Management",
+  "Athletics",
   "University Communications and Marketing",
   "Office of General Counsel",
   "Office of Information Technology",


### PR DESCRIPTION
## Summary

- add Vandals Stats Pipeline to the Athletics project inventory
- record the project as actively building with a proposed OIT-hosted deployment path
- record that it consumes Sidearm data but does not replace an enterprise system
- add Athletics to the ordered home-unit groups and include fresh repository activity metadata

## Why

The Sidearm pipeline is an active IIDS project for University of Idaho Athletics and should be visible in the governed portfolio alongside other institutional AI and data efforts.

## Impact

The public inventory now includes the project's purpose, lifecycle, deployment proposal, strategic-plan alignment, technology, related infrastructure, and repository. The named Athletics operational owner remains intentionally pending because the source repository does not identify one.

## Validation

- `npm run build`
- `npm run lint`
- `npm run verify:portfolio` — 25 projects, 0 errors; 3 pre-existing repository-metadata warnings

The source Sidearm repository and the untracked governance documents were not modified.
