### PR TITLE
Give the chat agent the Operational Excellence survey

### DIFF
--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -33,6 +33,8 @@ import { searchIssuesTool } from "./tools/search-issues";
 import { getIssueTool } from "./tools/get-issue";
 import { getProjectStatusTool } from "./tools/get-project-status";
 import { listRequestedProjectsTool } from "./tools/list-requested-projects";
+import { lookupSurveyThemesTool } from "./tools/lookup-survey-themes";
+import { listSurveyCandidateProjectsTool } from "./tools/list-survey-candidate-projects";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
 
 const MAX_ITERATIONS = 6;
@@ -58,6 +60,8 @@ export const publicRegistry: ToolRegistry = createRegistry([
   getIssueTool,
   getProjectStatusTool,
   listRequestedProjectsTool,
+  lookupSurveyThemesTool,
+  listSurveyCandidateProjectsTool,
 ]);
 
 export interface Citation {

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -23,6 +23,7 @@ For every user question:
 - "What projects…" / "what is IIDS building" / general portfolio browse: **search_portfolio**.
 - "What's the latest on X" / "how is X going" / "when will X be done" / per-project ROI estimate: **get_project_status** (the freshest synced status summary; if it returns not-found, fall back to **lookup_portfolio_entry**).
 - "What's been requested" / "what's in the queue" / "highest-priority request" / intake backlog: **list_requested_projects**.
+- Faculty/staff or student survey — "what did the survey say" / pain points / "what are people asking for": **lookup_survey_themes**. "Which projects emerge from the survey" / unmet demand / survey-driven gaps: **list_survey_candidate_projects** (these are triage proposals, never approved work — say so).
 - Money questions — "which projects save money" / "what replaces enterprise systems" / bottom-line ROI: **search_portfolio** (every row carries \`enterpriseSystemReplacement\` — incumbent system, annual cost, renewal date); the roll-up view is [/standards/intake-crosswalk](/standards/intake-crosswalk).
 - "What's blocking X" / "what's stalled" / "where are we waiting": **list_active_blockers** or **search_blockers** (filter by category or named party).
 - "What standards…" / "OIT standards" / "software standards": **list_standards** (optionally filter by status), then **get_standard** for the full detail of a specific item.

--- a/lib/agent/tools/list-survey-candidate-projects.ts
+++ b/lib/agent/tools/list-survey-candidate-projects.ts
@@ -1,0 +1,80 @@
+// list_survey_candidate_projects — the Operational Excellence survey's
+// demand signal turned into a potential-projects inventory (phase 2 of
+// the survey ingest). Each candidate names the survey clusters that
+// evidence it, its "by problem" category, and — honestly — how much of
+// the demand the current portfolio already covers. These are proposals
+// for triage, not commitments: no owners, dates, or ROI are asserted.
+
+import "server-only";
+import {
+  candidateProjectsByCoverage,
+  CANDIDATE_COVERAGE_LABEL,
+} from "@/lib/surveys/candidate-projects";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const CANONICAL_URL = "/standards/operational-excellence";
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const listSurveyCandidateProjectsTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "list_survey_candidate_projects",
+      description:
+        "Potential projects derived from the Operational Excellence survey's demand signal — the data-backed answer to 'what projects emerge from the faculty/staff (or student) survey'. Each candidate carries the problem in respondents' terms, a proposed shape, the survey clusters evidencing it, a coverage verdict against the current portfolio (gap = no current project, partial, covered), and related portfolio slugs. These are proposals awaiting triage — never present them as approved or resourced work.",
+      parameters: {
+        type: "object",
+        properties: {
+          coverage: {
+            type: "string",
+            description:
+              "Optional filter: 'gap' (unmet demand), 'partial', or 'covered'. Omit for all, sorted gap-first.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const coverageFilter = pickString(rawArgs, "coverage");
+    const all = candidateProjectsByCoverage();
+    const filtered =
+      coverageFilter === "gap" ||
+      coverageFilter === "partial" ||
+      coverageFilter === "covered"
+        ? all.filter((c) => c.coverage === coverageFilter)
+        : all;
+
+    return {
+      data: {
+        total: all.length,
+        returned: filtered.length,
+        note: "Proposals derived from survey demand, awaiting CADSO/IIDS triage — not commitments.",
+        candidates: filtered.map((c) => ({
+          id: c.id,
+          title: c.title,
+          problem: c.problem,
+          shape: c.shape,
+          audiences: c.audiences,
+          evidenceClusters: c.clusters,
+          workCategory: c.workCategory,
+          coverage: c.coverage,
+          coverageLabel: CANDIDATE_COVERAGE_LABEL[c.coverage],
+          relatedProjects: (c.relatedProjectSlugs ?? []).map(
+            (slug) => `/portfolio/${slug}`
+          ),
+          note: c.note ?? null,
+        })),
+      },
+      canonicalUrl: CANONICAL_URL,
+      links: filtered
+        .flatMap((c) => c.relatedProjectSlugs ?? [])
+        .filter((slug, i, arr) => arr.indexOf(slug) === i)
+        .map((slug) => ({ label: slug, url: `/portfolio/${slug}` })),
+    };
+  },
+};

--- a/lib/agent/tools/lookup-survey-themes.ts
+++ b/lib/agent/tools/lookup-survey-themes.ts
@@ -1,0 +1,99 @@
+// lookup_survey_themes — the Operational Excellence survey (October
+// 2025): what faculty/staff and students actually asked for, as
+// question-clusters with summaries and sub-themes. Everything returned
+// here is already published on /standards/operational-excellence —
+// verbatims pass through the same privacy handling as the page
+// (withheld responses never enter the module; featured quotes are
+// hand-curated).
+
+import "server-only";
+import {
+  OPERATIONAL_EXCELLENCE_META,
+  clustersFor,
+  getCluster,
+  featuredFor,
+  responseCount,
+} from "@/lib/surveys/operational-excellence";
+import type { SurveyAudience, SurveyClusterKey } from "@/lib/surveys/types";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const CANONICAL_URL = "/standards/operational-excellence";
+const AUDIENCES: SurveyAudience[] = ["faculty", "student"];
+
+function pickString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupSurveyThemesTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_survey_themes",
+      description:
+        "The Operational Excellence survey (fielded October 2025; 113 faculty/staff + 54 student respondents): the questions asked, summarized themes, and sub-themes per question-cluster. Use for 'what did the faculty/staff survey say', 'what are people asking for', 'what are the biggest pain points'. Call with no arguments for the full theme map; pass audience + cluster for one cluster's detail including representative verbatim quotes. For which PROJECTS the survey demand points at, use list_survey_candidate_projects instead.",
+      parameters: {
+        type: "object",
+        properties: {
+          audience: {
+            type: "string",
+            description: "Optional: 'faculty' (includes staff) or 'student'.",
+          },
+          cluster: {
+            type: "string",
+            description:
+              "Optional cluster key for one cluster's full detail (requires audience). Faculty: processes, data-tools, talent, collaboration, additional. Student: processes, data-access, technology, collaboration, additional.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const audience = pickString(rawArgs, "audience") as SurveyAudience | undefined;
+    const clusterKey = pickString(rawArgs, "cluster") as SurveyClusterKey | undefined;
+
+    if (audience && clusterKey) {
+      const cluster = getCluster(audience, clusterKey);
+      if (!cluster) {
+        return {
+          data: { found: false, audience, cluster: clusterKey },
+          canonicalUrl: CANONICAL_URL,
+        };
+      }
+      return {
+        data: {
+          found: true,
+          audience,
+          cluster: cluster.key,
+          label: cluster.label,
+          question: cluster.question,
+          summary: cluster.summary,
+          subThemes: cluster.subThemes,
+          responseCount: responseCount(audience, clusterKey),
+          featuredVerbatims: featuredFor(audience, clusterKey).map((r) => r.text),
+        },
+        canonicalUrl: CANONICAL_URL,
+      };
+    }
+
+    const audiences = audience ? [audience] : AUDIENCES;
+    return {
+      data: {
+        survey: OPERATIONAL_EXCELLENCE_META,
+        clusters: audiences.flatMap((a) =>
+          clustersFor(a).map((c) => ({
+            audience: a,
+            cluster: c.key,
+            label: c.label,
+            question: c.question,
+            summary: c.summary,
+            subThemes: c.subThemes.map((s) => s.label),
+            responseCount: responseCount(a, c.key),
+          }))
+        ),
+      },
+      canonicalUrl: CANONICAL_URL,
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Closes the gap surfaced by a real chat transcript: asked *"what are the most impactful projects that emerge from the faculty/staff survey data?"*, the agent couldn't see that the survey — and its phase-2 candidate-projects inventory — is already published at `/standards/operational-excellence`.

- **`lookup_survey_themes`** — survey meta (Oct 2025, 113 faculty/staff + 54 students), per-audience question clusters with summaries and sub-themes; per-cluster detail includes response counts and the hand-curated featured verbatims. Same privacy boundary as the public page: withheld responses never enter the module, redactions already applied.
- **`list_survey_candidate_projects`** — the data-backed answer to the transcript's question: the 8 demand-signal proposals from `lib/surveys/candidate-projects.ts` with problem/shape, evidencing clusters, coverage verdicts (2 gap · 4 partial · 2 covered), and related portfolio links. Tool description and cheatsheet both insist these are triage proposals, never approved work.
- Cheatsheet routes "what did the survey say" vs. "which projects emerge from it" to the right tool.

## Verification

- `npm run build` — clean.
- Direct tool execution: 10 clusters returned; faculty/processes detail = 6 sub-themes, 6 verbatims, 111 responses; candidates = 8 total, gap filter returns the 2 gaps (Onboarding & access automation, Student resource navigator).
- Live `/api/ask` re-test of the original question happens on dev post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)