### PR TITLE
Surface bottom-line ROI on the Intake Crosswalk

### DIFF
--- a/app/standards/intake-crosswalk/page.tsx
+++ b/app/standards/intake-crosswalk/page.tsx
@@ -15,7 +15,13 @@ import {
   PUBLIC_STAGE_CHIP,
   PUBLIC_STAGE_LABEL,
 } from "@/lib/portfolio";
-import { ROI_RUBRIC_READY } from "@/lib/roi-rubric";
+import {
+  ROI_RUBRIC_READY,
+  formatAnnualUsd,
+  formatAnnualUsdCompact,
+  formatRenewalDate,
+  type BottomLineRoi,
+} from "@/lib/roi-rubric";
 import { getRoiBySlug, type ClickUpRoi } from "@/lib/clickup-data";
 
 // Reads ClickUp-synced ROI from Postgres at request time.
@@ -69,6 +75,35 @@ function ClickUpRoiValue({ roi }: { roi: ClickUpRoi }) {
       <span className="mt-0.5 block text-[11px] not-italic text-ink-subtle">
         Estimated from ClickUp &middot; formal rubric pending
       </span>
+    </span>
+  );
+}
+
+// Bottom-line ROI — hard-dollar savings from retiring the named incumbent
+// contract. Full form for the cards view; every dollar names its contract.
+function BottomLineValue({ roi }: { roi: BottomLineRoi }) {
+  return (
+    <span>
+      <span className="font-semibold">{formatAnnualUsd(roi.annualUsd)}</span>{" "}
+      &mdash; replaces {roi.systemName}
+      {roi.renewalDate
+        ? ` (contract renews ${formatRenewalDate(roi.renewalDate)})`
+        : ""}
+    </span>
+  );
+}
+
+// Compact bottom-line ROI for the dense matrix cell; incumbent + renewal
+// ride in the title.
+function BottomLineCell({ roi }: { roi: BottomLineRoi }) {
+  const title = `Replaces ${roi.systemName}${
+    roi.renewalDate
+      ? ` — contract renews ${formatRenewalDate(roi.renewalDate)}`
+      : ""
+  }`;
+  return (
+    <span className="font-semibold" title={title}>
+      {formatAnnualUsdCompact(roi.annualUsd)}
     </span>
   );
 }
@@ -287,6 +322,21 @@ function ProfileCard({ p }: { p: ProfileWithRoi }) {
           )}
         </Field>
 
+        <Field label="Bottom-line ROI">
+          {p.bottomLineRoi ? (
+            <BottomLineValue roi={p.bottomLineRoi} />
+          ) : p.enterpriseReplacementStatus === "no" ? (
+            <span
+              className="italic text-ink-subtle"
+              title="This project does not replace an existing enterprise system, so it carries no hard-dollar contract savings."
+            >
+              None &mdash; not an enterprise-system replacement
+            </span>
+          ) : (
+            <Pending note="replacement status not yet documented" />
+          )}
+        </Field>
+
         <Field label="ROI">
           {p.roi?.summary ? (
             <span>
@@ -375,6 +425,7 @@ function MatrixView({ profiles }: { profiles: ProfileWithRoi[] }) {
             <Th>Data classification</Th>
             <Th>AI risk</Th>
             <Th>Funding</Th>
+            <Th>Bottom-line ROI</Th>
             <Th>ROI</Th>
           </tr>
         </thead>
@@ -422,6 +473,20 @@ function MatrixView({ profiles }: { profiles: ProfileWithRoi[] }) {
               </Td>
               <Td className="text-ink-muted">
                 {p.fundingSource ?? <Dash note="funding not specified" />}
+              </Td>
+              <Td>
+                {p.bottomLineRoi ? (
+                  <BottomLineCell roi={p.bottomLineRoi} />
+                ) : p.enterpriseReplacementStatus === "no" ? (
+                  <span
+                    className="text-ink-subtle"
+                    title="Not an enterprise-system replacement"
+                  >
+                    None
+                  </span>
+                ) : (
+                  <Dash note="replacement status not yet documented" />
+                )}
               </Td>
               <Td>
                 {p.roi?.summary ? (
@@ -532,6 +597,17 @@ export default async function IntakeCrosswalkPage({
             .map((t) => `${coverage.byTrack[t.key]} ${t.label}`)
             .join(" · ")}
         </p>
+        {coverage.bottomLineCount > 0 && (
+          <p className="mt-2 text-sm text-brand-black">
+            Bottom-line ROI identified:{" "}
+            <span className="font-semibold">
+              {formatAnnualUsd(coverage.bottomLineTotalUsd)}
+            </span>{" "}
+            across {coverage.bottomLineCount} enterprise-system replacements
+            &mdash; hard-dollar savings from retiring existing software
+            contracts.
+          </p>
+        )}
         <p className="mt-3 border-t border-hairline pt-3 text-xs text-ink-subtle">
           Awaiting the office&rsquo;s review: data classification pending on{" "}
           {coverage.classificationPending}, AI-risk posture pending on{" "}

--- a/lib/governance-profile.ts
+++ b/lib/governance-profile.ts
@@ -32,7 +32,11 @@ import {
   computePublicStage,
 } from "./portfolio";
 import { projects as governanceCatalog } from "./governance/catalog";
-import type { RoiAssessment } from "./roi-rubric";
+import {
+  bottomLineFromReplacement,
+  type BottomLineRoi,
+  type RoiAssessment,
+} from "./roi-rubric";
 
 // ---- Intake vocabulary (mirrors the Unified Technology Request) -------
 
@@ -201,6 +205,15 @@ export interface ResolvedProfile {
   fundingSource: string | null;
   strategicPlanAlignment: string[];
   roi: RoiAssessment | null;
+  /**
+   * Hard-dollar savings from replacing an incumbent system — the UTR
+   * working group's bottom-line ROI. Derived from the project's declared
+   * enterprise-system replacement facts; null when no replacement is
+   * declared ("yes" with facts → a claim, "no"/"to-be-determined" → null,
+   * distinguished via `enterpriseReplacementStatus`).
+   */
+  bottomLineRoi: BottomLineRoi | null;
+  enterpriseReplacementStatus: "yes" | "no" | "to-be-determined";
   /** Slug in the Data Model catalog, if this project has a schema page. */
   dataModelSlug: string | null;
 }
@@ -229,6 +242,8 @@ export function resolveGovernanceProfile(project: Project): ResolvedProfile {
     fundingSource: o.fundingSource ?? project.funding ?? null,
     strategicPlanAlignment: project.strategicPlanAlignment ?? [],
     roi: o.roi ?? null,
+    bottomLineRoi: bottomLineFromReplacement(project.enterpriseSystemReplacement),
+    enterpriseReplacementStatus: project.enterpriseSystemReplacement.status,
     dataModelSlug: dataModelSlugs.has(project.slug) ? project.slug : null,
   };
 }
@@ -247,6 +262,10 @@ export interface GovernanceCoverage {
   classificationPending: number;
   aiRiskPending: number;
   roiPending: number;
+  /** Projects with a declared enterprise-system replacement. */
+  bottomLineCount: number;
+  /** Summed annual hard-dollar savings across those projects. */
+  bottomLineTotalUsd: number;
 }
 
 export function governanceCoverage(
@@ -262,11 +281,17 @@ export function governanceCoverage(
   let classificationPending = 0;
   let aiRiskPending = 0;
   let roiPending = 0;
+  let bottomLineCount = 0;
+  let bottomLineTotalUsd = 0;
   for (const p of profiles) {
     byTrack[p.intakeTrack] += 1;
     if (!p.dataClassification) classificationPending += 1;
     if (!p.aiRiskTier) aiRiskPending += 1;
     if (!p.roi) roiPending += 1;
+    if (p.bottomLineRoi) {
+      bottomLineCount += 1;
+      bottomLineTotalUsd += p.bottomLineRoi.annualUsd;
+    }
   }
   return {
     total: profiles.length,
@@ -274,6 +299,8 @@ export function governanceCoverage(
     classificationPending,
     aiRiskPending,
     roiPending,
+    bottomLineCount,
+    bottomLineTotalUsd,
   };
 }
 

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -968,6 +968,34 @@ export const projects: Project[] = [
     strategicPlanAlignment: ["E.1"],
   },
   {
+    slug: "ir-reporting-modernization",
+    name: "IR Reporting Modernization (SAS Replacement)",
+    tagline:
+      "OIT-led replacement of the SAS platform behind Institutional Research's reporting dashboards.",
+    description:
+      "OIT is replacing SAS, the platform behind Institutional Research's reporting dashboards, with modern reporting tooling. Retiring the SAS contract is projected to save $80,000–$100,000 annually (per OIT, July 2026; recorded conservatively at the low end). Tracked here as part of the AI projects inventory; detail will be added as OIT shares scope and timeline.",
+    homeUnits: ["Office of Information Technology"],
+    operationalOwners: [
+      { name: "Dan Ewart", title: "Vice President for Information Technology" },
+    ],
+    buildParticipants: ["OIT"],
+    status: "tracked",
+    visibility: "Public",
+    proposedDeploymentEnvironment: "to-be-determined",
+    enterpriseSystemReplacement: {
+      status: "yes",
+      systemName: "SAS (Institutional Research reporting)",
+      annualCostUsd: 80_000,
+    },
+    ai4raRelationship: "None",
+    iidsSponsor: "Barrie Robison",
+    operationalFunction:
+      "Replaces the SAS-based reporting dashboards Institutional Research runs today with modern, OIT-supported tooling. Scope to be confirmed.",
+    operationalExcellenceOutcome:
+      "Retires the SAS contract — $80,000–$100,000 per year in hard-dollar savings — and moves institutional reporting onto supported tooling.",
+    trackingOnly: true,
+  },
+  {
     slug: "nexus",
     name: "Nexus",
     tagline:

--- a/lib/roi-rubric.ts
+++ b/lib/roi-rubric.ts
@@ -29,3 +29,58 @@ export interface RoiAssessment {
 // Flip to `true` once RUBRIC_DIMENSIONS + scoring exist. Consumers use
 // this to decide between "assessment pending" and a real score display.
 export const ROI_RUBRIC_READY = false as const;
+
+// ============================================================
+// Bottom-line ROI — hard-dollar savings from replacing software
+// and contracts (the institutional prioritization principle the
+// UTR working group adopted in July 2026; see ADR 0005).
+// ============================================================
+// Distinct from the rubric above and from capacity estimates:
+// bottom-line ROI is derived from each project's declared
+// enterprise-system replacement facts (lib/project-governance.ts,
+// Migration 012), so every dollar traces to a named incumbent
+// contract. No replacement declared → no bottom-line claim.
+
+import type { EnterpriseSystemReplacement } from "./project-governance";
+
+export interface BottomLineRoi {
+  /** Annual hard-dollar savings once the incumbent contract retires. */
+  annualUsd: number;
+  /** The incumbent system whose contract the project replaces. */
+  systemName: string;
+  /** ISO date the incumbent contract next renews, when known. */
+  renewalDate?: string;
+}
+
+export function bottomLineFromReplacement(
+  replacement: EnterpriseSystemReplacement
+): BottomLineRoi | null {
+  if (replacement.status !== "yes") return null;
+  return {
+    annualUsd: replacement.annualCostUsd,
+    systemName: replacement.systemName,
+    renewalDate: replacement.renewalDate,
+  };
+}
+
+/** "$150,000/yr" — full form for cards and the coverage strip. */
+export function formatAnnualUsd(amount: number): string {
+  return `$${amount.toLocaleString("en-US")}/yr`;
+}
+
+/** "$150k/yr" — compact form for dense matrix cells. */
+export function formatAnnualUsdCompact(amount: number): string {
+  const thousands = Math.round(amount / 1000);
+  return `$${thousands.toLocaleString("en-US")}k/yr`;
+}
+
+/** "Mar 31, 2027" — renewal dates in running text. */
+export function formatRenewalDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}


### PR DESCRIPTION
## Summary

First slice of [ADR 0005](https://github.com/ui-insight/AISPEG/pull/294) Phase 1, and the live URL for the 7/20 action item *"update the data on current projects and flag those with bottom-line ROI before Ben's meeting with Scott."*

- **`lib/roi-rubric.ts`** — `BottomLineRoi` derivation from each project's declared enterprise-system-replacement facts (Migration 012 shape), plus currency/date formatters. Distinct from the pending CADSO rubric and from ClickUp capacity estimates: bottom-line ROI is hard-dollar savings from retiring named software contracts, per the working group's adopted definition.
- **Intake Crosswalk** — new *Bottom-line ROI* field (cards) and column (matrix), each dollar naming its incumbent contract and renewal date; coverage strip gains the headline: **$447,000/yr across 4 enterprise-system replacements**.
- **New tracked entry: IR Reporting Modernization (SAS Replacement)** — OIT-owned (Dan Ewart), following the `oit-data-modernization` precedent. Records the $80–100k/yr SAS savings stated by OIT on 7/20, conservatively at $80k. Joins OpenERA→VERAS ($150k/yr, renews 2027-03-31), Financial Planning Suite→Axiom ($200k/yr), RFD Companion→InfoReady ($17k/yr).

## Verification

- `npm run verify:portfolio` — PASSED, 28 projects, 0 errors (2 pre-existing stale commit-date warnings).
- `npm run build` — clean.
- Verified in browser: cards + matrix views render all four dollar rows with incumbents/renewals; `None` vs `Pending` states distinct; no console errors.
- Dev `applications` table re-seeded (28 projects); `/portfolio/ir-reporting-modernization` renders with the replacement facts.
- No migration in this PR; the `roi_claims` table lands with the `tech_requests` registry migration per ADR 0005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)