### PR TITLE
Bring the chat agent's knowledge up to date with the site

### DIFF
--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -31,6 +31,8 @@ import { listProjectsForPriorityTool } from "./tools/list-projects-for-priority"
 import { listOpenIssuesTool } from "./tools/list-open-issues";
 import { searchIssuesTool } from "./tools/search-issues";
 import { getIssueTool } from "./tools/get-issue";
+import { getProjectStatusTool } from "./tools/get-project-status";
+import { listRequestedProjectsTool } from "./tools/list-requested-projects";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
 
 const MAX_ITERATIONS = 6;
@@ -54,6 +56,8 @@ export const publicRegistry: ToolRegistry = createRegistry([
   listOpenIssuesTool,
   searchIssuesTool,
   getIssueTool,
+  getProjectStatusTool,
+  listRequestedProjectsTool,
 ]);
 
 export interface Citation {

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -21,6 +21,9 @@ For every user question:
 
 - Specific project name (e.g. "MindRouter", "OpenERA", "UCM Daily Register"): call **search_portfolio** with the name as the \`query\`, then **lookup_portfolio_entry** on the slug for full detail.
 - "What projects…" / "what is IIDS building" / general portfolio browse: **search_portfolio**.
+- "What's the latest on X" / "how is X going" / "when will X be done" / per-project ROI estimate: **get_project_status** (the freshest synced status summary; if it returns not-found, fall back to **lookup_portfolio_entry**).
+- "What's been requested" / "what's in the queue" / "highest-priority request" / intake backlog: **list_requested_projects**.
+- Money questions — "which projects save money" / "what replaces enterprise systems" / bottom-line ROI: **search_portfolio** (every row carries \`enterpriseSystemReplacement\` — incumbent system, annual cost, renewal date); the roll-up view is [/standards/intake-crosswalk](/standards/intake-crosswalk).
 - "What's blocking X" / "what's stalled" / "where are we waiting": **list_active_blockers** or **search_blockers** (filter by category or named party).
 - "What standards…" / "OIT standards" / "software standards": **list_standards** (optionally filter by status), then **get_standard** for the full detail of a specific item.
 - "What's the latest report" / "show me the briefs" / "what has IIDS published": **list_reports** (optionally filter by kind), then **get_report** for the abstract.

--- a/lib/agent/tools/get-project-status.ts
+++ b/lib/agent/tools/get-project-status.ts
@@ -1,0 +1,75 @@
+// get_project_status — the freshest status narrative for one project,
+// synced from the IIDS-AI4UI ClickUp space (ADR 0004). Complements
+// lookup_portfolio_entry (static registry record) with the dated,
+// generated status summary, the ROI estimate, and projected completion.
+//
+// Public-safe by construction: only the MindRouter-generated summary is
+// passed through — the verbatim comment timeline (`updates`) is
+// internal-only and never reaches the model here.
+
+import "server-only";
+import { getProjectStatusBySlug, getLastSync } from "@/lib/clickup-data";
+import type { ToolHandler, ToolResult } from "./registry";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const getProjectStatusTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "get_project_status",
+      description:
+        "Fetch the latest synced status for a single project: a dated public status summary, the estimated capacity returned (ROI in FTE), projected completion, and sync freshness. Sourced from the IIDS project-management workspace, so it is fresher than the registry description. Use for 'what's the latest on X', 'how is X going', 'when will X be done', or 'what's the ROI estimate for X'. Not every project is tracked there — a not-found result means no synced status exists, not that the project doesn't exist (fall back to lookup_portfolio_entry).",
+      parameters: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description:
+              "The project's URL slug (e.g. 'invoice-processing', 'openera'). Use the slug returned by search_portfolio.",
+          },
+        },
+        required: ["slug"],
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const slug = pickString(rawArgs, "slug");
+    if (!slug) {
+      return { data: { error: "slug is required" }, canonicalUrl: "/portfolio" };
+    }
+    const [status, lastSync] = await Promise.all([
+      getProjectStatusBySlug(slug),
+      getLastSync(),
+    ]);
+    if (!status) {
+      return {
+        data: {
+          found: false,
+          slug,
+          note: "No synced project-management status for this slug. The registry record (lookup_portfolio_entry) may still exist.",
+        },
+        canonicalUrl: `/portfolio/${slug}`,
+      };
+    }
+    return {
+      data: {
+        found: true,
+        slug: status.slug,
+        statusSummary: status.statusSummary,
+        statusSummaryAt: status.statusSummaryAt,
+        roiFte: status.roiFte,
+        roiExplanation: status.roiExplanation,
+        projectedCompletion: status.projectedCompletion,
+        businessUnit: status.businessUnit,
+        syncedAt: status.syncedAt,
+        lastSyncAt: lastSync?.finishedAt ?? null,
+      },
+      canonicalUrl: `/portfolio/${status.slug}`,
+    };
+  },
+};

--- a/lib/agent/tools/list-requested-projects.ts
+++ b/lib/agent/tools/list-requested-projects.ts
@@ -1,0 +1,88 @@
+// list_requested_projects — the scored intake backlog: project requests
+// awaiting a start decision, each scored on the public 11-criterion
+// rubric (ADR 0004; rendered at /portfolio/pipeline). Lets the agent
+// answer "what has been requested", "what's in the queue", and "how are
+// requests prioritized".
+//
+// Submitter names are deliberately omitted — the pipeline surface shows
+// unit and category, not individuals, and the tool mirrors the surface.
+
+import "server-only";
+import {
+  listScoredRequests,
+  getLastSync,
+  type RequestStatus,
+} from "@/lib/clickup-data";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const STATUSES: RequestStatus[] = ["pending", "active", "rejected", "complete"];
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const listRequestedProjectsTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_requested_projects",
+      description:
+        "List requested AI projects in the intake backlog, scored on the public 11-criterion prioritization rubric (strategic impact, feasibility/effort, urgency/buy-in; weighted 0-100). Use for 'what projects have been requested', 'what's waiting to start', 'what's the highest-priority request', or 'has anyone asked for X'. Statuses: pending (in review), active (promoted to a project), rejected (not pursued), complete.",
+      parameters: {
+        type: "object",
+        properties: {
+          status: {
+            type: "string",
+            description:
+              "Optional filter. One of: pending, active, rejected, complete. Omit to return all, grouped by status.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const statusFilter = pickString(rawArgs, "status") as RequestStatus | undefined;
+    const [requests, lastSync] = await Promise.all([
+      listScoredRequests(),
+      getLastSync(),
+    ]);
+
+    const filtered =
+      statusFilter && STATUSES.includes(statusFilter)
+        ? requests.filter((r) => r.status === statusFilter)
+        : requests;
+
+    const rows = [...filtered]
+      .sort((a, b) => (b.weightedScore ?? -1) - (a.weightedScore ?? -1))
+      .map((r) => ({
+        name: r.name,
+        status: r.status,
+        unit: r.unit,
+        category: r.category,
+        feasibility: r.feasibility,
+        weightedScore: r.weightedScore,
+        requested: r.dateCreated,
+      }));
+
+    const countsByStatus: Record<RequestStatus, number> = {
+      pending: 0,
+      active: 0,
+      rejected: 0,
+      complete: 0,
+    };
+    for (const r of requests) countsByStatus[r.status] += 1;
+
+    return {
+      data: {
+        total: requests.length,
+        countsByStatus,
+        returned: rows.length,
+        requests: rows,
+        lastSyncAt: lastSync?.finishedAt ?? null,
+      },
+      canonicalUrl: "/portfolio/pipeline",
+    };
+  },
+};

--- a/lib/agent/tools/list-site-areas.ts
+++ b/lib/agent/tools/list-site-areas.ts
@@ -24,18 +24,20 @@ const SITE_AREAS: SiteArea[] = [
     name: "Projects",
     url: "/portfolio",
     purpose:
-      "The IIDS-coordinated portfolio of AI projects across UI units. Each project lists its home unit, operational owner, lifecycle status, and active blockers.",
+      "The IIDS-coordinated portfolio of AI projects across UI units. Each project lists its home unit, operational owner, lifecycle status, and active blockers. Browse by problem area with the category filter chips, or by lifecycle stage with the two-tier stage filter.",
     example_questions: [
       "What projects is IIDS working on?",
       "Who owns DGX Stack?",
       "What's the status of MindRouter?",
     ],
-  },
-  {
-    name: "Explore",
-    url: "/explore",
-    purpose:
-      "Browse the portfolio by problem area instead of by home unit. Categories include automation, communication, decision support, and others.",
+    sub_areas: [
+      {
+        name: "Requested projects",
+        url: "/portfolio/pipeline",
+        purpose:
+          "The scored intake backlog — project requests awaiting a start decision, ranked on the public 11-criterion prioritization rubric.",
+      },
+    ],
   },
   {
     name: "Submit a Project",
@@ -64,6 +66,30 @@ const SITE_AREAS: SiteArea[] = [
         url: "/standards/strategic-plan",
         purpose:
           "Maps portfolio projects to the UI Strategic Plan pillars and priorities. Bidirectional — see which projects advance each priority.",
+      },
+      {
+        name: "Strategic Plan Map",
+        url: "/standards/strategic-plan/map",
+        purpose:
+          "Coverage map of the strategic plan — which priorities have portfolio projects advancing them and where the gaps are.",
+      },
+      {
+        name: "Intake Crosswalk",
+        url: "/standards/intake-crosswalk",
+        purpose:
+          "Every project profiled in the Unified Technology Request vocabulary: intake track, data touched, AI-risk posture, funding, and bottom-line ROI (hard-dollar savings from replacing enterprise software contracts).",
+      },
+      {
+        name: "OIT Pathway",
+        url: "/standards/oit-pathway",
+        purpose:
+          "The OIT Enterprise AI Development Framework and AI-Assisted Builder Guide: the six-stage lifecycle with gates for teams deploying onto OIT-managed infrastructure, and where our projects sit in it.",
+      },
+      {
+        name: "Operational Excellence Survey",
+        url: "/standards/operational-excellence",
+        purpose:
+          "Explorable results of the Operational Excellence survey — themes and unit responses that inform where AI work is pointed.",
       },
     ],
   },

--- a/lib/agent/tools/lookup-portfolio-entry.ts
+++ b/lib/agent/tools/lookup-portfolio-entry.ts
@@ -5,6 +5,7 @@
 
 import "server-only";
 import { getApplicationBySlug } from "@/lib/work";
+import { publicStageFromStatus } from "@/lib/portfolio";
 import type { ToolHandler, ToolResult } from "./registry";
 
 function pickString(args: Record<string, unknown>, key: string): string | undefined {
@@ -18,7 +19,7 @@ export const lookupPortfolioEntryTool: ToolHandler = {
     function: {
       name: "lookup_portfolio_entry",
       description:
-        "Fetch the full record for a single project by its slug. Returns description, features, owners, status detail, repo/docs/live URLs, and currently active blockers (public-tier text only). Use this when the user asks about a specific project by name and search_portfolio returned the slug.",
+        "Fetch the full record for a single project by its slug. Returns description, features, owners, status detail, deployment plan, enterprise-system-replacement facts (the hard-dollar bottom-line ROI: incumbent system, annual cost, renewal date), repo/docs/live URLs, and currently active blockers (public-tier text only). Use this when the user asks about a specific project by name and search_portfolio returned the slug.",
       parameters: {
         type: "object",
         properties: {
@@ -59,6 +60,9 @@ export const lookupPortfolioEntryTool: ToolHandler = {
         operationalOwners: app.operationalOwners,
         buildParticipants: app.buildParticipants,
         status: app.status,
+        publicStage: publicStageFromStatus(app.status),
+        proposedDeploymentEnvironment: app.proposedDeploymentEnvironment,
+        enterpriseSystemReplacement: app.enterpriseSystemReplacement,
         iidsSponsor: app.iidsSponsor || null,
         institutionalReviewStatus: app.institutionalReviewStatus ?? null,
         productionScope: app.productionScope ?? null,

--- a/lib/agent/tools/search-portfolio.ts
+++ b/lib/agent/tools/search-portfolio.ts
@@ -53,7 +53,7 @@ export const searchPortfolioTool: ToolHandler = {
           status: {
             type: "string",
             description:
-              "Optional filter by lifecycle status. One of: idea, approved, building, prototype, piloting, production, maintained, sunsetting, archived, tracked.",
+              "Optional filter by lifecycle status. One of: idea, scoping, approved, building, prototype, piloting, production, maintained, paused, sunsetting, archived, tracked.",
           },
           limit: {
             type: "integer",


### PR DESCRIPTION
## Summary

Closes the coverage gaps from the chat-agent investigation: the agent's live data paths were fine, but its tool surface and hardcoded IA map lagged the site.

- **`list_site_areas`** — drops retired `/explore` (ADR 0003; it 308s to /portfolio), adds Requested Projects (`/portfolio/pipeline`), Strategic Plan Map, Intake Crosswalk, OIT Pathway, and Operational Excellence sub-areas.
- **`lookup_portfolio_entry`** — now projects `enterpriseSystemReplacement` (the bottom-line ROI facts), `proposedDeploymentEnvironment`, and `publicStage`; `search_portfolio`'s status enum learns `scoping`/`paused`.
- **New `get_project_status`** — per-project ClickUp-synced public status summary, ROI-FTE, projected completion, sync freshness. The verbatim comment timeline is never passed to the model (ADR 0004 amended boundary holds).
- **New `list_requested_projects`** — the scored intake backlog with rubric weighted scores and status buckets; submitter names omitted, mirroring what `/portfolio/pipeline` renders.
- **System prompt** — cheatsheet lines routing status/backlog/money questions to the new tools; "which projects save money" now resolves via replacement facts with the crosswalk as the roll-up citation.

## Verification

- `npm run build` — clean.
- Direct tool execution (tsx, react-server condition): lookup returns VERAS $150k/renewal facts + public stage; site map contains no `/explore` and includes crosswalk/pipeline; both ClickUp tools verified **against the remote dev DB**: status summary + 0.7 FTE for invoice-processing, backlog 40 requests (26 pending, top score 74.5), and graceful not-found on an empty database.
- End-to-end `/api/ask` check happens on dev post-deploy (MindRouter creds live there only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)