### PR TITLE
Refresh confirmed project portfolio statuses

### DIFF
--- a/db/migrations/014_refresh_project_statuses.sql
+++ b/db/migrations/014_refresh_project_statuses.sql
@@ -1,0 +1,49 @@
+-- Migration 014: Refresh confirmed portfolio statuses and descriptions
+--
+-- Records the July 2026 owner-confirmed project review:
+-- - Invoice Processing resumed Accounts Payable user testing and remains building.
+-- - Out-of-State Tax Tracking is paused pending Core4 dashboard capacity.
+-- - TEMPLATE-app is archived; its OIT-review blocker is no longer active.
+
+BEGIN;
+
+UPDATE applications
+SET description =
+  'Automates the front of the AP invoice pipeline: emailed invoices are captured, invoices without a PO number are auto-rejected back to the submitter, and the rest have key fields extracted (PO number, dates, invoice number, amount, remit-to address) and compared against PO data in Banner. AP staff work a review queue in a dashboard — correcting low-confidence extractions, requesting fixes from submitters, and marking invoices processed. User testing with Accounts Payable resumed in July 2026.',
+    status = 'building'
+WHERE slug = 'invoice-processing';
+
+-- Owner-confirmed correction to the cached public summary. Preserve the
+-- ClickUp source fingerprint so a genuinely newer ClickUp comment replaces
+-- this summary on the next sync.
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 2026, Invoice Processing has resumed user testing with Accounts Payable. The project remains in active development while the team validates the invoice-ingestion and review workflow.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962364';
+
+UPDATE applications
+SET description =
+  'Tracks state tax withholdings for UI employees working outside Idaho — including international W-4 cases routed through Payroll — and gets them remitted to the right state authorities. Automates the data transfer across systems that Payroll previously reconciled by hand. The project is paused until the Core4 dashboard is ready to accept additional modules.',
+    status = 'paused'
+WHERE slug = 'out-of-state-tax-tracking';
+
+UPDATE applications
+SET tagline = 'Archived reference scaffold for earlier UI business applications.',
+    description =
+      'Archived scaffold that established an opinionated starting point for University business applications built with agentic AI development. It combined UI''s technology stack, documentation standards, data-governance classification, security controls (JWT, RBAC, dependency scanning), CI/CD, and agent guidance. The record is retained as a reference for applications that adopted its patterns.',
+    status = 'archived',
+    institutional_review_status = NULL,
+    production_scope = NULL,
+    support_contact = NULL
+WHERE slug = 'template-app';
+
+UPDATE blockers
+SET resolved_at = CURRENT_DATE
+WHERE application_id = (
+  SELECT id FROM applications WHERE slug = 'template-app'
+)
+  AND category = 'oit-review'
+  AND resolved_at IS NULL;
+
+COMMIT;

--- a/db/migrations/015_apply_july_22_status_review.sql
+++ b/db/migrations/015_apply_july_22_status_review.sql
@@ -1,0 +1,93 @@
+-- Migration 015: Apply the July 22, 2026 project-status meeting review
+--
+-- Source: owner-provided meeting transcript. This migration records only
+-- explicit project facts and the OSP-module mapping documented in the
+-- canonical portfolio. It does not infer new lifecycle stages.
+
+BEGIN;
+
+UPDATE applications
+SET description =
+  'Replaces the paper/email retroactive payment request process with a validated electronic submission flow plus a dashboard for payroll analysts. Submissions are checked for completeness and verified against Banner data before they reach an analyst, so corrections happen at intake instead of mid-process. As of July 2026, several pull requests are ready for testing and temporary reactivation of the test environment has been requested.'
+WHERE slug = 'retroactive-payment-requests';
+
+UPDATE applications
+SET description =
+  'Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures. As of July 2026, the team has outlined the VERAS-replacement MVP and the required dual-operation period, with three to four developers contributing. The renamed OSP module is in development, with its sub-module access structure awaiting Microsoft Entra group creation; transfer of the repository to the new UI AI for UI GitHub organization is also pending.'
+WHERE slug = 'openera';
+
+UPDATE applications
+SET description =
+  'React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT''s Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT); OpenERA and UCM Daily Register are the first IIDS-built applications entering that pathway. Nexus continues to receive regular updates; recurring security-review tickets and approval steps on pull requests are the main reported delivery friction.'
+WHERE slug = 'nexus';
+
+-- Public status summaries derived from the meeting. For rows with an existing
+-- ClickUp fingerprint, keep it unchanged so a newer ClickUp comment naturally
+-- supersedes the meeting summary on the next sync.
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 22, 2026, Retroactive Payment Requests remains in active development. Several pull requests are ready for testing, and temporary reactivation of the test environment has been requested so validation can proceed.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962307';
+
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 22, 2026, the VERAS replacement team has outlined the MVP and the required dual-operation period with VERAS. Three to four developers are contributing, issues are logged, and transfer of the repository to the new UI AI for UI GitHub organization remains pending. The renamed OSP module is waiting on an access-group dependency before sub-module work can proceed.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962269';
+
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 22, 2026, Nexus continues to receive regular updates. Recurring security-review tickets and approval steps on pull requests are the main reported delivery friction, and the team is reviewing whether that process can be made more efficient.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962298';
+
+INSERT INTO blockers (
+  application_id, category, named_party, since,
+  public_text, internal_text, severity
+)
+SELECT
+  a.id,
+  'oit-standards',
+  'OIT',
+  DATE '2026-07-22',
+  'OSP sub-module access controls are awaiting Microsoft Entra group creation.',
+  'Nathan Layman reported that the renamed OSP module cannot implement its sub-module structure until the requested Entra group is created. Blair had reached out to Dan; status was still pending at the July 22 meeting.',
+  'medium'
+FROM applications a
+WHERE a.slug = 'openera'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM blockers b
+    WHERE b.application_id = a.id
+      AND b.category = 'oit-standards'
+      AND b.resolved_at IS NULL
+      AND b.public_text =
+        'OSP sub-module access controls are awaiting Microsoft Entra group creation.'
+  );
+
+INSERT INTO blockers (
+  application_id, category, named_party, since,
+  public_text, internal_text, severity
+)
+SELECT
+  a.id,
+  'compliance',
+  'OIT Security (SEC)',
+  DATE '2026-07-22',
+  'Release pull requests trigger recurring security-review tickets and approval steps.',
+  'Colin Addington reported that Nexus PRs repeatedly open SEC-team vulnerability tickets and require Nathan''s approval before release. Work continues, but the repeated approval path is creating delivery friction.',
+  'low'
+FROM applications a
+WHERE a.slug = 'nexus'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM blockers b
+    WHERE b.application_id = a.id
+      AND b.category = 'compliance'
+      AND b.resolved_at IS NULL
+      AND b.public_text =
+        'Release pull requests trigger recurring security-review tickets and approval steps.'
+  );
+
+COMMIT;

--- a/db/migrations/016_update_ucm_and_water_law_statuses.sql
+++ b/db/migrations/016_update_ucm_and_water_law_statuses.sql
@@ -1,0 +1,41 @@
+-- Migration 016: Update UCM Daily Register and Water Law project status
+--
+-- Owner-confirmed July 2026 review:
+-- - UCM Daily Register is in advanced user testing and ready for repository
+--   migration to ui-AI4UI.
+-- - Water Law Database is scheduling stakeholder feedback sessions.
+
+BEGIN;
+
+UPDATE applications
+SET description =
+      'Editorial pipeline for The Daily Register and My UI. Submission intake, AI-assisted style editing (Claude or OpenAI via MindRouter, with AP + UI style enforcement), word-level diff review, section-organized auto-assembly, and branded .docx export. The application is in advanced user testing with the UCM newsletter team and is ready for repository migration to ui-AI4UI.',
+    status = 'piloting',
+    pilot_cohort = jsonb_build_object(
+      'size', 3,
+      'scope', 'University Communications and Marketing newsletter team',
+      'namedUsers', jsonb_build_array('Joy Bauer', 'Leigh Cooper', 'Jodi Walker')
+    )
+WHERE slug = 'ucm-daily-register';
+
+UPDATE applications
+SET description =
+      'Tiered repository of Idaho water law centered on the Snake River Basin Adjudication (SRBA): judicial decisions, historical records, and key settlements, ingested from the existing system and from paper documents via large-scale OCR on IIDS''s on-prem GPU cluster. A web interface supports natural-language queries and visualizations such as diversion maps, giving legislators, water managers, and rights holders fast, verified answers instead of relitigating past disputes. Stakeholder feedback sessions are being scheduled to validate needs and priorities for the next phase.',
+    status = 'approved'
+WHERE slug = 'water-law-database';
+
+-- Keep the current ClickUp fingerprints so a genuinely newer ClickUp comment
+-- naturally supersedes these owner-confirmed summaries.
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 2026, UCM Daily Register is in advanced user testing with the UCM newsletter team. The application is ready for repository migration to ui-AI4UI; its current repository link remains in place until that move is complete.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962400';
+
+UPDATE clickup_projects
+SET status_summary =
+      'As of July 2026, Water Law Database is scheduling stakeholder feedback sessions to validate needs and priorities for the next phase of work.',
+    status_summary_at = now()
+WHERE clickup_list_id = '901713962384';
+
+COMMIT;

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -348,7 +348,7 @@ export const projects: Project[] = [
     tagline:
       "Electronic retro-pay intake and payroll analyst dashboard.",
     description:
-      "Replaces the paper/email retroactive payment request process with a validated electronic submission flow plus a dashboard for payroll analysts. Submissions are checked for completeness and verified against Banner data before they reach an analyst, so corrections happen at intake instead of mid-process.",
+      "Replaces the paper/email retroactive payment request process with a validated electronic submission flow plus a dashboard for payroll analysts. Submissions are checked for completeness and verified against Banner data before they reach an analyst, so corrections happen at intake instead of mid-process. As of July 2026, several pull requests are ready for testing and temporary reactivation of the test environment has been requested.",
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [
       { name: "Lisa Davis" },
@@ -534,7 +534,7 @@ export const projects: Project[] = [
     tagline:
       "Open electronic research administration system — canonical UDM implementor for sponsored research.",
     description:
-      "Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures.",
+      "Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures. As of July 2026, the team has outlined the VERAS-replacement MVP and the required dual-operation period, with three to four developers contributing. The renamed OSP module is in development, with its sub-module access structure awaiting Microsoft Entra group creation; transfer of the repository to the new UI AI for UI GitHub organization is also pending.",
     homeUnits: ["Office of Research and Economic Development"],
     operationalOwners: [
       { name: "Sarah Martonick", title: "UI implementation owner" },
@@ -940,7 +940,7 @@ export const projects: Project[] = [
     tagline:
       "OIT-managed application platform where UI application modules are deployed.",
     description:
-      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT's Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT); OpenERA and UCM Daily Register are the first IIDS-built applications entering that pathway.",
+      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT's Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT); OpenERA and UCM Daily Register are the first IIDS-built applications entering that pathway. Nexus continues to receive regular updates; recurring security-review tickets and approval steps on pull requests are the main reported delivery friction.",
     homeUnits: ["Office of Information Technology"],
     operationalOwners: [
       { name: "Kali Armitage" },

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -244,7 +244,7 @@ export const projects: Project[] = [
     tagline:
       "AI extraction and validation for Accounts Payable vendor invoices.",
     description:
-      "Automates the front of the AP invoice pipeline: emailed invoices are captured, invoices without a PO number are auto-rejected back to the submitter, and the rest have key fields extracted (PO number, dates, invoice number, amount, remit-to address) and compared against PO data in Banner. AP staff work a review queue in a dashboard — correcting low-confidence extractions, requesting fixes from submitters, and marking invoices processed.",
+      "Automates the front of the AP invoice pipeline: emailed invoices are captured, invoices without a PO number are auto-rejected back to the submitter, and the rest have key fields extracted (PO number, dates, invoice number, amount, remit-to address) and compared against PO data in Banner. AP staff work a review queue in a dashboard — correcting low-confidence extractions, requesting fixes from submitters, and marking invoices processed. User testing with Accounts Payable resumed in July 2026.",
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [
       { name: "Daniele Ramona Bodden", title: "AP team lead" },
@@ -321,14 +321,14 @@ export const projects: Project[] = [
     tagline:
       "Multi-state payroll withholding tracking for out-of-state employees.",
     description:
-      "Tracks state tax withholdings for UI employees working outside Idaho — including international W-4 cases routed through Payroll — and gets them remitted to the right state authorities. Automates the data transfer across systems that Payroll previously reconciled by hand.",
+      "Tracks state tax withholdings for UI employees working outside Idaho — including international W-4 cases routed through Payroll — and gets them remitted to the right state authorities. Automates the data transfer across systems that Payroll previously reconciled by hand. The project is paused until the Core4 dashboard is ready to accept additional modules.",
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [
       { name: "Cretia Bunney" },
       { name: "Lisa Davis" },
     ],
     buildParticipants: ["IIDS"],
-    status: "prototype",
+    status: "paused",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
     enterpriseSystemReplacement: { status: "to-be-determined" },
@@ -880,21 +880,18 @@ export const projects: Project[] = [
     slug: "template-app",
     name: "TEMPLATE-app",
     tagline:
-      "Production-ready scaffold for new UI business applications (under OIT review).",
+      "Archived reference scaffold for earlier UI business applications.",
     description:
-      "Opinionated starting point for building University business applications with agentic AI development. Bakes in UI's tech stack, documentation standards, data governance classification, security standards (JWT, RBAC, dependency scanning), CI/CD, and agent guidance from day one. Available for use by any UI unit; currently under OIT review for institutional-standards endorsement.",
+      "Archived scaffold that established an opinionated starting point for University business applications built with agentic AI development. It combined UI's technology stack, documentation standards, data-governance classification, security controls (JWT, RBAC, dependency scanning), CI/CD, and agent guidance. The record is retained as a reference for applications that adopted its patterns.",
     homeUnits: ["IIDS"],
     operationalOwners: [{ name: "Barrie Robison" }],
     buildParticipants: ["IIDS"],
-    status: "paused",
+    status: "archived",
     visibility: "Public",
     proposedDeploymentEnvironment: "not-applicable",
     enterpriseSystemReplacement: { status: "no" },
-    institutionalReviewStatus: "Under OIT review",
     ai4raRelationship: "Adjacent",
     iidsSponsor: "Luke Sheneman",
-    productionScope: "institution-wide",
-    supportContact: "Barrie Robison",
     repoUrl: "https://github.com/ui-insight/TEMPLATE-app",
     operationalFunction:
       "Standardizes how new UI business apps start. Enforces data governance, security, documentation, CI/CD, and agentic-development norms from day one. Consumed by SEM-experiential, Audit Dashboard, StratPlanTactics.",

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -186,11 +186,11 @@ export const projects: Project[] = [
     tagline:
       "AI-enabled Idaho water law repository — SRBA decisions, records, and settlements.",
     description:
-      "Tiered repository of Idaho water law centered on the Snake River Basin Adjudication (SRBA): judicial decisions, historical records, and key settlements, ingested from the existing system and from paper documents via large-scale OCR on IIDS's on-prem GPU cluster. A web interface supports natural-language queries and visualizations such as diversion maps, giving legislators, water managers, and rights holders fast, verified answers instead of relitigating past disputes.",
+      "Tiered repository of Idaho water law centered on the Snake River Basin Adjudication (SRBA): judicial decisions, historical records, and key settlements, ingested from the existing system and from paper documents via large-scale OCR on IIDS's on-prem GPU cluster. A web interface supports natural-language queries and visualizations such as diversion maps, giving legislators, water managers, and rights holders fast, verified answers instead of relitigating past disputes. Stakeholder feedback sessions are being scheduled to validate needs and priorities for the next phase.",
     homeUnits: ["Office of the President"],
     operationalOwners: [{ name: "Luke Sheneman" }],
     buildParticipants: ["IIDS"],
-    status: "building",
+    status: "approved",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
     enterpriseSystemReplacement: { status: "to-be-determined" },
@@ -432,7 +432,7 @@ export const projects: Project[] = [
     name: "UCM Daily Register",
     tagline: "AI-assisted newsletter production pipeline for UCM.",
     description:
-      "Editorial pipeline for The Daily Register and My UI. Submission intake, AI-assisted style editing (Claude or OpenAI via MindRouter, with AP + UI style enforcement), word-level diff review, section-organized auto-assembly, and branded .docx export.",
+      "Editorial pipeline for The Daily Register and My UI. Submission intake, AI-assisted style editing (Claude or OpenAI via MindRouter, with AP + UI style enforcement), word-level diff review, section-organized auto-assembly, and branded .docx export. The application is in advanced user testing with the UCM newsletter team and is ready for repository migration to ui-AI4UI.",
     homeUnits: ["University Communications and Marketing"],
     operationalOwners: [
       { name: "Joy Bauer" },
@@ -440,13 +440,18 @@ export const projects: Project[] = [
       { name: "Jodi Walker" },
     ],
     buildParticipants: ["IIDS"],
-    status: "prototype",
+    status: "piloting",
     visibility: "Public",
     proposedDeploymentEnvironment: "oit-hosted",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
     liveUrlIsStaging: true,
+    pilotCohort: {
+      size: 3,
+      scope: "University Communications and Marketing newsletter team",
+      namedUsers: ["Joy Bauer", "Leigh Cooper", "Jodi Walker"],
+    },
     repoUrl: "https://github.com/ui-insight/UCMDailyRegister",
     liveUrl: "https://ucmnews.insight.uidaho.edu",
     operationalFunction:


### PR DESCRIPTION
## Summary

- refresh canonical portfolio details and lifecycle states for Invoice Processing, Out-of-State Tax Tracking, Retroactive Payment Requests, UCM Daily Register, Water Law Database, OpenERA, Nexus, and TEMPLATE-app
- add migrations 014–016 to keep application rows, cached ClickUp summaries, pilot data, and current blockers aligned with the confirmed July 2026 project review
- record UCM's advanced user testing and pending `ui-AI4UI` migration without changing its repository URL before the move is complete

## Why

The portfolio's canonical records and database summaries had fallen behind current owner reports and the July 22 project-status meeting. That made several public project pages show stale lifecycle states, activity summaries, or blockers.

## Impact

Project exploration in the portfolio now reflects the latest known delivery stage and context, including resumed testing, paused work, stakeholder discovery, active development, governance friction, and archived reference projects. No production data is changed by this PR.

## Validation

- `npm run verify:portfolio` — 26 projects, 0 errors; 2 pre-existing unknown-commit-date warnings
- `npm run lint`
- `npm run build`
- `git diff --check`
- migrations 014–016 applied to the dev database after restricted backups
- affected public dev portfolio pages verified after migration
