### PR TITLE
Add ROI-focused project exploration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,10 +123,7 @@ export default async function Home() {
 
       {/* BUILD + EVALUATE — secondary lanes, side-by-side at desktop */}
       <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <Link
-          href="/builder-guide"
-          className="group block rounded-xl border border-hairline bg-white p-6 transition-shadow hover:shadow-md"
-        >
+        <div className="rounded-xl border border-hairline bg-white p-6">
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
             Build
           </p>
@@ -138,10 +135,15 @@ export default async function Home() {
             a 2-business-day SLA. We tell you whether it&rsquo;s a candidate,
             what&rsquo;s already adjacent, and what comes next.
           </p>
-          <p className="mt-4 inline-flex items-center text-sm font-semibold text-brand-clearwater group-hover:underline">
-            Submit a project &rarr;
-          </p>
-        </Link>
+          <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm font-semibold">
+            <Link href="/builder-guide" className="text-brand-clearwater">
+              Submit a project &rarr;
+            </Link>
+            <Link href="/portfolio/pipeline" className="text-brand-black">
+              Browse requested projects &rarr;
+            </Link>
+          </div>
+        </div>
 
         <div className="rounded-xl border border-hairline bg-white p-6">
           <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">

--- a/app/portfolio/layout.tsx
+++ b/app/portfolio/layout.tsx
@@ -1,0 +1,16 @@
+import ProjectsSubNav from "@/components/ProjectsSubNav";
+
+export default function PortfolioLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-10 border-b border-hairline">
+        <ProjectsSubNav />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -7,7 +7,18 @@ import {
   groupByHomeUnit,
   type ApplicationWithBlockers,
 } from "@/lib/work";
-import { getCardStatusLines, countPendingRequests } from "@/lib/clickup-data";
+import {
+  getCardStatusLines,
+  countPendingRequests,
+  getRoiBySlug,
+} from "@/lib/clickup-data";
+import {
+  PROJECT_VALUE_LENSES,
+  evidenceForLens,
+  isProjectValueLens,
+  projectValueEvidence,
+  type ProjectValueLens,
+} from "@/lib/project-value";
 import {
   WORK_CATEGORIES,
   WORK_CATEGORY_LABELS,
@@ -32,6 +43,7 @@ interface PortfolioSearchParams {
   stage?: string;
   status?: string;
   category?: string;
+  value?: string;
   blockers?: string;
   sort?: string;
 }
@@ -92,14 +104,43 @@ export default async function PortfolioPage({
   )
     ? (params.category!.trim() as WorkCategory)
     : null;
+  const selectedValue: ProjectValueLens | null = isProjectValueLens(
+    params.value?.trim()
+  )
+    ? (params.value!.trim() as ProjectValueLens)
+    : null;
   const blockersOnly = params.blockers === "1";
   const sortMode: SortMode = isSortMode(params.sort) ? params.sort : "default";
 
-  const [allApps, latestUpdates, pendingRequestCount] = await Promise.all([
+  const [allApps, latestUpdates, pendingRequestCount, roiBySlug] = await Promise.all([
     listApplications({ audience: "public" }),
     getCardStatusLines(),
     countPendingRequests(),
+    getRoiBySlug(),
   ]);
+
+  const valueEvidenceBySlug = new Map(
+    allApps.map((app) => [
+      app.slug,
+      projectValueEvidence(app, roiBySlug.get(app.slug) ?? null),
+    ])
+  );
+  const valueCounts = new Map<ProjectValueLens, number>();
+  for (const evidence of valueEvidenceBySlug.values()) {
+    for (const item of evidence) {
+      valueCounts.set(item.lens, (valueCounts.get(item.lens) ?? 0) + 1);
+    }
+  }
+  const annualSoftwareCostPotential = allApps.reduce((sum, app) => {
+    const replacement = app.enterpriseSystemReplacement;
+    return replacement.status === "yes"
+      ? sum + replacement.annualCostUsd
+      : sum;
+  }, 0);
+  const staffCapacityPotential = allApps.reduce((sum, app) => {
+    const roiFte = roiBySlug.get(app.slug)?.roiFte;
+    return sum + (roiFte && roiFte > 0 ? roiFte : 0);
+  }, 0);
 
   // Build filter option lists from the unfiltered set so users see what's
   // available to filter by even after they've applied something.
@@ -154,6 +195,11 @@ export default async function PortfolioPage({
       if (!rollup.includes(app.status)) return false;
     }
     if (selectedCategory && !app.workCategories.includes(selectedCategory))
+      return false;
+    if (
+      selectedValue &&
+      !evidenceForLens(valueEvidenceBySlug.get(app.slug) ?? [], selectedValue)
+    )
       return false;
     if (blockersOnly && app.activeBlockers.length === 0) return false;
     return true;
@@ -266,16 +312,133 @@ export default async function PortfolioPage({
           )}
         </p>
 
-        {/* CTA — gold-bordered, the only Pride Gold moment in the header */}
-        <div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
           <Link
             href="/builder-guide"
             className="unstyled inline-flex items-center gap-1.5 rounded-md border-2 border-ui-gold bg-ui-gold/10 px-3.5 py-1.5 text-sm font-semibold text-brand-black transition-colors hover:bg-ui-gold/25"
           >
             Submit a new AI project &rarr;
           </Link>
+          <Link
+            href="/portfolio/pipeline"
+            className="text-sm font-semibold text-brand-black"
+          >
+            Browse requested projects &rarr;
+          </Link>
         </div>
       </header>
+
+      <section aria-labelledby="browse-by-value-heading">
+        <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-2">
+          <div>
+            <p
+              id="browse-by-value-heading"
+              className="text-xs font-medium uppercase tracking-wider text-brand-silver"
+            >
+              Browse by return
+            </p>
+            <p className="mt-1 max-w-3xl text-sm text-ink-muted">
+              Compare direct financial potential with capacity, strategic,
+              reach, and reuse signals. These are estimates and declared
+              outcomes, not realized net savings.
+            </p>
+          </div>
+          {(annualSoftwareCostPotential > 0 || staffCapacityPotential > 0) && (
+            <p className="text-xs text-ink-muted">
+              {annualSoftwareCostPotential > 0 && (
+                <>
+                  <span className="font-bold tabular-nums text-brand-black">
+                    {new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: "USD",
+                      maximumFractionDigits: 0,
+                    }).format(annualSoftwareCostPotential)}
+                    /year
+                  </span>{" "}
+                  in software cost potentially displaced
+                </>
+              )}
+              {annualSoftwareCostPotential > 0 && staffCapacityPotential > 0 && (
+                <span className="mx-2 text-brand-silver">·</span>
+              )}
+              {staffCapacityPotential > 0 && (
+                <>
+                  <span className="font-bold tabular-nums text-brand-black">
+                    {new Intl.NumberFormat("en-US", {
+                      maximumFractionDigits: 2,
+                    }).format(staffCapacityPotential)}{" "}
+                    FTE
+                  </span>{" "}
+                  estimated capacity
+                </>
+              )}
+            </p>
+          )}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {(() => {
+            const valueHref = (value: ProjectValueLens | null) => {
+              const sp = new URLSearchParams();
+              if (selectedUnit) sp.set("unit", selectedUnit);
+              if (selectedStage) sp.set("stage", selectedStage);
+              if (selectedStatus) sp.set("status", selectedStatus);
+              if (selectedCategory) sp.set("category", selectedCategory);
+              if (value) sp.set("value", value);
+              if (blockersOnly) sp.set("blockers", "1");
+              if (sortMode !== "default") sp.set("sort", sortMode);
+              const qs = sp.toString();
+              return qs ? `/portfolio?${qs}` : "/portfolio";
+            };
+            return (
+              <>
+                <Link
+                  href={valueHref(null)}
+                  aria-current={!selectedValue ? "page" : undefined}
+                  className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                    !selectedValue
+                      ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                      : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                  }`}
+                >
+                  All return types
+                  <span className="rounded-full bg-surface-alt px-1.5 py-0 text-[10px] font-semibold text-ink-subtle">
+                    {allApps.length}
+                  </span>
+                </Link>
+                {PROJECT_VALUE_LENSES.map((lens) => {
+                  const count = valueCounts.get(lens.value) ?? 0;
+                  if (count === 0) return null;
+                  const active = selectedValue === lens.value;
+                  return (
+                    <Link
+                      key={lens.value}
+                      href={valueHref(lens.value)}
+                      aria-current={active ? "page" : undefined}
+                      title={lens.description}
+                      className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                        active
+                          ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                          : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                      }`}
+                    >
+                      {lens.label}
+                      <span
+                        className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${
+                          active
+                            ? "bg-brand-black/10 text-brand-black"
+                            : "bg-surface-alt text-ink-subtle"
+                        }`}
+                      >
+                        {count}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </>
+            );
+          })()}
+        </div>
+      </section>
 
       {/* Browse-by-problem entry strip — categories are also reachable
           via filter chips inside PortfolioFilters in spirit, but cold
@@ -303,6 +466,7 @@ export default async function PortfolioPage({
               if (selectedStage) sp.set("stage", selectedStage);
               if (selectedStatus) sp.set("status", selectedStatus);
               if (cat) sp.set("category", cat);
+              if (selectedValue) sp.set("value", selectedValue);
               if (blockersOnly) sp.set("blockers", "1");
               if (sortMode !== "default") sp.set("sort", sortMode);
               const qs = sp.toString();
@@ -368,6 +532,7 @@ export default async function PortfolioPage({
           stage: selectedStage,
           status: selectedStatus,
           category: selectedCategory,
+          value: selectedValue,
           blockers: blockersOnly,
           sort: sortMode,
         }}
@@ -398,6 +563,7 @@ export default async function PortfolioPage({
               app={app}
               audience="public"
               latestUpdate={latestUpdates.get(app.slug) ?? null}
+              roi={roiBySlug.get(app.slug) ?? null}
             />
           ))}
         </div>
@@ -422,6 +588,7 @@ export default async function PortfolioPage({
                   app={app}
                   audience="public"
                   latestUpdate={latestUpdates.get(app.slug) ?? null}
+                  roi={roiBySlug.get(app.slug) ?? null}
                 />
               ))}
             </div>

--- a/app/portfolio/pipeline/page.tsx
+++ b/app/portfolio/pipeline/page.tsx
@@ -11,21 +11,28 @@ import {
   RUBRIC_CRITERIA,
   RUBRIC_FORMULA,
   RUBRIC_GROUPS,
+  REQUEST_VALUE_LENSES,
+  isRequestValueLens,
+  type RequestValueLens,
 } from "@/lib/rubric";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "Project Pipeline · UI AI Portfolio",
+  title: "Requested Projects · UI AI Portfolio",
   description:
-    "How new AI project requests are scored and prioritized — the full rubric, weighted scores, and current review queue.",
+    "Explore requested AI projects by financial impact, strategic value, reach, urgency, and other prioritization evidence.",
 };
+
+interface PipelineSearchParams {
+  value?: string;
+}
 
 function scoreCell(value: number | null): string {
   return value === null ? "–" : String(value);
 }
 
-function PendingTable({ requests }: { requests: ScoredRequest[] }) {
+function DetailedScoreTable({ requests }: { requests: ScoredRequest[] }) {
   const hasComputed = requests.some((r) => r.scoreSource === "computed");
   return (
     <div className="overflow-x-auto rounded-xl border border-hairline bg-white">
@@ -105,6 +112,124 @@ function PendingTable({ requests }: { requests: ScoredRequest[] }) {
   );
 }
 
+function requestDate(value: string | null): string | null {
+  if (!value) return null;
+  return new Date(value).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function scoreForLens(
+  request: ScoredRequest,
+  lens: (typeof REQUEST_VALUE_LENSES)[number]
+): number | null {
+  return request.rubric[lens.rubricKey];
+}
+
+function sortPending(
+  requests: ScoredRequest[],
+  lens: (typeof REQUEST_VALUE_LENSES)[number] | null
+): ScoredRequest[] {
+  return [...requests].sort((a, b) => {
+    if (lens) {
+      const aValue = scoreForLens(a, lens) ?? -1;
+      const bValue = scoreForLens(b, lens) ?? -1;
+      if (aValue !== bValue) return bValue - aValue;
+    }
+    return (b.weightedScore ?? -1) - (a.weightedScore ?? -1);
+  });
+}
+
+function PendingExplorer({
+  requests,
+  selectedLens,
+}: {
+  requests: ScoredRequest[];
+  selectedLens: (typeof REQUEST_VALUE_LENSES)[number] | null;
+}) {
+  return (
+    <ul className="divide-y divide-hairline border-y border-hairline">
+      {requests.map((request) => {
+        const strongestSignals = REQUEST_VALUE_LENSES.map((lens) => ({
+          lens,
+          score: scoreForLens(request, lens),
+        }))
+          .filter(
+            (item): item is {
+              lens: (typeof REQUEST_VALUE_LENSES)[number];
+              score: number;
+            } => item.score !== null
+          )
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 3);
+        const selectedScore = selectedLens
+          ? scoreForLens(request, selectedLens)
+          : null;
+
+        return (
+          <li
+            key={request.taskId}
+            className="grid gap-4 py-5 md:grid-cols-[minmax(0,1fr)_9rem]"
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h3 className="text-base font-bold text-brand-black">
+                  {request.name}
+                </h3>
+                <p className="text-xs text-ink-subtle">
+                  {[request.unit, request.category, requestDate(request.dateCreated)]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </p>
+              </div>
+              {request.description && (
+                <p className="mt-2 max-w-3xl whitespace-pre-line text-sm leading-relaxed text-ink-muted">
+                  {request.description}
+                </p>
+              )}
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {(selectedLens && selectedScore !== null
+                  ? [{ lens: selectedLens, score: selectedScore }]
+                  : strongestSignals
+                ).map(({ lens, score }) => (
+                  <span
+                    key={lens.value}
+                    title={lens.description}
+                    className="rounded-full border border-hairline bg-surface-alt px-2.5 py-0.5 text-xs font-medium text-brand-black"
+                  >
+                    {lens.label}{" "}
+                    <span className="font-bold tabular-nums">{score}/5</span>
+                  </span>
+                ))}
+                {request.feasibility && (
+                  <span className="rounded-full border border-hairline bg-white px-2.5 py-0.5 text-xs text-ink-muted">
+                    Feasibility: {request.feasibility}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="md:text-right">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-brand-silver">
+                Priority score
+              </p>
+              <p className="mt-1 text-2xl font-black tabular-nums text-brand-black">
+                {request.weightedScore === null
+                  ? "Not scored"
+                  : Math.round(request.weightedScore * 10) / 10}
+              </p>
+              {request.weightedScore !== null && (
+                <p className="text-xs text-ink-subtle">out of 100</p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 function CompactRequestList({
   requests,
   slugByName,
@@ -148,7 +273,19 @@ function CompactRequestList({
   );
 }
 
-export default async function PipelinePage() {
+export default async function PipelinePage({
+  searchParams,
+}: {
+  searchParams: Promise<PipelineSearchParams>;
+}) {
+  const params = await searchParams;
+  const selectedValue: RequestValueLens | null = isRequestValueLens(
+    params.value?.trim()
+  )
+    ? (params.value!.trim() as RequestValueLens)
+    : null;
+  const selectedLens =
+    REQUEST_VALUE_LENSES.find((lens) => lens.value === selectedValue) ?? null;
   const [requests, lastSync, apps] = await Promise.all([
     listScoredRequests(),
     getLastSync(),
@@ -159,6 +296,10 @@ export default async function PipelinePage() {
   const promoted = requests.filter((r) => r.status === "active");
   const notPursued = requests.filter((r) => r.status === "rejected");
   const completed = requests.filter((r) => r.status === "complete");
+  const sortedPending = sortPending(pending, selectedLens);
+  const financialPotentialCount = pending.filter(
+    (request) => (request.rubric.a2 ?? 0) >= 3
+  ).length;
 
   // Best-effort link from a promoted request to its portfolio entry: the
   // request name rarely matches the project name exactly, so map through
@@ -178,51 +319,157 @@ export default async function PipelinePage() {
           Projects
         </Link>
         <span className="mx-2">/</span>
-        <span className="text-ui-charcoal">Pipeline</span>
+        <span className="text-ui-charcoal">Requested projects</span>
       </nav>
 
       <header>
         <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-          Projects · Pipeline
+          Projects
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-brand-black">
-          How new project requests are prioritized
+          Requested projects awaiting a start decision
         </h1>
         <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
           Every AI project request submitted to IIDS is scored by Colin
-          Addington on an 11-criterion rubric — strategic impact (A1–A4),
-          feasibility and effort (B1–B4), and urgency and buy-in (C1–C3) —
-          and prioritized by weighted score. This is the live review queue,
+          Addington on an 11-criterion rubric: strategic impact (A1–A4),
+          feasibility and effort (B1–B4), and urgency and buy-in (C1–C3),
+          then prioritized by weighted score. This is the live review queue,
           synced from the IIDS-AI4UI workspace.
         </p>
+        {requests.length > 0 && (
+          <p className="mt-5 flex flex-wrap items-baseline gap-x-2 text-sm text-ink-muted">
+            <span>
+              <span className="font-bold tabular-nums text-brand-black">
+                {pending.length}
+              </span>{" "}
+              in review
+            </span>
+            <span aria-hidden className="text-brand-silver">
+              ·
+            </span>
+            <span>
+              <span className="font-bold tabular-nums text-brand-black">
+                {financialPotentialCount}
+              </span>{" "}
+              with moderate or higher financial impact
+            </span>
+            {promoted.length > 0 && (
+              <>
+                <span aria-hidden className="text-brand-silver">
+                  ·
+                </span>
+                <span>
+                  <span className="font-bold tabular-nums text-brand-black">
+                    {promoted.length}
+                  </span>{" "}
+                  promoted to active work
+                </span>
+              </>
+            )}
+          </p>
+        )}
       </header>
 
       {requests.length === 0 ? (
         <div className="rounded-xl border border-hairline bg-surface-alt p-8 text-center">
           <p className="text-sm font-medium text-ink-muted">
-            No synced request data yet. The queue appears here after the
-            first ClickUp sync runs.
+            No requested-project data has been synced yet. This view remains
+            the permanent home for intake requests before work starts.
           </p>
         </div>
       ) : (
         <>
           <section className="space-y-3">
-            <div className="flex items-baseline gap-3">
-              <h2 className="text-xl font-black tracking-tight text-brand-black">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+                Explore by value
+              </p>
+              <h2 className="mt-1 text-xl font-black tracking-tight text-brand-black">
                 In review
               </h2>
-              <span className="text-sm text-ink-subtle">
-                {pending.length}{" "}
-                {pending.length === 1 ? "request" : "requests"}, highest
-                score first
-              </span>
+              <p className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                Start with overall priority, or rank the queue by a particular
+                kind of return. Financial impact includes potential savings,
+                revenue, and grant value; it is broader than software
+                replacement alone.
+              </p>
             </div>
-            <PendingTable requests={pending} />
-            <p className="text-xs text-ink-subtle">
-              Weighted score = {RUBRIC_FORMULA}, on a 0–100 scale. Criteria
-              are scored 1–5 — full definitions below. Hover a column header
-              for the criterion name.
-            </p>
+            <div className="flex flex-wrap gap-1.5 pb-2">
+              <Link
+                href="/portfolio/pipeline"
+                aria-current={!selectedLens ? "page" : undefined}
+                className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  !selectedLens
+                    ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                    : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                }`}
+              >
+                Overall priority
+                <span className="rounded-full bg-surface-alt px-1.5 py-0 text-[10px] font-semibold text-ink-subtle">
+                  {pending.length}
+                </span>
+              </Link>
+              {REQUEST_VALUE_LENSES.map((lens) => {
+                const count = pending.filter(
+                  (request) => scoreForLens(request, lens) !== null
+                ).length;
+                const active = selectedLens?.value === lens.value;
+                return (
+                  <Link
+                    key={lens.value}
+                    href={`/portfolio/pipeline?value=${lens.value}`}
+                    aria-current={active ? "page" : undefined}
+                    title={lens.description}
+                    className={`unstyled inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                      active
+                        ? "border-ui-gold bg-ui-gold/15 text-brand-black"
+                        : "border-hairline bg-white text-ink-muted hover:border-brand-silver/40 hover:bg-surface-alt"
+                    }`}
+                  >
+                    {lens.label}
+                    <span
+                      className={`rounded-full px-1.5 py-0 text-[10px] font-semibold ${
+                        active
+                          ? "bg-brand-black/10 text-brand-black"
+                          : "bg-surface-alt text-ink-subtle"
+                      }`}
+                    >
+                      {count}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+            {pending.length > 0 ? (
+              <>
+                <p className="text-xs font-medium text-ink-subtle">
+                  {selectedLens
+                    ? `Sorted by ${selectedLens.label.toLowerCase()}, then overall priority.`
+                    : "Sorted by overall priority score."}
+                </p>
+                <PendingExplorer
+                  requests={sortedPending}
+                  selectedLens={selectedLens}
+                />
+                <details className="group pt-2">
+                  <summary className="cursor-pointer text-sm font-semibold text-brand-black">
+                    Show the complete 11-criterion score table
+                  </summary>
+                  <div className="mt-4">
+                    <DetailedScoreTable requests={sortedPending} />
+                  </div>
+                </details>
+                <p className="text-xs text-ink-subtle">
+                  Weighted score = {RUBRIC_FORMULA}, on a 0–100 scale.
+                  Individual criteria use a 1–5 scale; full definitions are
+                  below.
+                </p>
+              </>
+            ) : (
+              <p className="border-y border-hairline py-6 text-sm text-ink-muted">
+                No requests are currently awaiting review.
+              </p>
+            )}
           </section>
 
           <section className="space-y-4">

--- a/components/PortfolioCard.tsx
+++ b/components/PortfolioCard.tsx
@@ -3,6 +3,8 @@ import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
 import { WORK_CATEGORY_LABELS } from "@/lib/work-categories";
 import { getPriority } from "@/lib/strategic-plan/catalog";
+import type { ClickUpRoi } from "@/lib/clickup-data";
+import { projectValueEvidence } from "@/lib/project-value";
 import {
   OPERATIONAL_LABEL,
   OPERATIONAL_TITLE,
@@ -54,6 +56,7 @@ export default function PortfolioCard({
   audience = "public",
   basePath = "/portfolio",
   latestUpdate,
+  roi,
 }: {
   app: ApplicationWithBlockers;
   audience?: "public" | "internal";
@@ -61,6 +64,9 @@ export default function PortfolioCard({
   // Most recent ClickUp status update (ADR 0004); omitted for projects
   // without a mapped ClickUp list.
   latestUpdate?: { postedAt: string; body: string } | null;
+  // Quantified return estimate from the ClickUp projection. Enterprise
+  // replacement economics live on `app` itself.
+  roi?: ClickUpRoi | null;
 }) {
   const owners = app.operationalOwners
     .map((o) => o.name)
@@ -90,6 +96,9 @@ export default function PortfolioCard({
     app.ai4raRelationship === "Adjacent" ||
     app.ai4raRelationship === "Reference";
   const isCapabilityDiffusion = app.tags.includes("diffusion");
+  const quantifiedReturns = projectValueEvidence(app, roi ?? null).filter(
+    (item) => item.lens === "direct-cost" || item.lens === "staff-capacity"
+  );
 
   return (
     <article className="group relative flex h-full flex-col rounded-xl border border-hairline bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
@@ -132,6 +141,28 @@ export default function PortfolioCard({
         <p className="mt-3 text-sm leading-relaxed text-ink-muted">
           {app.tagline}
         </p>
+      )}
+
+      {quantifiedReturns.length > 0 && (
+        <div className="mt-4 border-y border-hairline py-3">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-brand-silver">
+            Potential return
+          </p>
+          <dl className="mt-1.5 space-y-1.5">
+            {quantifiedReturns.map((item) => (
+              <div key={item.lens} className="flex items-baseline gap-2 text-xs">
+                <dt className="font-bold tabular-nums text-brand-black">
+                  {item.summary}
+                </dt>
+                <dd className="text-ink-muted">
+                  {item.lens === "direct-cost"
+                    ? "annual software cost potentially displaced"
+                    : "estimated staff capacity returned"}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
       )}
 
       {latestUpdate && (

--- a/components/PortfolioFilters.tsx
+++ b/components/PortfolioFilters.tsx
@@ -11,6 +11,7 @@ import {
   type ProjectStatus,
   type PublicStage,
 } from "@/lib/portfolio";
+import type { ProjectValueLens } from "@/lib/project-value";
 
 // Pure URL-state filter chip group. The portfolio page builds the option
 // lists from the unfiltered data and passes them in; clicking a pill
@@ -57,6 +58,9 @@ export interface PortfolioFiltersProps {
     // (per #260). Kept in the prop so this component can preserve it in
     // hrefs for the other filter chips.
     category: string | null;
+    // Selected in the page-level return lens strip. Preserved here when
+    // changing stage, unit, blocker, or sort controls.
+    value: ProjectValueLens | null;
     blockers: boolean;
     sort: "default" | "name" | "blockers";
   };
@@ -163,6 +167,7 @@ export default function PortfolioFilters({
     !!selected.stage ||
     !!selected.status ||
     !!selected.category ||
+    !!selected.value ||
     selected.blockers ||
     selected.sort !== "default";
 
@@ -172,6 +177,7 @@ export default function PortfolioFilters({
     stage: selected.stage,
     status: selected.status,
     category: selected.category,
+    value: selected.value,
     blockers: selected.blockers ? "1" : null,
     sort: selected.sort === "default" ? null : selected.sort,
   };

--- a/components/ProjectsSubNav.tsx
+++ b/components/ProjectsSubNav.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const projectSections = [
+  { href: "/portfolio", label: "Active projects" },
+  { href: "/portfolio/pipeline", label: "Requested projects" },
+] as const;
+
+function activeHrefFor(pathname: string): string {
+  return pathname === "/portfolio/pipeline" ||
+    pathname.startsWith("/portfolio/pipeline/")
+    ? "/portfolio/pipeline"
+    : "/portfolio";
+}
+
+export default function ProjectsSubNav() {
+  const pathname = usePathname();
+  const activeHref = activeHrefFor(pathname);
+
+  return (
+    <nav
+      aria-label="Project sections"
+      className="-mb-px flex gap-8 overflow-x-auto"
+    >
+      {projectSections.map((item) => {
+        const active = item.href === activeHref;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? "page" : undefined}
+            className={`unstyled whitespace-nowrap border-b-2 pb-3 text-sm font-semibold tracking-tight transition-colors ${
+              active
+                ? "border-brand-clearwater text-ui-charcoal"
+                : "border-transparent text-gray-600 hover:text-ui-charcoal"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/lib/project-value.ts
+++ b/lib/project-value.ts
@@ -1,0 +1,142 @@
+import type { ClickUpRoi } from "./clickup-data";
+import type { Project } from "./portfolio";
+
+export const PROJECT_VALUE_LENSES = [
+  {
+    value: "direct-cost",
+    label: "Direct cost",
+    description: "Existing annual software spend this work could displace.",
+  },
+  {
+    value: "staff-capacity",
+    label: "Staff capacity",
+    description: "Estimated staff time returned for higher-value work.",
+  },
+  {
+    value: "strategic-alignment",
+    label: "Strategic alignment",
+    description: "University strategic-plan priorities advanced.",
+  },
+  {
+    value: "institutional-reach",
+    label: "Institutional reach",
+    description: "Work spanning units or intended for institution-wide use.",
+  },
+  {
+    value: "reuse",
+    label: "Reuse beyond UI",
+    description: "Open or partner-ready work designed for use beyond UI.",
+  },
+] as const;
+
+export type ProjectValueLens =
+  (typeof PROJECT_VALUE_LENSES)[number]["value"];
+
+export interface ProjectValueEvidence {
+  lens: ProjectValueLens;
+  summary: string;
+  detail: string;
+  sortValue: number;
+}
+
+const usd = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+const decimal = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
+export function isProjectValueLens(
+  value: string | undefined
+): value is ProjectValueLens {
+  return PROJECT_VALUE_LENSES.some((lens) => lens.value === value);
+}
+
+export function projectValueEvidence(
+  project: Project,
+  roi: ClickUpRoi | null = null
+): ProjectValueEvidence[] {
+  const evidence: ProjectValueEvidence[] = [];
+  const replacement = project.enterpriseSystemReplacement;
+
+  if (replacement.status === "yes") {
+    evidence.push({
+      lens: "direct-cost",
+      summary: `${usd.format(replacement.annualCostUsd)}/year`,
+      detail: `Potential annual software cost displaced by replacing ${replacement.systemName}.`,
+      sortValue: replacement.annualCostUsd,
+    });
+  }
+
+  if (roi?.roiFte != null && roi.roiFte > 0) {
+    evidence.push({
+      lens: "staff-capacity",
+      summary: `${decimal.format(roi.roiFte)} FTE`,
+      detail:
+        roi.roiExplanation ??
+        "Estimated staff capacity returned for higher-value work.",
+      sortValue: roi.roiFte,
+    });
+  }
+
+  if ((project.strategicPlanAlignment?.length ?? 0) > 0) {
+    const count = project.strategicPlanAlignment!.length;
+    evidence.push({
+      lens: "strategic-alignment",
+      summary: `${count} strategic priorit${count === 1 ? "y" : "ies"}`,
+      detail: "Declared alignment with the University of Idaho strategic plan.",
+      sortValue: count,
+    });
+  }
+
+  const hasInstitutionalReach =
+    project.productionScope === "institution-wide" ||
+    project.homeUnits.length > 1;
+  if (hasInstitutionalReach) {
+    const unitCount = project.homeUnits.length;
+    evidence.push({
+      lens: "institutional-reach",
+      summary:
+        project.productionScope === "institution-wide"
+          ? "Institution-wide"
+          : `${unitCount} home units`,
+      detail:
+        project.productionScope === "institution-wide"
+          ? "Recorded for institution-wide production use."
+          : "Shared ownership or use across more than one UI unit.",
+      sortValue:
+        project.productionScope === "institution-wide" ? 100 : unitCount,
+    });
+  }
+
+  const reuseCount =
+    (project.externalDeployments?.length ?? 0) +
+    (project.dualDestinyPlanned ? 1 : 0);
+  if (reuseCount > 0) {
+    evidence.push({
+      lens: "reuse",
+      summary:
+        (project.externalDeployments?.length ?? 0) > 0
+          ? `${project.externalDeployments!.length} external deployment${
+              project.externalDeployments!.length === 1 ? "" : "s"
+            }`
+          : "Partner-ready",
+      detail: project.dualDestinyPlanned
+        ? "Designed for both UI use and open-source adoption."
+        : "Already deployed outside the University of Idaho.",
+      sortValue: reuseCount,
+    });
+  }
+
+  return evidence;
+}
+
+export function evidenceForLens(
+  evidence: readonly ProjectValueEvidence[],
+  lens: ProjectValueLens
+): ProjectValueEvidence | null {
+  return evidence.find((item) => item.lens === lens) ?? null;
+}

--- a/lib/rubric.ts
+++ b/lib/rubric.ts
@@ -38,6 +38,54 @@ export interface RubricGroup {
   description: string;
 }
 
+export const REQUEST_VALUE_LENSES = [
+  {
+    value: "financial",
+    label: "Financial impact",
+    rubricKey: "a2",
+    description: "Potential annual savings, revenue, or grant value.",
+  },
+  {
+    value: "strategic",
+    label: "Strategic alignment",
+    rubricKey: "a1",
+    description: "Direct support for a university strategic priority.",
+  },
+  {
+    value: "reach",
+    label: "Breadth of impact",
+    rubricKey: "a3",
+    description: "How many users, departments, or divisions benefit.",
+  },
+  {
+    value: "visibility",
+    label: "Reputation",
+    rubricKey: "a4",
+    description: "Institutional visibility and leadership potential.",
+  },
+  {
+    value: "time-returned",
+    label: "Time returned",
+    rubricKey: "c2",
+    description: "How much work the project could remove for each user.",
+  },
+  {
+    value: "urgency",
+    label: "Risk and urgency",
+    rubricKey: "c1",
+    description: "Severity of the compliance, security, or operational need.",
+  },
+] as const;
+
+export type RequestValueLens =
+  (typeof REQUEST_VALUE_LENSES)[number]["value"];
+
+export function isRequestValueLens(
+  value: string | undefined
+): value is RequestValueLens {
+  return REQUEST_VALUE_LENSES.some((lens) => lens.value === value);
+}
+
 export const RUBRIC_GROUPS: readonly RubricGroup[] = [
   {
     code: "A",


### PR DESCRIPTION
## Summary

- add persistent **Active projects** and **Requested projects** navigation under Projects, plus entry points from the home and active-project pages
- add active-project value lenses for direct cost, staff capacity, strategic alignment, institutional reach, and reuse beyond UI
- surface quantified software-cost displacement and FTE-return estimates on project cards
- redesign the requested-project queue around financial and nonfinancial value lenses while retaining the complete 11-criterion score table
- show request descriptions, strongest value signals, overall priority, and sync-aware empty states

## Why

Requested projects with intake data were only reachable through a conditional count on the active-project page. Existing enterprise-system replacement economics and ClickUp ROI estimates were visible on detail or specialist surfaces but could not be used to explore the portfolio.

This change gives stakeholders a durable path to work that has not started and lets them compare direct financial potential with staff capacity, strategic value, reach, reputation, urgency, and reuse.

## Data and behavior

- active-project direct cost uses the structured enterprise-system replacement fields in `applications`
- staff-capacity evidence uses ClickUp-synced FTE estimates
- requested-project lenses use the published ClickUp prioritization rubric
- financial figures are labeled as potential cost displaced, not realized net savings
- URL-backed filters compose with the existing stage, unit, category, blocker, and sort controls

## Validation

- `npm run verify:portfolio`: 26 projects, 0 errors, 3 existing commit-date warnings
- `npm run build`
- `npm run lint`
- desktop and 390px mobile visual QA
- active return-filter behavior verified against the local database
- no browser console errors
