### PR TITLE
Add RFD Companion to inventory

### DIFF
--- a/lib/portfolio-meta.ts
+++ b/lib/portfolio-meta.ts
@@ -20,6 +20,7 @@ export const portfolioMeta: Record<string, PortfolioMetaEntry> = {
   "openera": { lastCommitDate: "2026-07-09T20:10:34Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "processmapping": { lastCommitDate: "2026-06-30T06:54:37Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "rfd-career": { lastCommitDate: "2026-06-09T22:52:23Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
+  "rfd-companion": { lastCommitDate: "2026-07-14T22:40:44Z", fetchedAt: "2026-07-22T14:20:03.000Z" },
   "sem-experiential": { lastCommitDate: "2026-06-30T14:55:27Z", fetchedAt: "2026-07-09T20:33:00.770Z" },
   "sidearm-pipeline": { lastCommitDate: "2026-07-17T21:03:11Z", fetchedAt: "2026-07-21T19:51:04.000Z" },
   "stratplan": { lastCommitDate: "2026-05-05T09:35:03Z", fetchedAt: "2026-07-09T20:33:00.770Z" },

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -670,6 +670,52 @@ export const projects: Project[] = [
   // Research Faculty Development (ORED)
   // ============================================================
   {
+    slug: "rfd-companion",
+    name: "RFD Companion",
+    tagline:
+      "One accountable workspace for Research and Faculty Development operations.",
+    description:
+      "Standalone operational workspace for proposal-development support, faculty-development programs, internal competitions, events, reviews, shared calendars, and staff and faculty next actions. RFD Companion integrates with OpenERA through explicit least-privilege APIs, is intended to replace RFD's InfoReady workflows after parity and migration validation, and will replace TDX for proposal-development operations after a controlled cutover.",
+    homeUnits: ["Research Faculty Development (ORED)"],
+    operationalOwners: [
+      {
+        name: "Carly Cummings",
+        title: "Director of Research and Faculty Development",
+      },
+    ],
+    buildParticipants: ["IIDS", "Research and Faculty Development"],
+    status: "building",
+    visibility: "Public",
+    proposedDeploymentEnvironment: "to-be-determined",
+    enterpriseSystemReplacement: {
+      status: "yes",
+      systemName: "InfoReady",
+      annualCostUsd: 17_000,
+      renewalDate: "2026-11-06",
+    },
+    ai4raRelationship: "Adjacent",
+    iidsSponsor: "Barrie Robison",
+    repoUrl: "https://github.com/ui-insight/RFDModule",
+    isPrivateRepo: true,
+    operationalFunction:
+      "Coordinates RFD service requests, proposal checklists and task schedules, faculty-development programs and cohorts, competitions, events, reviews, shared deadlines, and role-scoped next actions while exchanging authoritative proposal and award data with OpenERA.",
+    operationalExcellenceOutcome:
+      "Replaces fragmented spreadsheets and vendor-shaped workflows with one RFD-owned operating model, reduces duplicate entry across research-administration systems, and positions RFD to retire the approximately $17,000-per-year InfoReady contract after validated parity and migration.",
+    tech: [
+      "React",
+      "TypeScript",
+      "FastAPI",
+      "SQLAlchemy 2.0",
+      "PostgreSQL 16",
+      "Redis",
+      "arq",
+      "Docker",
+    ],
+    relatedSlugs: ["openera", "rfd-career"],
+    workCategories: ["research-admin", "process", "coordination"],
+    strategicPlanAlignment: ["D.2", "E.2", "E.4"],
+  },
+  {
     slug: "rfd-career",
     name: "RFD CAREER Dashboard",
     tagline: "Cohort progress dashboard for the CAREER Club program.",


### PR DESCRIPTION
## Summary

- add RFD Companion to the Research Faculty Development portfolio group
- record Carly Cummings as the operational owner and the project as actively building
- record the deployment environment as still to be determined
- record the intended replacement of InfoReady at approximately $17,000 per year, renewing November 6, 2026
- include current private-repository activity metadata and relationships to OpenERA and the RFD CAREER Dashboard

## Why

RFD Companion is an active IIDS and Research and Faculty Development effort that needs to be represented in the governed institutional project inventory. Its planned InfoReady replacement also has a material renewal deadline and annual cost that should be visible for governance and planning.

## Impact

The inventory now captures the project's operational scope, owner, lifecycle, technology, strategic-plan alignment, deployment uncertainty, and incumbent-system economics. The entry states that InfoReady retirement remains contingent on successful parity, migration, retention, and cutover validation. It also describes the separately documented TDX proposal-development transition without attributing InfoReady's contract cost to TDX.

## Validation

- `npm run build`
- `npm run lint`
- `npm run verify:portfolio` — 26 projects, 0 errors; 3 pre-existing repository-metadata warnings

The RFDModule source repository and the untracked governance source materials were not modified.
