### PR TITLE
Add UTR request registry (ADR 0005 Phase 1)

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -55,6 +55,42 @@ export async function POST(request: NextRequest) {
       ]
     );
 
+    // File the submission into the UTR request registry (tech_requests,
+    // ADR 0005) so it joins the unified queue alongside ClickUp and
+    // (later) TDX requests. Best-effort: registry failure must not
+    // break the submitter's confirmation flow.
+    try {
+      const registryRow = await queryOne<{ id: string }>(
+        `INSERT INTO tech_requests (
+           origin, submission_id, requestor_name, requestor_email,
+           requestor_unit, title, need_statement, disposition, received_at
+         ) VALUES ('site-submission',$1,$2,$3,$4,$5,$6,'open',now())
+         ON CONFLICT (submission_id) WHERE submission_id IS NOT NULL
+         DO NOTHING
+         RETURNING id`,
+        [
+          submission.id,
+          submitter_name || null,
+          submitter_email || null,
+          department || null,
+          String(idea_text).split("\n")[0].slice(0, 200),
+          idea_text,
+        ]
+      );
+      if (registryRow) {
+        await query(
+          `INSERT INTO tech_request_events (request_id, actor, event_type, note)
+           VALUES ($1, 'site', 'received', 'Submitted through the Submit-a-Project assessment.')`,
+          [registryRow.id]
+        );
+      }
+    } catch (registryError) {
+      console.error(
+        "POST /api/submissions: UTR registry insert failed (submission saved):",
+        registryError
+      );
+    }
+
     return NextResponse.json({ id: submission.id }, { status: 201 });
   } catch (error) {
     console.error("POST /api/submissions error:", error);

--- a/app/internal/page.tsx
+++ b/app/internal/page.tsx
@@ -69,6 +69,20 @@ export default async function InternalHome() {
 
       <section className="grid gap-4 md:grid-cols-3">
         <Link
+          href="/internal/requests"
+          className="group rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md"
+        >
+          <p className="text-xs font-medium uppercase tracking-wider text-ui-gold-dark">
+            UTR registry
+          </p>
+          <p className="mt-1 text-base font-semibold text-ui-charcoal group-hover:text-ui-gold-dark">
+            Unified request queue &rarr;
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            Every request from every origin — ClickUp, site, TDX (soon)
+          </p>
+        </Link>
+        <Link
           href="/internal/agent-log"
           className="group rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-ui-gold/40 hover:shadow-md md:col-span-2"
         >

--- a/app/internal/requests/page.tsx
+++ b/app/internal/requests/page.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import { listTechRequests, requestCounts } from "@/lib/requests";
+import {
+  INTAKE_TRACK_SHORT,
+  INTAKE_TRACK_TITLE,
+  REQUEST_DISPOSITION_LABEL,
+  REQUEST_ORIGIN_LABEL,
+  isIntakeTrack,
+} from "@/lib/utr";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Unified Request Queue — Internal",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function InternalRequestsPage() {
+  const [requests, counts] = await Promise.all([
+    listTechRequests(),
+    requestCounts(),
+  ]);
+
+  const openFirst = [...requests].sort((a, b) => {
+    const aOpen = a.disposition === "open" ? 0 : 1;
+    const bOpen = b.disposition === "open" ? 0 : 1;
+    if (aOpen !== bOpen) return aOpen - bOpen;
+    return b.receivedAt.localeCompare(a.receivedAt);
+  });
+
+  return (
+    <div className="space-y-10">
+      <nav className="text-sm text-gray-500">
+        <Link href="/internal" className="hover:text-brand-black">
+          Internal
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-ui-charcoal">Unified request queue</span>
+      </nav>
+
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-wider text-ui-gold-dark">
+          IIDS Internal
+        </p>
+        <h1 className="mt-2 text-3xl font-black tracking-tight text-ui-charcoal">
+          Unified request queue
+        </h1>
+        <p className="mt-3 max-w-3xl text-base leading-relaxed text-gray-700">
+          Every technology request the registry knows about, from every
+          origin — the ClickUp intake backlog, Submit-a-Project
+          assessments, and (once wired) TDX — in one queue per the
+          Unified Technology Request process (ADR 0005). Track and stage
+          stay empty until UTR triage assigns them; the queue existing
+          before the process starts is the point.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Requests registered
+          </p>
+          <p className="mt-1 text-3xl font-black text-ui-charcoal">
+            {counts.total}
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            {Object.entries(counts.byOrigin)
+              .filter(([, n]) => n > 0)
+              .map(
+                ([origin, n]) =>
+                  `${n} ${REQUEST_ORIGIN_LABEL[origin as keyof typeof REQUEST_ORIGIN_LABEL].toLowerCase()}`
+              )
+              .join(" · ") || "No sources synced yet"}
+          </p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Open
+          </p>
+          <p className="mt-1 text-3xl font-black text-ui-charcoal">
+            {counts.open}
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            Awaiting review or a decision
+          </p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            UTR-triaged
+          </p>
+          <p className="mt-1 text-3xl font-black text-ui-charcoal">
+            {requests.filter((r) => r.track !== null).length}
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            Assigned a track by the joint triage process
+          </p>
+        </div>
+      </section>
+
+      {requests.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center shadow-sm">
+          <p className="text-sm font-medium text-gray-600">
+            The registry is empty. Run Migration 018, then a ClickUp sync
+            — existing backlog requests and site submissions backfill
+            automatically.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+          <table className="w-full min-w-[900px] border-collapse text-left">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Request
+                </th>
+                <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Origin
+                </th>
+                <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Requestor
+                </th>
+                <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Received
+                </th>
+                <th className="px-3 py-3 text-center text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Track
+                </th>
+                <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Signal
+                </th>
+                <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                  Disposition
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {openFirst.map((r) => (
+                <tr
+                  key={r.id}
+                  className="border-b border-gray-100 last:border-b-0"
+                >
+                  <td className="max-w-md px-4 py-2.5">
+                    <p className="truncate text-sm font-medium text-ui-charcoal">
+                      {r.title}
+                    </p>
+                    {r.submissionId && (
+                      <Link
+                        href={`/intake/${r.submissionId}`}
+                        className="text-xs text-gray-400 hover:text-brand-black"
+                      >
+                        View submission →
+                      </Link>
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-gray-600">
+                    {REQUEST_ORIGIN_LABEL[r.origin]}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-gray-600">
+                    {r.requestorName ?? "—"}
+                    {r.requestorUnit && (
+                      <span className="text-gray-400"> · {r.requestorUnit}</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-xs text-gray-600">
+                    {formatDate(r.receivedAt)}
+                  </td>
+                  <td className="px-3 py-2.5 text-center text-xs text-gray-600">
+                    {r.track && isIntakeTrack(r.track) ? (
+                      <span title={INTAKE_TRACK_TITLE[r.track]}>
+                        {INTAKE_TRACK_SHORT[r.track]}
+                      </span>
+                    ) : (
+                      <span
+                        className="text-gray-300"
+                        title="Not yet triaged under the UTR process"
+                      >
+                        —
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-xs tabular-nums text-gray-600">
+                    {r.weightedScore !== null ? (
+                      <span title="ClickUp rubric weighted score (0–100)">
+                        {Math.round(r.weightedScore * 10) / 10}
+                      </span>
+                    ) : r.submissionTier !== null ? (
+                      <span title="Site assessment tier (1–4)">
+                        Tier {r.submissionTier}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <span
+                      className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${
+                        r.disposition === "open"
+                          ? "border-amber-200 bg-amber-50 text-amber-800"
+                          : "border-gray-200 bg-gray-50 text-gray-600"
+                      }`}
+                    >
+                      {REQUEST_DISPOSITION_LABEL[r.disposition]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400">
+        Registry rows are durable memory: a request deleted upstream keeps
+        its row and last-known disposition here. Requestor names and
+        submission content have no public-visibility decision yet, so this
+        queue is internal-only (ADR 0005).
+      </p>
+    </div>
+  );
+}

--- a/db/migrations/018_utr_registry.sql
+++ b/db/migrations/018_utr_registry.sql
@@ -1,0 +1,275 @@
+-- Migration 018: Unified Technology Request registry (ADR 0005, Phase 1)
+--
+-- The canonical request registry: one row per technology request
+-- regardless of origin (TDX ticket, ClickUp backlog task, site
+-- submission, direct entry). Per-source projection tables
+-- (clickup_requests today, tdx_requests later) remain disposable
+-- sync targets; this registry is durable site-canonical memory that
+-- links, claims, and decisions attach to.
+--
+-- Vocabulary posture (mirrors 006/007/008): `origin` is structural and
+-- carries a CHECK; `track` / `stage` / `disposition` / event and link
+-- types are evolving UTR process vocabularies owned by lib/utr.ts — no
+-- CHECK constraints, so taxonomy edits stay decoupled from migration
+-- cadence.
+--
+-- FK posture (mirrors ADR 0004 §1): `submission_id` and request↔request
+-- links are real FKs (those tables are never truncated by re-seeds).
+-- Anything pointing at the portfolio uses `application_slug` as a soft
+-- key, because scripts/seed-portfolio.ts TRUNCATEs applications on
+-- every re-seed and a CASCADE FK would silently wipe registry data.
+
+BEGIN;
+
+-- ── tech_requests: the canonical request registry ─────────────
+
+CREATE TABLE IF NOT EXISTS tech_requests (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Where the request entered. Structural enum — extending it is a
+  -- deliberate migration, unlike the process vocabularies below.
+  origin          TEXT NOT NULL
+                  CHECK (origin IN ('tdx', 'clickup', 'site-submission', 'direct')),
+
+  -- Origin references. Soft TEXT ids for external systems; a real FK
+  -- for submissions (never truncated). At most one is expected per row;
+  -- partial unique indexes below make each an idempotent upsert key.
+  tdx_ticket_id   TEXT,
+  clickup_task_id TEXT,
+  submission_id   UUID REFERENCES submissions(id) ON DELETE SET NULL,
+
+  -- Requestor (named humans are load-bearing UI).
+  requestor_name  TEXT,
+  requestor_email TEXT,
+  requestor_unit  TEXT,
+
+  -- Substance.
+  title           TEXT NOT NULL,
+  need_statement  TEXT,
+
+  -- Routing state. NULL track/stage = not yet triaged under the UTR
+  -- process. Values come from lib/utr.ts (no CHECK by design).
+  track           TEXT,
+  stage           TEXT,
+  approval_level  TEXT,
+
+  -- Outcome. Values from lib/utr.ts (no CHECK by design).
+  disposition     TEXT NOT NULL DEFAULT 'open',
+  decided_at      TIMESTAMPTZ,
+  decided_by      TEXT,
+  decision_summary TEXT,
+
+  received_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotent upsert keys per origin reference.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tech_requests_tdx_ticket
+  ON tech_requests (tdx_ticket_id) WHERE tdx_ticket_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tech_requests_clickup_task
+  ON tech_requests (clickup_task_id) WHERE clickup_task_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tech_requests_submission
+  ON tech_requests (submission_id) WHERE submission_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tech_requests_disposition
+  ON tech_requests (disposition);
+CREATE INDEX IF NOT EXISTS idx_tech_requests_received_at
+  ON tech_requests (received_at DESC);
+
+CREATE OR REPLACE FUNCTION update_tech_requests_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tech_requests_updated_at ON tech_requests;
+CREATE TRIGGER trg_tech_requests_updated_at
+  BEFORE UPDATE ON tech_requests
+  FOR EACH ROW
+  EXECUTE FUNCTION update_tech_requests_updated_at();
+
+-- ── tech_request_events: append-only audit trail ──────────────
+
+CREATE TABLE IF NOT EXISTS tech_request_events (
+  id           BIGSERIAL PRIMARY KEY,
+  request_id   UUID NOT NULL REFERENCES tech_requests(id) ON DELETE CASCADE,
+  at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  actor        TEXT,
+  -- Values from lib/utr.ts: received | triaged | track-assigned |
+  -- stage-advanced | flag-raised | flag-resolved | routed | decision |
+  -- merged | converted (no CHECK by design).
+  event_type   TEXT NOT NULL,
+  from_value   TEXT,
+  to_value     TEXT,
+  note         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tech_request_events_request
+  ON tech_request_events (request_id, at DESC);
+
+-- ── tech_request_links: request ↔ request ─────────────────────
+
+CREATE TABLE IF NOT EXISTS tech_request_links (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id          UUID NOT NULL REFERENCES tech_requests(id) ON DELETE CASCADE,
+  related_request_id  UUID NOT NULL REFERENCES tech_requests(id) ON DELETE CASCADE,
+  -- duplicate-of | roi-aggregates-to | related (lib/utr.ts).
+  link_type           TEXT NOT NULL,
+  created_by          TEXT,
+  note                TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (request_id <> related_request_id),
+  UNIQUE (request_id, related_request_id, link_type)
+);
+
+-- ── tech_request_project_links: request ↔ portfolio project ───
+-- The graph Barrie's stretch goal runs on: duplicates, expanded use of
+-- an existing solution, interest in an underway build, conversion.
+
+CREATE TABLE IF NOT EXISTS tech_request_project_links (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id       UUID NOT NULL REFERENCES tech_requests(id) ON DELETE CASCADE,
+  -- Soft key into applications.slug (survives portfolio re-seeds).
+  application_slug TEXT NOT NULL,
+  -- duplicate-of | expanded-use | interest | converted-to | supersedes |
+  -- informs (lib/utr.ts).
+  link_type        TEXT NOT NULL,
+  -- triage | similarity-engine | admin (lib/utr.ts).
+  created_by       TEXT,
+  score            REAL,
+  note             TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE (request_id, application_slug, link_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tech_request_project_links_slug
+  ON tech_request_project_links (application_slug);
+
+-- ── roi_claims: the ROI ledger ────────────────────────────────
+-- Claims on projects (soft slug) or requests (FK). Portfolio
+-- enterprise-replacement facts remain the source for project
+-- bottom-line ROI (rendered directly from lib/portfolio.ts); this
+-- table carries request-side claims and non-replacement dimensions,
+-- and is what aggregation across the request graph reads.
+
+CREATE TABLE IF NOT EXISTS roi_claims (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Exactly one subject: a portfolio project (soft slug) or a request.
+  application_slug  TEXT,
+  request_id        UUID REFERENCES tech_requests(id) ON DELETE CASCADE,
+  -- hard-dollar-replacement | capacity-fte | cost-avoidance | revenue |
+  -- risk-reduction | time-savings (lib/utr.ts; extensible as the
+  -- Ben/Scott ROI framework lands — no CHECK by design).
+  dimension         TEXT NOT NULL,
+  annual_value_usd  NUMERIC(14, 2),
+  fte               NUMERIC,
+  -- Plain-language justification; every number carries its basis.
+  basis             TEXT NOT NULL,
+  -- clickup-sync | worksheet | triage | cadso-rubric | owner-attested.
+  source            TEXT NOT NULL,
+  -- estimated | attested | verified | realized.
+  status            TEXT NOT NULL DEFAULT 'estimated',
+  effective_fy      TEXT,
+  claimed_by        TEXT,
+  claimed_at        DATE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (
+    (application_slug IS NOT NULL)::int + (request_id IS NOT NULL)::int = 1
+  ),
+  CHECK (annual_value_usd IS NOT NULL OR fte IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_roi_claims_application_slug
+  ON roi_claims (application_slug);
+CREATE INDEX IF NOT EXISTS idx_roi_claims_request
+  ON roi_claims (request_id);
+
+DROP TRIGGER IF EXISTS trg_roi_claims_updated_at ON roi_claims;
+CREATE TRIGGER trg_roi_claims_updated_at
+  BEFORE UPDATE ON roi_claims
+  FOR EACH ROW
+  EXECUTE FUNCTION update_tech_requests_updated_at();
+
+-- ── Backfill: existing request-shaped rows join the registry ──
+-- Idempotent via the per-origin unique keys + ON CONFLICT DO NOTHING;
+-- ongoing rows flow in through lib/clickup-sync.ts and the submissions
+-- POST route from this migration forward. Registry rows persist even
+-- if their projection row is later deleted — the registry is memory,
+-- not a mirror.
+
+-- ClickUp backlog → registry. Raw ClickUp status text maps onto the
+-- registry disposition vocabulary; unknown statuses stay 'open'.
+INSERT INTO tech_requests (
+  origin, clickup_task_id, requestor_name, requestor_unit,
+  title, need_statement, disposition, received_at
+)
+SELECT
+  'clickup',
+  cr.clickup_task_id,
+  cr.submitter,
+  cr.unit,
+  cr.name,
+  cr.description,
+  CASE lower(cr.status)
+    WHEN 'to be reviewed' THEN 'open'
+    WHEN 'active'         THEN 'approved'
+    WHEN 'rejected'       THEN 'denied'
+    WHEN 'complete'       THEN 'converted-to-project'
+    ELSE 'open'
+  END,
+  COALESCE(cr.date_created, cr.synced_at)
+FROM clickup_requests cr
+ON CONFLICT (clickup_task_id) WHERE clickup_task_id IS NOT NULL
+DO NOTHING;
+
+-- Site submissions → registry. Title is the first line of the idea
+-- text; the full text is the need statement.
+INSERT INTO tech_requests (
+  origin, submission_id, requestor_name, requestor_email, requestor_unit,
+  title, need_statement, disposition, received_at
+)
+SELECT
+  'site-submission',
+  s.id,
+  s.submitter_name,
+  s.submitter_email,
+  s.department,
+  left(split_part(s.idea_text, E'\n', 1), 200),
+  s.idea_text,
+  CASE s.status
+    WHEN 'new'         THEN 'open'
+    WHEN 'reviewed'    THEN 'open'
+    WHEN 'in-progress' THEN 'approved'
+    WHEN 'archived'    THEN 'closed'
+    ELSE 'open'
+  END,
+  s.created_at
+FROM submissions s
+ON CONFLICT (submission_id) WHERE submission_id IS NOT NULL
+DO NOTHING;
+
+-- One 'received' audit event per backfilled row that has none yet.
+INSERT INTO tech_request_events (request_id, at, actor, event_type, note)
+SELECT
+  tr.id,
+  tr.received_at,
+  'migration-018',
+  'received',
+  'Backfilled into the UTR registry from ' || tr.origin || '.'
+FROM tech_requests tr
+WHERE NOT EXISTS (
+  SELECT 1 FROM tech_request_events e
+  WHERE e.request_id = tr.id AND e.event_type = 'received'
+);
+
+INSERT INTO schema_migrations (version) VALUES ('018_utr_registry')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/lib/clickup-sync.ts
+++ b/lib/clickup-sync.ts
@@ -39,6 +39,8 @@ import {
   type ClickUpTask,
 } from "./clickup";
 
+import type { RequestDisposition } from "./utr";
+
 export interface SyncSummary {
   runId: number;
   startedAt: string;
@@ -47,6 +49,24 @@ export interface SyncSummary {
   statusUpdates: number;
   requests: number;
   warnings: string[];
+}
+
+// Raw ClickUp backlog status → registry disposition (ADR 0005). Unknown
+// upstream statuses land as 'open' so a rename degrades loudly in the
+// queue rather than silently hiding a request.
+function dispositionForClickUpStatus(status: string): RequestDisposition {
+  switch (status.toLowerCase()) {
+    case "to be reviewed":
+      return "open";
+    case "active":
+      return "approved";
+    case "rejected":
+      return "denied";
+    case "complete":
+      return "converted-to-project";
+    default:
+      return "open";
+  }
 }
 
 function msEpochToIso(ms: string): string {
@@ -287,8 +307,46 @@ async function syncBacklog(warnings: string[]): Promise<number> {
         msEpochToIso(task.date_updated),
       ]
     );
+
+    // Mirror into the UTR registry (tech_requests, ADR 0005). ClickUp
+    // is authoritative for the sync-owned fields below; site-owned
+    // routing state (track, stage, links, claims) is never touched.
+    // A 'received' audit event is written once, on first appearance.
+    const registryRow = await queryOne<{ id: string; inserted: boolean }>(
+      `INSERT INTO tech_requests (
+         origin, clickup_task_id, requestor_name, requestor_unit,
+         title, need_statement, disposition, received_at
+       ) VALUES ('clickup',$1,$2,$3,$4,$5,$6,$7)
+       ON CONFLICT (clickup_task_id) WHERE clickup_task_id IS NOT NULL
+       DO UPDATE SET
+         requestor_name = EXCLUDED.requestor_name,
+         requestor_unit = EXCLUDED.requestor_unit,
+         title = EXCLUDED.title,
+         need_statement = EXCLUDED.need_statement,
+         disposition = EXCLUDED.disposition,
+         received_at = EXCLUDED.received_at
+       RETURNING id, (xmax = 0) AS inserted`,
+      [
+        task.id,
+        getTextField(task, RUBRIC_FIELDS.submitter),
+        getTextField(task, RUBRIC_FIELDS.unit),
+        task.name,
+        task.text_content?.trim() || null,
+        dispositionForClickUpStatus(task.status.status),
+        msEpochToIso(task.date_created),
+      ]
+    );
+    if (registryRow?.inserted) {
+      await query(
+        `INSERT INTO tech_request_events (request_id, at, actor, event_type, note)
+         VALUES ($1, $2, 'clickup-sync', 'received', 'Synced from the ClickUp intake backlog.')`,
+        [registryRow.id, msEpochToIso(task.date_created)]
+      );
+    }
   }
 
+  // Projection rows mirror ClickUp deletions; registry rows persist —
+  // the registry is memory, not a mirror (ADR 0005).
   await query(
     `DELETE FROM clickup_requests WHERE NOT (clickup_task_id = ANY($1::text[]))`,
     [seenTaskIds]

--- a/lib/governance-profile.ts
+++ b/lib/governance-profile.ts
@@ -39,18 +39,20 @@ import {
 } from "./roi-rubric";
 
 // ---- Intake vocabulary (mirrors the Unified Technology Request) -------
+// The track vocabulary itself lives in lib/utr.ts (the UTR process
+// module, ADR 0005) and is re-exported here so existing consumers keep
+// their import path.
+
+import type { IntakeTrack } from "./utr";
+
+export type { IntakeTrack };
+export {
+  INTAKE_TRACK_LABEL,
+  INTAKE_TRACK_SHORT,
+  INTAKE_TRACK_TITLE,
+} from "./utr";
 
 export type BuildType = "built-in-house" | "bought" | "hybrid";
-
-// Fast Lane / Track A / B / C from the request routing, plus `external`
-// for work tracked in the inventory that predates (or sits outside) the
-// IIDS build pipeline.
-export type IntakeTrack =
-  | "fast-lane"
-  | "track-a"
-  | "track-b"
-  | "track-c"
-  | "external";
 
 // Provisional — reconcile with APM 30.11 data classification when the
 // office confirms its tiers. Ships unused (classification is pending).
@@ -310,33 +312,6 @@ export const BUILD_TYPE_LABEL: Record<BuildType, string> = {
   "built-in-house": "Built in-house",
   bought: "Purchased",
   hybrid: "Hybrid (vendor-assisted)",
-};
-
-export const INTAKE_TRACK_LABEL: Record<IntakeTrack, string> = {
-  "fast-lane": "Fast Lane",
-  "track-a": "Track A · Standard software",
-  "track-b": "Track B · Built in-house",
-  "track-c": "Track C · Idea / concept",
-  external: "External — tracked",
-};
-
-// Compact labels for the dense matrix view, where the full
-// "Track B · Built in-house" string is too wide. Pair with the title
-// tooltip (INTAKE_TRACK_TITLE) so the short form stays legible.
-export const INTAKE_TRACK_SHORT: Record<IntakeTrack, string> = {
-  "fast-lane": "Fast Lane",
-  "track-a": "A",
-  "track-b": "B",
-  "track-c": "C",
-  external: "Ext",
-};
-
-export const INTAKE_TRACK_TITLE: Record<IntakeTrack, string> = {
-  "fast-lane": "Fast Lane — low-risk individual purchase, automated approval.",
-  "track-a": "Track A — commercial purchase or subscription requiring governance review.",
-  "track-b": "Track B — fully realized in-house application needing security and operational acceptance.",
-  "track-c": "Track C — early-stage build requiring feasibility assessment and the development queue.",
-  external: "External — owned outside IIDS; tracked in the inventory, not routed through the intake process.",
 };
 
 export const DATA_CLASSIFICATION_LABEL: Record<DataClassification, string> = {

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -1,0 +1,141 @@
+// lib/requests.ts
+//
+// Postgres read module for the Unified Technology Request registry
+// (tech_requests, Migration 018 / ADR 0005). Mirrors the lib/work.ts
+// pattern: typed rows out, SQL in one place, callers never touch the
+// pool directly.
+//
+// The registry unifies request-shaped rows from every origin. Where a
+// projection table carries richer per-origin detail (the ClickUp
+// rubric score, the site submission tier), the queries join it in at
+// read time — same read-time-join posture as ADR 0004.
+
+import { query } from "./db";
+import {
+  isRequestDisposition,
+  type RequestDisposition,
+  type RequestOrigin,
+} from "./utr";
+
+export interface TechRequest {
+  id: string;
+  origin: RequestOrigin;
+  title: string;
+  needStatement: string | null;
+  requestorName: string | null;
+  requestorUnit: string | null;
+  track: string | null;
+  stage: string | null;
+  disposition: RequestDisposition;
+  decidedAt: string | null;
+  decidedBy: string | null;
+  decisionSummary: string | null;
+  receivedAt: string;
+  /** ClickUp weighted rubric score, when the request came from ClickUp. */
+  weightedScore: number | null;
+  /** Site-assessment tier (1–4), when the request came from the site quiz. */
+  submissionTier: number | null;
+  /** Token for the submitter-visible status page, for site submissions. */
+  submissionId: string | null;
+}
+
+interface TechRequestRow {
+  id: string;
+  origin: RequestOrigin;
+  title: string;
+  need_statement: string | null;
+  requestor_name: string | null;
+  requestor_unit: string | null;
+  track: string | null;
+  stage: string | null;
+  disposition: string;
+  // node-postgres returns TIMESTAMPTZ columns as JS Date objects.
+  decided_at: Date | null;
+  decided_by: string | null;
+  decision_summary: string | null;
+  received_at: Date;
+  weighted_score: string | null;
+  submission_tier: number | null;
+  submission_id: string | null;
+}
+
+function toTechRequest(row: TechRequestRow): TechRequest {
+  return {
+    id: row.id,
+    origin: row.origin,
+    title: row.title,
+    needStatement: row.need_statement,
+    requestorName: row.requestor_name,
+    requestorUnit: row.requestor_unit,
+    track: row.track,
+    stage: row.stage,
+    // Unknown disposition text degrades loudly to 'open' rather than
+    // corrupting the typed union (same posture as ClickUp status
+    // normalization in lib/clickup-data.ts).
+    disposition: isRequestDisposition(row.disposition)
+      ? row.disposition
+      : "open",
+    decidedAt: row.decided_at ? row.decided_at.toISOString() : null,
+    decidedBy: row.decided_by,
+    decisionSummary: row.decision_summary,
+    receivedAt: row.received_at.toISOString(),
+    weightedScore:
+      row.weighted_score === null ? null : Number(row.weighted_score),
+    submissionTier: row.submission_tier,
+    submissionId: row.submission_id,
+  };
+}
+
+/**
+ * Every registry row, newest first, with per-origin detail joined in.
+ * Internal-audience: rows include requestor names and site-submission
+ * content that has no public-visibility decision yet — render only on
+ * auth-gated surfaces (see ADR 0005 open question on visibility).
+ */
+export async function listTechRequests(): Promise<TechRequest[]> {
+  const rows = await query<TechRequestRow>(
+    `SELECT
+       tr.id, tr.origin, tr.title, tr.need_statement,
+       tr.requestor_name, tr.requestor_unit,
+       tr.track, tr.stage, tr.disposition,
+       tr.decided_at, tr.decided_by, tr.decision_summary,
+       tr.received_at,
+       cr.weighted_score,
+       s.tier AS submission_tier,
+       tr.submission_id
+     FROM tech_requests tr
+     LEFT JOIN clickup_requests cr ON cr.clickup_task_id = tr.clickup_task_id
+     LEFT JOIN submissions s ON s.id = tr.submission_id
+     ORDER BY tr.received_at DESC`
+  );
+  return rows.map(toTechRequest);
+}
+
+export interface RequestCounts {
+  total: number;
+  open: number;
+  byOrigin: Record<RequestOrigin, number>;
+}
+
+export async function requestCounts(): Promise<RequestCounts> {
+  const rows = await query<{ origin: RequestOrigin; disposition: string; n: string }>(
+    `SELECT origin, disposition, COUNT(*) AS n
+     FROM tech_requests
+     GROUP BY origin, disposition`
+  );
+  const byOrigin: Record<RequestOrigin, number> = {
+    tdx: 0,
+    clickup: 0,
+    "site-submission": 0,
+    direct: 0,
+  };
+  let total = 0;
+  let open = 0;
+  for (const row of rows) {
+    const n = Number(row.n);
+    total += n;
+    byOrigin[row.origin] += n;
+    if (row.disposition === "open") open += n;
+  }
+  return { total, open, byOrigin };
+}

--- a/lib/utr.ts
+++ b/lib/utr.ts
@@ -1,0 +1,216 @@
+// ============================================================
+// Unified Technology Request — process vocabulary (ADR 0005)
+// ============================================================
+// The typed source of truth for the UTR process vocabularies the
+// registry tables in Migration 018 deliberately leave un-CHECKed:
+// tracks, per-track stages, dispositions, origins, event and link
+// types. Editing a vocabulary here is the taxonomy change; tsc
+// surfaces every consumer (006/007/008 pattern).
+//
+// Source process: the July 2026 "Unified Technology Request Process"
+// draft (one intake form, three tracks, DATA/AI/BUY flags, two gates).
+// Flag and gate vocabularies land with their tables in ADR 0005
+// Phase 3; this module carries what Phase 1 writes and renders.
+
+// ---- Tracks -----------------------------------------------------------
+// Fast Lane / Track A / B / C from the request routing, plus `external`
+// for work tracked in the inventory that predates (or sits outside) the
+// IIDS build pipeline. Also used by the Intake Crosswalk's per-project
+// track derivation (lib/governance-profile.ts).
+
+export type IntakeTrack =
+  | "fast-lane"
+  | "track-a"
+  | "track-b"
+  | "track-c"
+  | "external";
+
+export const INTAKE_TRACK_LABEL: Record<IntakeTrack, string> = {
+  "fast-lane": "Fast Lane",
+  "track-a": "Track A · Standard software",
+  "track-b": "Track B · Built in-house",
+  "track-c": "Track C · Idea / concept",
+  external: "External — tracked",
+};
+
+// Compact labels for dense matrix/table views, where the full
+// "Track B · Built in-house" string is too wide. Pair with the title
+// tooltip (INTAKE_TRACK_TITLE) so the short form stays legible.
+export const INTAKE_TRACK_SHORT: Record<IntakeTrack, string> = {
+  "fast-lane": "Fast Lane",
+  "track-a": "A",
+  "track-b": "B",
+  "track-c": "C",
+  external: "Ext",
+};
+
+export const INTAKE_TRACK_TITLE: Record<IntakeTrack, string> = {
+  "fast-lane": "Fast Lane — low-risk individual purchase, automated approval.",
+  "track-a": "Track A — commercial purchase or subscription requiring governance review.",
+  "track-b": "Track B — fully realized in-house application needing security and operational acceptance.",
+  "track-c": "Track C — early-stage build requiring feasibility assessment and the development queue.",
+  external: "External — owned outside IIDS; tracked in the inventory, not routed through the intake process.",
+};
+
+export function isIntakeTrack(value: unknown): value is IntakeTrack {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(INTAKE_TRACK_LABEL, value)
+  );
+}
+
+// ---- Per-track stages -------------------------------------------------
+// The named boxes on the process flowchart, in order. Nothing writes
+// stages yet (triage under the UTR hasn't started); the vocabulary
+// ships so flag/gate work in later phases writes against typed slugs.
+
+export interface UtrStage {
+  slug: string;
+  label: string;
+}
+
+export const UTR_STAGES: Record<Exclude<IntakeTrack, "external">, UtrStage[]> =
+  {
+    "fast-lane": [
+      { slug: "auto-screen", label: "Automated screen" },
+      { slug: "purchase", label: "Purchase" },
+    ],
+    "track-a": [
+      { slug: "scorecard", label: "Project scorecard" },
+      { slug: "board-first-review", label: "Advisory board first review" },
+      { slug: "assessment", label: "Assessment" },
+      { slug: "approval-decision", label: "Approval decision" },
+      { slug: "decision-documented", label: "Decision documented" },
+      { slug: "prioritization", label: "Prioritization" },
+      { slug: "purchase-or-project", label: "Purchase or project" },
+    ],
+    "track-b": [
+      { slug: "technical-intake", label: "Technical intake" },
+      { slug: "security-review", label: "Security review" },
+      { slug: "flag-reviews", label: "Flag reviews" },
+      { slug: "acceptance-gate", label: "OIT acceptance gate" },
+      { slug: "prioritization", label: "Prioritization" },
+      { slug: "hosting-handoff", label: "Hosting & handoff" },
+      { slug: "operate", label: "Operate" },
+    ],
+    "track-c": [
+      { slug: "build-registration", label: "Build registration" },
+      { slug: "feasibility-scoping", label: "Feasibility & scoping" },
+      { slug: "standards-gate", label: "Early standards gate" },
+      { slug: "design-flag-reviews", label: "Design-stage flag reviews" },
+      { slug: "prioritization", label: "Prioritization" },
+      { slug: "development", label: "Development" },
+    ],
+  };
+
+// ---- Request origins --------------------------------------------------
+// Structural (CHECKed in Migration 018): where a request entered.
+
+export type RequestOrigin = "tdx" | "clickup" | "site-submission" | "direct";
+
+export const REQUEST_ORIGIN_LABEL: Record<RequestOrigin, string> = {
+  tdx: "TDX",
+  clickup: "ClickUp intake",
+  "site-submission": "Site submission",
+  direct: "Direct entry",
+};
+
+// ---- Dispositions -----------------------------------------------------
+// Where a request stands or ended. `routed-to-existing` is the
+// "existing solution meets need" outcome: the request closes AND the
+// requestor joins the existing project's interest pool (Phase 2).
+
+export type RequestDisposition =
+  | "open"
+  | "fast-tracked"
+  | "approved"
+  | "denied"
+  | "withdrawn"
+  | "closed"
+  | "merged"
+  | "converted-to-project"
+  | "routed-to-existing";
+
+export const REQUEST_DISPOSITION_LABEL: Record<RequestDisposition, string> = {
+  open: "Open",
+  "fast-tracked": "Fast-tracked",
+  approved: "Approved",
+  denied: "Not pursued",
+  withdrawn: "Withdrawn",
+  closed: "Closed",
+  merged: "Merged",
+  "converted-to-project": "Became a project",
+  "routed-to-existing": "Routed to existing solution",
+};
+
+/** Dispositions that still need attention (the working queue). */
+export const OPEN_DISPOSITIONS: RequestDisposition[] = ["open"];
+
+export function isRequestDisposition(
+  value: unknown
+): value is RequestDisposition {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(REQUEST_DISPOSITION_LABEL, value)
+  );
+}
+
+// ---- Audit event types ------------------------------------------------
+
+export type RequestEventType =
+  | "received"
+  | "triaged"
+  | "track-assigned"
+  | "stage-advanced"
+  | "flag-raised"
+  | "flag-resolved"
+  | "routed"
+  | "decision"
+  | "merged"
+  | "converted";
+
+// ---- Link types -------------------------------------------------------
+// Request ↔ project (tech_request_project_links).
+
+export type RequestProjectLinkType =
+  | "duplicate-of"
+  | "expanded-use"
+  | "interest"
+  | "converted-to"
+  | "supersedes"
+  | "informs";
+
+// Request ↔ request (tech_request_links).
+
+export type RequestLinkType = "duplicate-of" | "roi-aggregates-to" | "related";
+
+// ---- ROI claim vocabularies (roi_claims) ------------------------------
+// Dimensions extend as the ROI framework the working group is drafting
+// lands; `hard-dollar-replacement` is stable now (the adopted
+// bottom-line definition — see lib/roi-rubric.ts).
+
+export type RoiDimension =
+  | "hard-dollar-replacement"
+  | "capacity-fte"
+  | "cost-avoidance"
+  | "revenue"
+  | "risk-reduction"
+  | "time-savings";
+
+export const ROI_DIMENSION_LABEL: Record<RoiDimension, string> = {
+  "hard-dollar-replacement": "Bottom-line (contract replacement)",
+  "capacity-fte": "Capacity returned (FTE)",
+  "cost-avoidance": "Cost avoidance",
+  revenue: "Revenue",
+  "risk-reduction": "Risk reduction",
+  "time-savings": "Time savings",
+};
+
+export type RoiClaimSource =
+  | "clickup-sync"
+  | "worksheet"
+  | "triage"
+  | "cadso-rubric"
+  | "owner-attested";
+
+export type RoiClaimStatus = "estimated" | "attested" | "verified" | "realized";


### PR DESCRIPTION
## Summary

The registry core from [ADR 0005](docs/adr/0005-unified-technology-request-registry.md): requests become first-class rows with durable identity across origins, an audit trail, and the link/claim substrate the matching and ROI-aggregation phases build on.

**Migration 018** (applied to dev already):
- `tech_requests` — one row per request from any origin (`tdx` / `clickup` / `site-submission` / `direct`), with per-origin idempotent upsert keys, track/stage/disposition routing state, and decision fields. Origin is CHECKed (structural); process vocabularies are deliberately un-CHECKed and owned by `lib/utr.ts` (006/007/008 pattern).
- `tech_request_events` — append-only audit trail.
- `tech_request_links` + `tech_request_project_links` — the request↔request and request↔project graph (project side is a soft slug key, surviving portfolio re-seeds per ADR 0004 §1).
- `roi_claims` — the ROI ledger (subject = project slug or request FK; dimension/source/status vocabularies in `lib/utr.ts`).
- Idempotent backfill: existing ClickUp backlog rows + site submissions (incl. the GEO/Scrunch evaluation records) join the registry with `received` events.

**Ongoing ingestion**: `lib/clickup-sync.ts` upserts registry rows per backlog task (registry rows persist when upstream deletes — memory, not a mirror); the submissions POST route files new assessments in (best-effort, never breaks the submitter flow).

**`lib/utr.ts`**: typed UTR vocabulary — tracks (moved from `governance-profile`, which re-exports for existing consumers), per-track stages from the process deck, dispositions (incl. `routed-to-existing` for the "existing solution meets need" outcome), origins, event/link types, ROI dimensions.

**`/internal/requests`**: the unified queue — origin, requestor, per-origin signal (ClickUp rubric score / site tier), track (— until UTR triage runs), disposition. Internal-only: submission content and requestor names have no public-visibility decision yet (flagged in ADR 0005). `/portfolio/pipeline` is unchanged.

## Verification

- `npm run build` — clean.
- Migration applied against dev: 3 site submissions backfilled with audit events (`clickup_requests` was empty in the dev snapshot; the next host-cron sync populates ClickUp rows through the new path).
- `/internal/requests` verified authed in the browser: stat cards + queue render (GEO evaluation, Tier 2, open · etc.).
- Note for deploy: dev deploys don't run migrations — 018 is already applied to the dev DB, so the container just needs the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)