### PR TITLE
Correct stale statuses, retire Core4 language, add FY-aware ROI framing

### DIFF
--- a/app/standards/intake-crosswalk/page.tsx
+++ b/app/standards/intake-crosswalk/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/portfolio";
 import {
   ROI_RUBRIC_READY,
+  fiscalYearLabel,
   formatAnnualUsd,
   formatAnnualUsdCompact,
   formatRenewalDate,
@@ -87,7 +88,7 @@ function BottomLineValue({ roi }: { roi: BottomLineRoi }) {
       <span className="font-semibold">{formatAnnualUsd(roi.annualUsd)}</span>{" "}
       &mdash; replaces {roi.systemName}
       {roi.renewalDate
-        ? ` (contract renews ${formatRenewalDate(roi.renewalDate)})`
+        ? ` (contract renews ${formatRenewalDate(roi.renewalDate)} — savings bank in ${fiscalYearLabel(roi.renewalDate)})`
         : ""}
     </span>
   );
@@ -98,7 +99,7 @@ function BottomLineValue({ roi }: { roi: BottomLineRoi }) {
 function BottomLineCell({ roi }: { roi: BottomLineRoi }) {
   const title = `Replaces ${roi.systemName}${
     roi.renewalDate
-      ? ` — contract renews ${formatRenewalDate(roi.renewalDate)}`
+      ? ` — contract renews ${formatRenewalDate(roi.renewalDate)} (savings bank in ${fiscalYearLabel(roi.renewalDate)})`
       : ""
   }`;
   return (
@@ -605,7 +606,9 @@ export default async function IntakeCrosswalkPage({
             </span>{" "}
             across {coverage.bottomLineCount} enterprise-system replacements
             &mdash; hard-dollar savings from retiring existing software
-            contracts.
+            contracts. UI&rsquo;s fiscal year runs July&nbsp;1 &ndash;
+            June&nbsp;30; each contract&rsquo;s savings bank in the fiscal
+            year its renewal lapses, not on approval.
           </p>
         )}
         <p className="mt-3 border-t border-hairline pt-3 text-xs text-ink-subtle">

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ApplicationWithBlockers, Blocker } from "@/lib/work";
 import { blockerCategoryLabels, daysSince } from "@/lib/work";
 import type { ClickUpProjectStatus } from "@/lib/clickup-data";
+import { fiscalYearLabel } from "@/lib/roi-rubric";
 import SyncFreshness, { formatSyncDate } from "@/components/SyncFreshness";
 import {
   OPERATIONAL_LABEL,
@@ -90,7 +91,9 @@ function replacementSummary(replacement: EnterpriseSystemReplacement) {
   return {
     headline: `Replaces ${replacement.systemName}`,
     detail: `${usd.format(replacement.annualCostUsd)} per year${
-      renewal ? ` · current agreement renews ${renewal}` : ""
+      renewal && replacement.renewalDate
+        ? ` · current agreement renews ${renewal} — savings bank in ${fiscalYearLabel(replacement.renewalDate)}`
+        : ""
     }`,
   };
 }

--- a/docs/adr/0001-product-lifecycle-taxonomy.md
+++ b/docs/adr/0001-product-lifecycle-taxonomy.md
@@ -31,8 +31,8 @@ The day-to-day status IIDS tracks. Each state has a verification rule that can b
 | `building` | Building | `repoUrl` set; `lastCommitDate` within last 60 days; no `liveUrl` (or `liveUrl` is staging-only — flagged via a `liveUrlIsStaging: true`); `pilotCohort` empty. |
 | `prototype` | Prototype | Demo-able; `liveUrl` may be set (often staging). `pilotCohort` empty. **Either** `lastCommitDate` is older than 30 days **OR** `featureComplete: true` is explicitly set. |
 | `piloting` | Piloting | `liveUrl` accessible to a **named cohort**. `pilotCohort` populated with `size > 0` and a bounded `scope` (single unit OR named individuals OR an explicit "limited beta" descriptor). |
-| `production` | Production | A **publicly-accessible artifact** exists beyond the original pilot cohort: either (a) a `liveUrl` reachable beyond the pilot, or (b) a public `repoUrl` (`isPrivateRepo: false` or unset) where the repo itself is the consumable deliverable — the path that covers infrastructure, scaffolds, and self-hostable appliances. `productionScope` is `"home-unit"` (entire home unit's users), `"institution-wide"`, or `"external"` (institutional + outside-UI deployments). `supportContact` populated. |
-| `maintained` | Maintained | Inherits production's accessibility rule (liveUrl OR public repo). **No commits to `main` in the last 90 days.** No open feature issues — only `bug`-, `security`-, or `chore`-labeled issues. |
+| `production` | Production | A **publicly-accessible artifact** exists beyond the original pilot cohort: either (a) a `liveUrl` reachable beyond the pilot, or (b) a public `repoUrl` (`isPrivateRepo: false` or unset) where the repo itself is the consumable deliverable — the path that covers infrastructure, scaffolds, and self-hostable appliances, or (c) operation on an OIT-managed environment (`proposedDeploymentEnvironment` in the `oit-*` family) — the path that covers SSO-gated internal enterprise apps such as Nexus modules. `productionScope` is `"home-unit"` (entire home unit's users), `"institution-wide"`, or `"external"` (institutional + outside-UI deployments). `supportContact` populated. |
+| `maintained` | Maintained | Inherits production's accessibility rule (liveUrl, public repo, or OIT-managed environment). **No commits to `main` in the last 90 days.** No open feature issues — only `bug`-, `security`-, or `chore`-labeled issues. |
 | `sunsetting` | Sunsetting | `sunsetDate` set (ISO date, future or recent past). `replacedBy` populated — either a successor project `slug` or the literal string `manual-process`. |
 | `archived` | Archived | `liveUrl` returns 404, is null, or domain is dead (or, for repo-as-artifact deliverables, `repoUrl` is archived/deleted). Service stopped. Record kept for institutional memory. |
 | `tracked` *(meta)* | Tracked | Not built by IIDS. `trackingOnly: true`. Bypasses the operational ladder; the public stage is its own bucket. |
@@ -51,7 +51,7 @@ What stakeholders see. Rolls up automatically from operational state. Stable, lo
 
 The operational status remains visible as a **secondary chip** on portfolio cards (e.g. `Live · Piloting`). On the landing's stat strip and `/explore`, only public stage shows.
 
-## Three sub-decisions resolved
+## Sub-decisions resolved
 
 ### 1. Governance domain name → `iids-portfolio`
 
@@ -70,6 +70,22 @@ Pure commit-cadence has false positives — a healthy maintained project with sp
 ### 4. `production` accepts a public repo as the artifact, not just `liveUrl`
 
 The first draft of the rules required a `liveUrl` for `production`. That broke for two real cases in the portfolio: `template-app` is a scaffold consumed by cloning, and `dgx-stack` is a self-hostable appliance — neither is a hosted webapp, and both are honestly in production use. The semantic the rule is reaching for is "**is there a publicly-accessible artifact someone outside the build team can use right now?**" For hosted apps, that's `liveUrl`. For infrastructure, scaffolds, and self-hostable deliverables, the public repo *is* the consumable artifact. Either satisfies the rule. The verifier checks that `repoUrl` is set and `isPrivateRepo` is not true — a private repo with no liveUrl fails, as it should.
+
+### 5. OIT-managed production counts as accessible (2026-07-24 amendment)
+
+The Retroactive Payment Requests module went into production on OIT's
+Nexus platform in July 2026 — SSO-gated, used daily by Payroll, private
+repo, and (initially) no recorded URL. Under the original rule it could
+not honestly claim `production` even though it plainly is. The semantic
+gap: sub-decision #4's "publicly-accessible artifact" predates
+OIT-hosted internal enterprise apps, which are *deliberately* not
+anonymous-accessible. For those, the operated platform is the artifact:
+an `oit-*` `proposedDeploymentEnvironment` means OIT has accepted,
+hosts, and monitors the app on managed infrastructure. The verifier
+therefore also accepts `proposedDeploymentEnvironment` starting with
+`oit-` for `production`/`maintained` accessibility (with
+`productionScope` and `supportContact` still required). A liveUrl
+should still be recorded whenever one exists.
 
 ## Schema additions to `Project`
 
@@ -234,3 +250,13 @@ names to satisfy `idea`.
 
 **Follow-up.** Same as `paused`: add `scoping` to the vendored
 `iids-portfolio` ProjectStatus vocabulary upstream.
+
+### 2026-07-24 — OIT-managed production accessibility (sub-decision #5)
+
+**Context.** Retroactive Payment Requests reached production on OIT's
+Nexus platform — SSO-gated with a private repo — and failed the
+production accessibility rule despite being in daily use by Payroll.
+
+**Decision.** Recorded as sub-decision #5 above: an `oit-*`
+`proposedDeploymentEnvironment` satisfies `production`/`maintained`
+accessibility; the OIT-operated platform is the artifact.

--- a/lib/portfolio-verification.ts
+++ b/lib/portfolio-verification.ts
@@ -50,8 +50,13 @@ function hasPubliclyAccessibleArtifact(i: Project): boolean {
   // ADR sub-decision #4: production-grade accessibility is satisfied by
   // either a liveUrl OR a public repoUrl (the repo IS the deliverable
   // for infrastructure / scaffolds / self-hostable appliances).
+  // ADR sub-decision #5 (2026-07-24 amendment): production operated on
+  // an OIT-managed environment (`oit-*`) also satisfies it — internal
+  // enterprise apps (e.g. Nexus modules) are SSO-gated with no anonymous
+  // URL; the operated platform is the artifact.
   if (i.liveUrl && !i.liveUrlIsStaging) return true;
   if (i.repoUrl && !i.isPrivateRepo) return true;
+  if (i.proposedDeploymentEnvironment.startsWith("oit-")) return true;
   return false;
 }
 
@@ -224,13 +229,13 @@ const verifyPiloting: Verifier = (i) => {
 
 const verifyProduction: Verifier = (i) => {
   const problems: VerificationProblem[] = [];
-  const rule = "production: liveUrl OR public repoUrl (the repo as artifact); productionScope set; supportContact set.";
+  const rule = "production: liveUrl OR public repoUrl (the repo as artifact) OR OIT-managed deployment (oit-*); productionScope set; supportContact set.";
   if (!hasPubliclyAccessibleArtifact(i)) {
     problems.push(
       problem(
         i,
         rule,
-        "claims `production` but has no publicly-accessible artifact — needs a liveUrl, or a public repoUrl (with isPrivateRepo unset/false) for repo-as-artifact deliverables."
+        "claims `production` but has no accessible artifact — needs a liveUrl, a public repoUrl (with isPrivateRepo unset/false) for repo-as-artifact deliverables, or an OIT-managed (oit-*) deployment environment."
       )
     );
   }
@@ -245,7 +250,7 @@ const verifyProduction: Verifier = (i) => {
 
 const verifyMaintained: Verifier = (i) => {
   const problems: VerificationProblem[] = [];
-  const rule = "maintained: production accessibility (liveUrl or public repo); no commits to main in last 90d.";
+  const rule = "maintained: production accessibility (liveUrl, public repo, or OIT-managed deployment); no commits to main in last 90d.";
   if (!hasPubliclyAccessibleArtifact(i)) {
     problems.push(problem(i, rule, "claims `maintained` but has no publicly-accessible artifact (liveUrl or public repoUrl)."));
   }

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -322,7 +322,7 @@ export const projects: Project[] = [
     tagline:
       "Multi-state payroll withholding tracking for out-of-state employees.",
     description:
-      "Tracks state tax withholdings for UI employees working outside Idaho — including international W-4 cases routed through Payroll — and gets them remitted to the right state authorities. Automates the data transfer across systems that Payroll previously reconciled by hand. The project is paused until the Core4 dashboard is ready to accept additional modules.",
+      "Tracks state tax withholdings for UI employees working outside Idaho — including international W-4 cases routed through Payroll — and gets them remitted to the right state authorities. Automates the data transfer across systems that Payroll previously reconciled by hand. The project is feature-complete and paused pending onboarding onto OIT's Nexus platform, following the Retroactive Payment Requests module.",
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [
       { name: "Cretia Bunney" },
@@ -349,26 +349,31 @@ export const projects: Project[] = [
     tagline:
       "Electronic retro-pay intake and payroll analyst dashboard.",
     description:
-      "Replaces the paper/email retroactive payment request process with a validated electronic submission flow plus a dashboard for payroll analysts. Submissions are checked for completeness and verified against Banner data before they reach an analyst, so corrections happen at intake instead of mid-process. As of July 2026, several pull requests are ready for testing and temporary reactivation of the test environment has been requested.",
+      "Replaces the paper/email retroactive payment request process with a validated electronic submission flow plus a dashboard for payroll analysts. Submissions are checked for completeness and verified against Banner data before they reach an analyst, so corrections happen at intake instead of mid-process. Deployed on OIT's Nexus platform and in production use by Payroll since July 2026; payroll-staff feedback now drives the enhancement backlog.",
     homeUnits: ["Division of Financial Affairs"],
     operationalOwners: [
       { name: "Lisa Davis" },
       { name: "Cretia Bunney" },
     ],
     buildParticipants: ["IIDS"],
-    status: "building",
+    status: "production",
     visibility: "Public",
-    proposedDeploymentEnvironment: "to-be-determined",
+    proposedDeploymentEnvironment: "oit-hosted",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Colin Addington",
+    productionScope: "home-unit",
+    supportContact: "Colin Addington",
     repoUrl: "https://github.com/ui-insight/reactfast",
     isPrivateRepo: true,
+    liveUrl: "https://nexus.uidaho.edu",
+    usageNote:
+      "In production use by Payroll on OIT's Nexus platform since July 2026.",
     operationalFunction:
       "Validated intake for retroactive pay requests (completeness checks, Banner verification) feeding a payroll-analyst dashboard for processing late or missed hours.",
     operationalExcellenceOutcome:
       "Employees are paid correctly with less back-and-forth: an estimated 0.3 FTE returned by shortening the process and catching incomplete submissions at intake.",
-    relatedSlugs: ["invoice-processing"],
+    relatedSlugs: ["invoice-processing", "nexus"],
     workCategories: ["process", "reconciliation"],
     strategicPlanAlignment: ["E.2"],
   },
@@ -606,7 +611,7 @@ export const projects: Project[] = [
     tagline:
       "Open electronic research administration system — canonical UDM implementor for sponsored research.",
     description:
-      "Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures. As of July 2026, the team has outlined the VERAS-replacement MVP and the required dual-operation period, with three to four developers contributing. The renamed OSP module is in development, with its sub-module access structure awaiting Microsoft Entra group creation; transfer of the repository to the new UI AI for UI GitHub organization is also pending.",
+      "Institutional sponsored-research administration system, operated by IIDS for the Office of Research and Economic Development. The canonical implementor of the AI4RA Unified Data Model in research administration: 32 tables spanning 20 canonical UDM tables and 12 project-specific extensions. AI4RA Core dual-destiny project; designed to be deployable beyond UI as the partnership matures. As of July 2026, the team has outlined the VERAS-replacement MVP and the required dual-operation period, with three to four developers contributing; transfer of the repository to the ui-AI4UI GitHub organization is pending.",
     homeUnits: ["Office of Research and Economic Development"],
     operationalOwners: [
       { name: "Sarah Martonick", title: "UI implementation owner" },
@@ -1040,7 +1045,7 @@ export const projects: Project[] = [
     tagline:
       "OIT-managed application platform where UI application modules are deployed.",
     description:
-      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT's Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT); OpenERA and UCM Daily Register are the first IIDS-built applications entering that pathway. Nexus continues to receive regular updates; recurring security-review tickets and approval steps on pull requests are the main reported delivery friction.",
+      "React + FastAPI application platform running on OIT-managed secure infrastructure, built collaboratively by OIT and IIDS. Nexus is the institutional template where University of Idaho application modules are deployed, providing a shared, audited, and security-hardened runtime for AI-enabled and traditional unit-level apps. Complements TEMPLATE-app: where TEMPLATE-app is the development scaffold, Nexus is the production landing zone. Governed by OIT's Enterprise AI Development Framework (the approved tech stack) and AI-Assisted Builder Guide (the six-stage pathway for teams outside OIT). The Retroactive Payment Requests module is deployed on Nexus and in production use by Payroll; OpenERA and UCM Daily Register are next through the pathway. Nexus continues to receive regular updates; recurring security-review tickets and approval steps on pull requests are the main reported delivery friction.",
     homeUnits: ["Office of Information Technology"],
     operationalOwners: [
       { name: "Kali Armitage" },
@@ -1054,12 +1059,18 @@ export const projects: Project[] = [
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
     trackingOnly: true,
+    liveUrl: "https://nexus.uidaho.edu",
     tech: ["React", "FastAPI", "OIT managed infrastructure"],
     operationalFunction:
       "Hosts UI application modules on OIT-managed secure infrastructure with a consistent runtime, identity, and security baseline. Target deployment surface for new UI apps that need institutional hosting.",
     operationalExcellenceOutcome:
       "Standardizes where institutional application modules live. Shared security posture, audit trail, and operational footprint across UI units. Reduces per-app hosting overhead and fragmentation.",
-    relatedSlugs: ["template-app", "openera", "ucm-daily-register"],
+    relatedSlugs: [
+      "template-app",
+      "openera",
+      "ucm-daily-register",
+      "retroactive-payment-requests",
+    ],
     workCategories: ["ai-infrastructure"],
     strategicPlanAlignment: ["E.1", "E.4"],
   },

--- a/lib/roi-rubric.ts
+++ b/lib/roi-rubric.ts
@@ -74,6 +74,19 @@ export function formatAnnualUsdCompact(amount: number): string {
   return `$${thousands.toLocaleString("en-US")}k/yr`;
 }
 
+/**
+ * "FY27" — the UI fiscal year a date falls in. UI fiscal years run
+ * July 1 – June 30 and are named for the ending calendar year
+ * (Jul 1 2026 – Jun 30 2027 = FY27). Savings from a contract
+ * retirement land in the fiscal year containing its renewal date, so
+ * renewal labels carry the FY to keep ROI timing honest.
+ */
+export function fiscalYearLabel(isoDate: string): string {
+  const [year, month] = isoDate.split("-").map(Number);
+  const fyEndYear = month >= 7 ? year + 1 : year;
+  return `FY${String(fyEndYear % 100).padStart(2, "0")}`;
+}
+
 /** "Mar 31, 2027" — renewal dates in running text. */
 export function formatRenewalDate(isoDate: string): string {
   const [year, month, day] = isoDate.split("-").map(Number);


### PR DESCRIPTION
Data-integrity cleanup surfaced while drafting the presidential status brief.

## What was wrong

1. **RPR was stale.** Retroactive Payment Requests is deployed on OIT's Nexus platform and in daily production use by Payroll — the entry still said "building" with "PRs ready for testing." Now `production`, with the Nexus liveUrl, scope, support contact, and an honest usage note.
2. **Core4 is dead vocabulary.** Out-of-State Tax Tracking was "paused until the Core4 dashboard is ready" — reworded to the actual dependency: onboarding onto Nexus, following the RPR module.
3. **OpenERA ≠ Nexus OSP module.** OpenERA's description had absorbed status text about the Nexus platform's OSP module (Entra group waits, sub-module access). That module is deliberately not tracked in this inventory; the sentence is gone. The ui-AI4UI repo transfer note stays.
4. **ROI timing was FY-blind.** UI fiscal years run July 1 – June 30. New `fiscalYearLabel()` in `lib/roi-rubric.ts`; the Intake Crosswalk (cards, matrix titles, coverage strip) and project detail replacement lines now state the FY each contract's savings bank in — InfoReady + VERAS in FY27, Axiom in FY28.

## ADR 0001 amendment (sub-decision #5)

RPR could not honestly claim `production`: private repo, SSO-gated platform, no anonymous URL. Production operated on an OIT-managed (`oit-*`) environment now satisfies the accessibility rule — the operated platform is the artifact. Verifier updated to match; `productionScope` + `supportContact` still required.

## Also done (outside the diff)

- Remote dev `applications` reseeded from the corrected inventory.
- Three stale `clickup_projects.status_summary` rows hand-corrected on dev (RPR, Out-of-State Tax, OpenERA). These regenerate only when new ClickUp comments post, so the fix persists — but the upstream ClickUp status comments still carry the stale text and should be corrected at the source.

`npm run verify:portfolio` passes (29 projects, 0 errors, 2 pre-existing commit-date warnings). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)