### PR TITLE
Add MindRouter Video Storyboard to portfolio

### DIFF
--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -491,6 +491,38 @@ export const projects: Project[] = [
     workCategories: ["documents", "process"],
     strategicPlanAlignment: ["E.2"],
   },
+  {
+    slug: "mindrouter-video-storyboard",
+    name: "MindRouter Video Storyboard",
+    tagline:
+      "On-prem text- and image-to-video storyboarding for rapid advertising mockups.",
+    description:
+      "Video previsualization workflow requested by University Communications and Marketing to mock up an advertisement before filming. IIDS added a model-agnostic video-generation endpoint to MindRouter, currently backed by the open-weight LTX-Video 2.3 model on a dedicated NVIDIA H200, with integrated voice support and a limited MindRouter interface. A separate web application is now being built with Melissa Hartley to generate clips from text or reference photos, arrange them into a storyboard, and stitch them into an editable video sequence.",
+    homeUnits: ["University Communications and Marketing"],
+    operationalOwners: [{ name: "Melissa Hartley" }],
+    buildParticipants: ["IIDS"],
+    status: "building",
+    visibility: "Public",
+    proposedDeploymentEnvironment: "iids-hosted",
+    enterpriseSystemReplacement: { status: "no" },
+    ai4raRelationship: "None",
+    iidsSponsor: "Luke Sheneman",
+    repoUrl: "https://github.com/ui-insight/MindRouter",
+    operationalFunction:
+      "Generates short video clips from prompts or reference images, adds generated voice or audio, sequences clips on a storyboard, and stitches them into a draft that UCM can refine in its existing editing workflow.",
+    operationalExcellenceOutcome:
+      "Compresses ad concept development from a filming-first process to rapid visual iteration, gives stakeholders a concrete mockup before production resources are committed, and avoids per-clip commercial generation credits during early creative development.",
+    features: [
+      "Text-to-video clip generation",
+      "Image-to-video clip generation",
+      "Integrated voice and audio generation",
+      "Storyboard sequencing and clip stitching",
+    ],
+    tech: ["MindRouter", "LTX-Video 2.3", "NVIDIA H200"],
+    relatedSlugs: ["mindrouter", "dgx-stack", "ucm-daily-register"],
+    workCategories: ["process"],
+    strategicPlanAlignment: ["E.2"],
+  },
 
   // ============================================================
   // Office of Sponsored Programs (ORED)


### PR DESCRIPTION
## Summary

- add MindRouter Video Storyboard to the University Communications and Marketing portfolio group
- name Melissa Hartley as operational owner and Luke Sheneman as IIDS sponsor
- document the MindRouter video endpoint, dedicated H200 capacity, text/image-to-video workflow, integrated voice support, and storyboard editing scope
- classify the project as an IIDS-hosted active build aligned to strategic priority E.2

## Why

UCM requested a rapid way to mock up an advertisement before committing filming resources. IIDS has implemented the reusable video-generation infrastructure in MindRouter and is building the separate storyboarding workflow with the initial user.

## Impact

The portfolio now captures both the reusable infrastructure and the operational outcome: faster ad previsualization, earlier stakeholder feedback, and reduced dependence on commercial per-clip generation credits during concept development. ROI remains qualitative until the first user iterations produce defensible evidence.

## Validation

- `npm run verify:portfolio` — passed for 28 projects with 0 errors (3 commit-metadata freshness warnings)
- `npm run build` — passed
- `npm run seed:portfolio` — refreshed the local `aispeg_dev` registry
- confirmed the seeded row records the expected slug, owner, sponsor, status, unit, deployment environment, and replacement classification
