### PR TITLE
Add ui-AI4UI repository milestone

### DIFF
--- a/app/docs/builder-guide/page.tsx
+++ b/app/docs/builder-guide/page.tsx
@@ -115,6 +115,18 @@ export default function BuilderGuideDocsPage() {
         <li>Connect you with the right resources to get started building</li>
       </ul>
 
+      <InfoBox type="info" title="OIT-bound repository milestone">
+        If OIT-managed deployment is accepted as the target, the application&apos;s
+        deployment repository is created in or transferred to the{" "}
+        <a href="https://github.com/ui-AI4UI" target="_blank" rel="noopener noreferrer">
+          ui-AI4UI GitHub organization
+        </a>{" "}
+        during Stage 2, no later than the pre-review handoff. That milestone records
+        deployment intent and shared custody; it does not replace the security,
+        staging, or production gates. See the{" "}
+        <Link href="/standards/oit-pathway">OIT deployment pathway</Link>.
+      </InfoBox>
+
       <InfoBox type="info" title="Your submission is not a commitment">
         Submitting an idea through the assessment doesn&apos;t commit you to anything. It&apos;s a
         way to get guidance and start a conversation with the IIDS team about your needs.

--- a/app/standards/oit-pathway/page.tsx
+++ b/app/standards/oit-pathway/page.tsx
@@ -2,11 +2,13 @@ import Link from "next/link";
 import {
   OIT_SOURCE_DOCS,
   PATHWAY_STAGES,
+  PATHWAY_MILESTONES,
   PATHWAY_RULES,
   IN_SCOPE_TRIGGERS,
   OUT_OF_SCOPE_EXAMPLES,
   PATHWAY_PROJECTS,
   type PathwayStage,
+  type PathwayMilestone,
   type StageLead,
 } from "@/lib/oit-pathway";
 
@@ -32,7 +34,64 @@ function LeadChip({ lead }: { lead: StageLead }) {
   );
 }
 
+function MilestoneCard({ milestone }: { milestone: PathwayMilestone }) {
+  return (
+    <div className="mt-3 rounded-lg border border-brand-lupine/30 bg-brand-lupine/5 p-4">
+      <div className="flex flex-wrap items-center gap-2.5">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-huckleberry">
+          Operating milestone
+        </p>
+        <LeadChip lead={milestone.ledBy} />
+      </div>
+      <h4 className="mt-2 text-sm font-bold tracking-tight text-brand-black">
+        {milestone.href ? (
+          <a href={milestone.href} target="_blank" rel="noopener noreferrer">
+            {milestone.name}
+          </a>
+        ) : (
+          milestone.name
+        )}
+      </h4>
+      <p className="mt-1.5 text-sm leading-relaxed text-ink-muted">
+        {milestone.summary}
+      </p>
+      <p className="mt-3 text-xs font-semibold uppercase tracking-wider text-brand-silver">
+        Complete when
+      </p>
+      <ul className="mt-1.5 space-y-1">
+        {milestone.completeWhen.map((item) => (
+          <li key={item} className="text-sm leading-relaxed text-brand-black">
+            {item}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-3 border-t border-brand-lupine/20 pt-3 text-xs leading-relaxed text-ink-subtle">
+        <span className="font-semibold text-brand-black">Boundary.</span>{" "}
+        {milestone.boundary}
+      </p>
+      {milestone.openQuestions && milestone.openQuestions.length > 0 && (
+        <div className="mt-3 border-t border-brand-lupine/20 pt-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-brand-silver">
+            Still to define
+          </p>
+          <ul className="mt-1.5 space-y-1">
+            {milestone.openQuestions.map((item) => (
+              <li key={item} className="text-xs leading-relaxed text-ink-muted">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StageRow({ stage }: { stage: PathwayStage }) {
+  const milestones = PATHWAY_MILESTONES.filter(
+    (milestone) => milestone.stage === stage.number
+  );
+
   return (
     <li className="relative pl-12">
       <span
@@ -55,6 +114,9 @@ function StageRow({ stage }: { stage: PathwayStage }) {
           <span className="font-semibold">Gate.</span> {stage.gate}
         </p>
       )}
+      {milestones.map((milestone) => (
+        <MilestoneCard key={milestone.id} milestone={milestone} />
+      ))}
     </li>
   );
 }

--- a/lib/oit-pathway.ts
+++ b/lib/oit-pathway.ts
@@ -65,6 +65,21 @@ export interface PathwayStage {
   gate?: string;
 }
 
+// Concrete operating decisions that make the still-evolving source process
+// actionable. These are local IIDS/OIT milestones layered onto the published
+// draft lifecycle; they do not imply that the source wiki has been revised.
+export interface PathwayMilestone {
+  id: string;
+  stage: number;
+  name: string;
+  ledBy: StageLead;
+  href?: string;
+  summary: string;
+  completeWhen: string[];
+  boundary: string;
+  openQuestions?: string[];
+}
+
 export const PATHWAY_STAGES: PathwayStage[] = [
   {
     number: 1,
@@ -79,8 +94,8 @@ export const PATHWAY_STAGES: PathwayStage[] = [
     name: "Design & Build",
     ledBy: "Collaborative",
     summary:
-      "Builders lead development and engage OIT at defined milestones: intake, a design check-in before significant investment, and a pre-review handoff. Enterprise tooling (university-licensed Claude or GitHub Copilot, GitHub Enterprise) from day one; synthetic or anonymized test data only.",
-    gate: "Checkpoint: documentation and a working demo before requesting security review.",
+      "Builders lead development and engage OIT at defined milestones: intake, a design check-in before significant investment, and a pre-review handoff. Enterprise tooling (university-licensed Claude or GitHub Copilot, GitHub Enterprise) from day one; synthetic or anonymized test data only. The OIT deployment repository is established in ui-AI4UI no later than the pre-review handoff.",
+    gate: "Checkpoint: the repository-placement milestone, documentation, and a working demo are complete before requesting security review.",
   },
   {
     number: 3,
@@ -116,6 +131,31 @@ export const PATHWAY_STAGES: PathwayStage[] = [
   },
 ];
 
+export const PATHWAY_MILESTONES: PathwayMilestone[] = [
+  {
+    id: "oit-deployment-repository",
+    stage: 2,
+    name: "Establish the OIT deployment repository in ui-AI4UI",
+    ledBy: "Collaborative",
+    href: "https://github.com/ui-AI4UI",
+    summary:
+      "Once OIT-managed deployment is the accepted target, create the application's deployment repository in—or transfer it to—the ui-AI4UI GitHub organization. New projects should start there; existing projects complete the move no later than the Stage 2 pre-review handoff.",
+    completeWhen: [
+      "The deployment-bound repository exists under github.com/ui-AI4UI.",
+      "Named builder and OIT collaborators can access the repository for review and handoff work.",
+      "The repository URL is recorded in the project inventory and the OIT intake or handoff record.",
+    ],
+    boundary:
+      "Repository placement records deployment intent and shared custody. It is not security approval, support acceptance, or authorization to deploy; Stages 3 through 5 still apply.",
+    openQuestions: [
+      "Whether ui-AI4UI is the authoritative application repository or a deployment repository when an upstream or open-source repository also exists.",
+      "Which OIT and IIDS teams administer organization membership, repository creation, CODEOWNERS, and branch protections.",
+      "Whether GitHub Actions, Azure Pipelines, or both provide the binding CI/CD and required checks.",
+      "Who performs an existing-repository transfer and how issues, history, secrets, and external links are preserved.",
+    ],
+  },
+];
+
 // ---- Six rules for every in-scope application -------------------------
 
 export interface PathwayRule {
@@ -127,7 +167,7 @@ export const PATHWAY_RULES: PathwayRule[] = [
   {
     title: "Enterprise tooling from day one",
     detail:
-      "University-licensed Claude or GitHub Copilot plus GitHub Enterprise, with university guardrails, from the first line of code. Personal accounts and free tiers are not permitted for in-scope projects.",
+      "University-licensed Claude or GitHub Copilot plus GitHub Enterprise, with university guardrails, from the first line of code. For OIT-bound applications, the deployment repository is placed in ui-AI4UI as the Stage 2 operating milestone. Personal accounts and free tiers are not permitted for in-scope projects.",
   },
   {
     title: "Data classification first",
@@ -207,7 +247,7 @@ export const PATHWAY_PROJECTS: PathwayProject[] = [
     gateQuestions: [
       "Data classification under APM 30.11 — sponsored-research administration data spans multiple regulated types",
       "Authentication path to university SSO (Entra ID)",
-      "Source-control and CI/CD placement — the framework lists ADO with GitHub Enterprise and GitHub Actions under review",
+      "Repository and CI/CD handoff — establish the OIT deployment repository in ui-AI4UI at Stage 2; define its relationship to the AI4RA upstream plus branch, workflow, and release controls",
       "Observability stack (OpenTelemetry, Prometheus, Jaeger, Splunk) and pre-deploy artifact set",
     ],
   },
@@ -226,6 +266,7 @@ export const PATHWAY_PROJECTS: PathwayProject[] = [
       "Data classification under APM 30.11 — editorial submissions are institutional content; classification review will confirm the tier",
       "Authentication path to university SSO (Entra ID)",
       "AI API posture — MindRouter is on-prem and named in the framework's stack table; the approved-models list is still TBD",
+      "Repository and CI/CD handoff — establish the OIT deployment repository in ui-AI4UI by the Stage 2 pre-review handoff; define branch, workflow, and release controls",
       "Named individual owner for the Stage 5 go-live requirement (runbook and decommission path on file)",
     ],
   },


### PR DESCRIPTION
## Summary

- add repository placement in the new [ui-AI4UI](https://github.com/ui-AI4UI) organization as a formal Stage 2 OIT-pathway milestone
- define when the milestone applies, what evidence completes it, and what it does not authorize
- surface the milestone directly within the six-stage pathway and the submit-a-project documentation
- update OpenERA and UCM pathway questions to use ui-AI4UI as the OIT deployment-repository destination

## Why

Applications destined for OIT-managed infrastructure now have a shared GitHub organization, but the existing pathway did not say when or how repository placement occurs. Making this a named milestone gives builders and OIT a concrete handoff artifact without overstating the maturity of the surrounding process.

## Impact

For new OIT-bound applications, the deployment repository should begin in ui-AI4UI. Existing applications must establish or transfer the deployment repository no later than the Stage 2 pre-review handoff. Completion requires the repository, builder/OIT access, and repository links in inventory and handoff records.

Repository placement records deployment intent and shared custody; it does not replace security review, support acceptance, staging approval, or production authorization.

The pathway also preserves the unresolved decisions:

- authoritative repository versus deployment mirror when an upstream exists
- organization administration, membership, CODEOWNERS, and branch protections
- GitHub Actions versus Azure Pipelines
- transfer responsibility and preservation of issues, history, secrets, and links

## Validation

- `npm run lint`
- `npm run build`

The untracked governance source materials were not modified or included.
