### PR TITLE
Model OIT's FY2027 EA portfolio and crosswalk it to ours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,8 @@ app/                       # Next.js App Router
   intake/[token]/          # Submitter-visible status page (Sprint 3a)
   reports/                 # Reports surface
   presentations/           # Legacy redirect → /reports (kept to preserve inbound links)
-  standards/               # Standards (sub-nav: ledger + data-model + strategic-plan)
+  standards/               # Standards (sub-nav: ledger + data-model + strategic-plan
+                           #   + intake-crosswalk + oit-pathway + oit-portfolio + op-excellence)
     data-model/            # Data Governance Explorer (UDM catalog + extensions)
     strategic-plan/        # Strategic Plan Alignment Explorer (pillars + priorities)
   ai4ra-ecosystem/         # AI4RA partnership deep-dive (linked from /about)
@@ -218,6 +219,7 @@ components/                # Reusable components
 lib/                       # Domain logic
   portfolio.ts             # Project inventory + lifecycle module (types, rollup, labels, colors, type guards)
   portfolio-verification.ts # ADR 0001 verifier — `npm run verify:portfolio`
+  oit-ea-portfolio.ts      # OIT's FY2027 EA inventory in OIT's structure + crosswalk to portfolio slugs
   portfolio-meta.ts        # AUTO-GENERATED — derived lastCommitDate per repo (do not edit)
   work.ts                  # Postgres-backed query module for /portfolio (reads applications + blockers)
   work-categories.ts       # "By problem" taxonomy — typed slugs + audience-facing labels
@@ -296,6 +298,7 @@ normative version of any of these lives in **Agent Rules** above).
 | A standards ledger entry | `lib/standards-watch.ts` | Each is commit-worthy; the git log is the audit trail. |
 | A sub-section under `/standards` | `app/standards/<sub>/page.tsx` + add a row to `subNavItems` in `components/StandardsSubNav.tsx` | The shared eyebrow + sub-nav lives in `app/standards/layout.tsx`. Each sub-page owns its own H1. Sidebar stays at one "Standards" entry — never edit `Sidebar.tsx` for sub-sections. |
 | A canonical UDM table tag | `lib/governance/canonical-udm-tables.ts` | Hand-curated v1 list. The data-governance catalog JSONs do not yet carry canonical/extension classification — once they do, this module retires. |
+| An OIT FY portfolio row, or a crosswalk to one | `lib/oit-ea-portfolio.ts` | Point-in-time transcription of OIT's spreadsheet — re-transcribe on a new cut and bump `SOURCE_AS_OF`. Keep OIT's columns in OIT's vocabulary; `portfolioSlug` is the only seam to `lib/portfolio.ts`, and a claimed match needs both `crosswalkConfidence` and `crosswalkNote`. `npm run verify:portfolio` polices both. |
 | A presentation or external talk | `lib/artifacts.ts` (entry with `kind: "presentation"`, `external: true`, `href` pointing at the hosted deck) | The artifact appears in the /reports timeline. |
 | A report | `app/reports/page.tsx` and (if needed) a route under `app/reports/<slug>` | Time-stamped, reverse-chron. |
 

--- a/app/standards/oit-portfolio/page.tsx
+++ b/app/standards/oit-portfolio/page.tsx
@@ -1,0 +1,272 @@
+import Link from "next/link";
+import {
+  CROSSWALK_CONFIDENCE_LABELS,
+  OIT_CATEGORY_ORDER,
+  OIT_EA_PROJECTS,
+  OIT_EFFORT_DISCIPLINES,
+  OIT_PRIORITY_ORDER,
+  SOURCE_AS_OF,
+  SOURCE_FISCAL_YEAR,
+  crosswalkedProjects,
+  highEffortCounts,
+  priorityCounts,
+  projectsByCategory,
+  surfaceLinkedProjects,
+  teamCounts,
+  type OitEaProject,
+  type OitPriority,
+} from "@/lib/oit-ea-portfolio";
+import { projects } from "@/lib/portfolio";
+
+export const metadata = {
+  title: "OIT Portfolio — Standards",
+  description:
+    "OIT's FY2027 Enterprise Applications portfolio in OIT's own tracking structure — priority, owning team, TPM, and effort by discipline — and the three projects it shares with this inventory.",
+};
+
+// Priority is the one dimension where OIT is making a commitment claim, so
+// it earns the site's one accent color at Critical and nothing below it.
+const PRIORITY_CHIP: Record<OitPriority, string> = {
+  Critical: "border-ui-gold bg-ui-gold/15 text-ui-gold-dark",
+  High: "border-brand-huckleberry/30 bg-brand-huckleberry/10 text-brand-huckleberry",
+  Medium: "border-hairline bg-surface-alt text-ui-charcoal",
+  Low: "border-hairline bg-white text-brand-silver",
+};
+
+function PriorityChip({ priority }: { priority: OitPriority }) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold ${PRIORITY_CHIP[priority]}`}
+    >
+      {priority}
+    </span>
+  );
+}
+
+function EffortChips({ row }: { row: OitEaProject }) {
+  const efforts = OIT_EFFORT_DISCIPLINES.filter(
+    ({ key }) => row.effort[key] !== undefined
+  );
+  if (efforts.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      {efforts.map(({ key, label }) => (
+        <span
+          key={key}
+          className="rounded border border-hairline bg-white px-2 py-0.5 text-[11px] text-ink-muted"
+        >
+          {label} <span className="font-semibold">{row.effort[key]}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function nameForSlug(slug: string): string {
+  return projects.find((p) => p.slug === slug)?.name ?? slug;
+}
+
+function ProjectRow({ row }: { row: OitEaProject }) {
+  return (
+    <li className="border-t border-hairline py-4 first:border-t-0 first:pt-0">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
+        <PriorityChip priority={row.priority} />
+        <p className="text-sm font-semibold tracking-tight text-brand-black">
+          {row.name}
+        </p>
+        <p className="text-xs text-brand-silver">
+          {row.primaryTeam} &middot; {row.tpmOrManager}
+        </p>
+      </div>
+
+      <EffortChips row={row} />
+
+      {row.notes && (
+        <p className="mt-2 text-xs text-ink-muted">{row.notes}</p>
+      )}
+
+      {row.portfolioSlug && row.crosswalkConfidence && (
+        <p className="mt-2 text-xs leading-relaxed text-ink-subtle">
+          <span className="font-semibold text-brand-clearwater">
+            {CROSSWALK_CONFIDENCE_LABELS[row.crosswalkConfidence]}
+          </span>{" "}
+          with{" "}
+          <Link href={`/portfolio/${row.portfolioSlug}`}>
+            {nameForSlug(row.portfolioSlug)}
+          </Link>{" "}
+          in this inventory. {row.crosswalkNote}
+        </p>
+      )}
+
+      {row.relatedSurface && (
+        <p className="mt-2 text-xs leading-relaxed text-ink-subtle">
+          Touches <Link href={row.relatedSurface.href}>
+            {row.relatedSurface.label}
+          </Link>{" "}
+          on this site. {row.relatedSurface.note}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export default function OitPortfolioPage() {
+  const crosswalked = crosswalkedProjects();
+  const surfaceLinked = surfaceLinkedProjects();
+  const priorities = priorityCounts();
+  const teams = teamCounts();
+  const highEffort = highEffortCounts();
+
+  return (
+    <div className="space-y-14">
+      <header>
+        <h1 className="text-4xl font-black tracking-tight text-brand-black">
+          OIT&apos;s {SOURCE_FISCAL_YEAR} portfolio
+        </h1>
+        <p className="mt-4 max-w-3xl text-lg leading-relaxed text-ink-muted">
+          OIT&apos;s Enterprise Applications group tracks{" "}
+          {OIT_EA_PROJECTS.length} committed efforts for {SOURCE_FISCAL_YEAR},
+          sized by priority, owning team, and the load each of four
+          disciplines carries. This page reproduces that structure as OIT
+          keeps it, then names where their portfolio and this inventory
+          describe the same work.
+        </p>
+        <p className="mt-3 max-w-3xl text-sm text-ink-subtle">
+          Source: OIT&apos;s FY2027 Enterprise Applications projects and
+          priorities spreadsheet, shared July 2026. Transcribed as of{" "}
+          {SOURCE_AS_OF} — a point-in-time snapshot, not a live feed. OIT owns
+          every fact on this page; the crosswalk notes are ours.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          Where the two inventories meet
+        </h2>
+        <p className="mt-2 max-w-3xl text-base leading-relaxed text-ink-muted">
+          {crosswalked.length} of OIT&apos;s {OIT_EA_PROJECTS.length} rows
+          describe work this inventory also tracks. The rest is OIT&apos;s
+          own — infrastructure, Softdocs forms, Banner operations — and the
+          overlap is deliberately small, so each match carries its basis and
+          its open questions rather than an implied equivalence.
+        </p>
+        <ul className="mt-6 space-y-0">
+          {crosswalked.map((row) => (
+            <ProjectRow key={row.id} row={row} />
+          ))}
+        </ul>
+
+        {surfaceLinked.length > 0 && (
+          <>
+            <h3 className="mt-10 text-lg font-bold tracking-tight text-brand-black">
+              And {surfaceLinked.length} more that meet our standards work
+            </h3>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
+              These are not projects in our inventory, but they govern or feed
+              surfaces this site maintains.
+            </p>
+            <ul className="mt-4 space-y-0">
+              {surfaceLinked.map((row) => (
+                <ProjectRow key={row.id} row={row} />
+              ))}
+            </ul>
+          </>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          How OIT sizes the year
+        </h2>
+        <div className="mt-6 grid gap-6 md:grid-cols-3">
+          <div className="rounded-lg border border-hairline bg-surface-alt p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              By priority
+            </p>
+            <dl className="mt-3 space-y-2">
+              {priorities.map(({ priority, count }) => (
+                <div key={priority} className="flex items-center gap-3">
+                  <dt className="flex-1">
+                    <PriorityChip priority={priority} />
+                  </dt>
+                  <dd className="text-sm font-semibold tabular-nums text-ui-charcoal">
+                    {count}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="rounded-lg border border-hairline bg-surface-alt p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              By owning team
+            </p>
+            <dl className="mt-3 space-y-2">
+              {teams.map(({ team, count }) => (
+                <div key={team} className="flex items-baseline gap-3">
+                  <dt className="flex-1 text-sm text-ui-charcoal">{team}</dt>
+                  <dd className="text-sm font-semibold tabular-nums text-ui-charcoal">
+                    {count}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="rounded-lg border border-hairline bg-surface-alt p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              Rows drawing high effort
+            </p>
+            <dl className="mt-3 space-y-2">
+              {highEffort.map(({ key, label, count }) => (
+                <div key={key} className="flex items-baseline gap-3">
+                  <dt className="flex-1 text-sm text-ui-charcoal">{label}</dt>
+                  <dd className="text-sm font-semibold tabular-nums text-ui-charcoal">
+                    {count}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            <p className="mt-3 text-xs leading-relaxed text-ink-subtle">
+              OIT leaves a discipline blank when it contributes no effort, and
+              records &ldquo;Unknown&rdquo; when the effort is real but
+              unsized.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          The full portfolio
+        </h2>
+        <p className="mt-2 max-w-3xl text-base leading-relaxed text-ink-muted">
+          Every row OIT tracks, grouped by their work category and ordered by
+          priority within it.
+        </p>
+        <div className="mt-8 space-y-10">
+          {OIT_CATEGORY_ORDER.map((category) => {
+            const rows = projectsByCategory(category).sort(
+              (a, b) =>
+                OIT_PRIORITY_ORDER.indexOf(a.priority) -
+                OIT_PRIORITY_ORDER.indexOf(b.priority)
+            );
+            if (rows.length === 0) return null;
+            return (
+              <div key={category}>
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+                  {category} &middot; {rows.length}
+                </h3>
+                <ul className="mt-4 space-y-0">
+                  {rows.map((row) => (
+                    <ProjectRow key={row.id} row={row} />
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/standards/oit-portfolio/page.tsx
+++ b/app/standards/oit-portfolio/page.tsx
@@ -100,7 +100,8 @@ function ProjectRow({ row }: { row: OitEaProject }) {
 
       {row.relatedSurface && (
         <p className="mt-2 text-xs leading-relaxed text-ink-subtle">
-          Touches <Link href={row.relatedSurface.href}>
+          Related to{" "}
+          <Link href={row.relatedSurface.href}>
             {row.relatedSurface.label}
           </Link>{" "}
           on this site. {row.relatedSurface.note}
@@ -145,10 +146,11 @@ export default function OitPortfolioPage() {
         </h2>
         <p className="mt-2 max-w-3xl text-base leading-relaxed text-ink-muted">
           {crosswalked.length} of OIT&apos;s {OIT_EA_PROJECTS.length} rows
-          describe work this inventory also tracks. The rest is OIT&apos;s
-          own — infrastructure, Softdocs forms, Banner operations — and the
-          overlap is deliberately small, so each match carries its basis and
-          its open questions rather than an implied equivalence.
+          describe work this inventory also tracks, each confirmed by the
+          portfolio owner rather than inferred from a shared subject. The
+          rest is OIT&apos;s own — infrastructure, Softdocs forms, Banner
+          operations. The overlap is genuinely this small, and rows that
+          merely read as adjacent are left unlinked.
         </p>
         <ul className="mt-6 space-y-0">
           {crosswalked.map((row) => (
@@ -159,11 +161,12 @@ export default function OitPortfolioPage() {
         {surfaceLinked.length > 0 && (
           <>
             <h3 className="mt-10 text-lg font-bold tracking-tight text-brand-black">
-              And {surfaceLinked.length} more that meet our standards work
+              Related, but not the same work
             </h3>
             <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
-              These are not projects in our inventory, but they govern or feed
-              surfaces this site maintains.
+              Not a project in our inventory, and not a match — a row whose
+              subject overlaps a surface this site maintains, where the
+              scopes differ enough that saying more would overstate it.
             </p>
             <ul className="mt-4 space-y-0">
               {surfaceLinked.map((row) => (

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -16,6 +16,13 @@ import {
   DEPLOYMENT_ENVIRONMENT_LABELS,
   type EnterpriseSystemReplacement,
 } from "@/lib/project-governance";
+import {
+  CROSSWALK_CONFIDENCE_LABELS,
+  OIT_EFFORT_DISCIPLINES,
+  SOURCE_FISCAL_YEAR,
+  oitProjectForSlug,
+  type OitEaProject,
+} from "@/lib/oit-ea-portfolio";
 
 // Blocker severity is a documented exception to the brand-token rule —
 // the amber/red signals are functional alerting, not status decoration.
@@ -96,6 +103,92 @@ function replacementSummary(replacement: EnterpriseSystemReplacement) {
         : ""
     }`,
   };
+}
+
+// A project OIT also carries in its FY2027 Enterprise Applications
+// portfolio. Rendered in OIT's own vocabulary — priority, owning team,
+// TPM, effort by discipline — because those facts are theirs, not ours,
+// and the crosswalk note is explicit about how firm the match is.
+function OitPortfolioSection({ row }: { row: OitEaProject }) {
+  const efforts = OIT_EFFORT_DISCIPLINES.filter(
+    ({ key }) => row.effort[key] !== undefined
+  );
+  return (
+    <section className="border-t border-hairline pt-6">
+      <SectionEyebrow>Also tracked by OIT</SectionEyebrow>
+      <div className="mt-3 max-w-3xl rounded-lg border border-hairline bg-surface-alt p-5">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <p className="text-sm font-bold tracking-tight text-brand-black">
+            {row.name}
+          </p>
+          <span className="text-xs text-brand-silver">
+            {SOURCE_FISCAL_YEAR} Enterprise Applications portfolio
+          </span>
+        </div>
+
+        <dl className="mt-4 grid gap-x-6 gap-y-3 sm:grid-cols-3">
+          <div>
+            <dt className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              OIT priority
+            </dt>
+            <dd className="mt-0.5 text-sm text-ui-charcoal">{row.priority}</dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              Owning team
+            </dt>
+            <dd className="mt-0.5 text-sm text-ui-charcoal">
+              {row.primaryTeam}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              TPM or manager
+            </dt>
+            <dd className="mt-0.5 text-sm text-ui-charcoal">
+              {row.tpmOrManager}
+            </dd>
+          </div>
+        </dl>
+
+        {efforts.length > 0 && (
+          <div className="mt-4">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+              Effort by discipline
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {efforts.map(({ key, label }) => (
+                <span
+                  key={key}
+                  className="rounded-md border border-hairline bg-white px-2.5 py-1 text-xs text-ui-charcoal"
+                >
+                  {label}{" "}
+                  <span className="font-semibold">{row.effort[key]}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {row.notes && (
+          <p className="mt-4 text-sm text-ink-muted">{row.notes}</p>
+        )}
+
+        {row.crosswalkConfidence && row.crosswalkNote && (
+          <p className="mt-4 border-t border-hairline pt-3 text-xs leading-relaxed text-ink-subtle">
+            <span className="font-semibold">
+              {CROSSWALK_CONFIDENCE_LABELS[row.crosswalkConfidence]}.
+            </span>{" "}
+            {row.crosswalkNote}{" "}
+            <Link href="/standards/oit-portfolio">
+              See the full OIT portfolio
+            </Link>
+            .
+          </p>
+        )}
+      </div>
+    </section>
+  );
 }
 
 function GitHubIcon() {
@@ -196,6 +289,7 @@ export default function ProjectDetail({
   const showBuildSegment =
     buildParticipantsLabel && buildParticipantsLabel !== homeUnitLabel;
   const replacement = replacementSummary(app.enterpriseSystemReplacement);
+  const oitRow = oitProjectForSlug(app.slug);
 
   return (
     <div className="space-y-12">
@@ -478,6 +572,8 @@ export default function ProjectDetail({
           </p>
         </section>
       )}
+
+      {oitRow && <OitPortfolioSection row={oitRow} />}
 
       {/* Beat 3 — Can I use it? Engagement surface: links, deployments,
           tech, features, related. */}

--- a/components/StandardsSubNav.tsx
+++ b/components/StandardsSubNav.tsx
@@ -10,6 +10,7 @@ const subNavItems = [
   { href: "/standards/strategic-plan/map", label: "Map" },
   { href: "/standards/intake-crosswalk", label: "Intake Crosswalk" },
   { href: "/standards/oit-pathway", label: "OIT Pathway" },
+  { href: "/standards/oit-portfolio", label: "OIT Portfolio" },
   { href: "/standards/operational-excellence", label: "Op Excellence Survey" },
 ];
 

--- a/lib/oit-ea-portfolio.ts
+++ b/lib/oit-ea-portfolio.ts
@@ -92,8 +92,13 @@ export type CrosswalkConfidence =
 
 /**
  * A row of OIT's portfolio that lands on a surface this site already
- * maintains without being a project in our inventory — OIT's governance
- * and data-standards work, mostly.
+ * maintains without being a project in our inventory.
+ *
+ * The bar is the same as for a crosswalk: an owner has affirmed the
+ * relationship. Shared subject matter is not enough — several rows that
+ * read as adjacent (the AI decision framework, the operational-excellence
+ * CoP, MyUI) were reviewed in July 2026 and left unlinked because the
+ * connection could not be supported. Leave the field off by default.
  */
 export interface RelatedSurface {
   label: string;
@@ -164,7 +169,7 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     relatedSurface: {
       label: "Data Model",
       href: "/standards/data-model",
-      note: "The AI4RA Unified Data Model catalog and controlled vocabularies this site tracks are the data-standards layer OIT's enablement work governs.",
+      note: "Adjacent to the UDM catalog and controlled vocabularies tracked here, but OIT's enablement scope is institution-wide and considerably broader than that work — related, not equivalent.",
     },
   },
   {
@@ -181,9 +186,9 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
       systems: "High",
     },
     portfolioSlug: "data-infrastructure-pilot",
-    crosswalkConfidence: "candidate",
+    crosswalkConfidence: "confirmed",
     crosswalkNote:
-      "Both efforts stand up a lakehouse for institutional data. Whether the Data Infrastructure Pilot is meant to land on OIT's Databricks platform, or is a parallel IIDS track, has not been confirmed with OIT.",
+      "Databricks is the main technical platform deliverable of the Data Infrastructure Pilot — one effort, tracked from both sides (confirmed by Barrie Robison, July 2026).",
   },
   {
     id: "nacubo-dashboards-data-architecture",
@@ -217,9 +222,9 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
       systems: "Low",
     },
     portfolioSlug: "openera",
-    crosswalkConfidence: "probable",
+    crosswalkConfidence: "confirmed",
     crosswalkNote:
-      "OpenERA declares VERAS as the enterprise system it replaces ($150k/yr, renewal March 2027), and OIT carries VERAS replacement as a Critical FY27 commitment. Open question: whether OIT's row denotes OpenERA itself or the Nexus sponsored-programs module — these are separate efforts and should not be conflated.",
+      "OpenERA is the system that will replace VERAS (confirmed by Barrie Robison, July 2026). OIT carries the replacement as a Critical FY27 commitment; our entry carries the incumbent economics — $150k/yr, renewal March 2027.",
   },
   {
     id: "nexus",
@@ -237,7 +242,7 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     portfolioSlug: "nexus",
     crosswalkConfidence: "confirmed",
     crosswalkNote:
-      "The same platform on both sides: OIT's Enterprise Applications team owns delivery; our inventory tracks it as the OIT-managed landing zone where UI application modules deploy.",
+      "The same platform on both sides (confirmed by Barrie Robison, July 2026): OIT's Enterprise Applications team owns delivery; our inventory tracks it as the OIT-managed landing zone where UI application modules deploy.",
   },
   {
     id: "ai-development-decision-framework",
@@ -247,11 +252,6 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     primaryTeam: "Enterprise Applications",
     tpmOrManager: "Kali Armitage",
     effort: { tpmManager: "Medium" },
-    relatedSurface: {
-      label: "OIT Pathway",
-      href: "/standards/oit-pathway",
-      note: "The Enterprise AI Development Framework and AI-Assisted Builder Guide tracked on that page are the decision framework this row funds.",
-    },
   },
   {
     id: "edabroad-platform-assessment",
@@ -530,11 +530,6 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     primaryTeam: "Product Management",
     tpmOrManager: "Trevor Humble",
     effort: { tpmManager: "Medium", administration: "Low" },
-    relatedSurface: {
-      label: "Data Model",
-      href: "/standards/data-model",
-      note: "Data-governance capacity work adjacent to the UDM catalog and controlled vocabularies tracked here.",
-    },
   },
   {
     id: "disability-resurvey-form",
@@ -554,11 +549,6 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     tpmOrManager: "Trevor Humble",
     effort: { tpmManager: "Medium", administration: "High" },
     notes: "Q3 and Q4 project",
-    relatedSurface: {
-      label: "Op Excellence Survey",
-      href: "/standards/operational-excellence",
-      note: "A real MyUI mobile app was one of the most-requested items in the student survey.",
-    },
   },
   {
     id: "myui-custom-card-resurvey",
@@ -765,11 +755,6 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
     primaryTeam: "Product Management",
     tpmOrManager: "Kali Armitage",
     effort: { tpmManager: "Medium" },
-    relatedSurface: {
-      label: "Op Excellence Survey",
-      href: "/standards/operational-excellence",
-      note: "The community of practice this row funds is the standing home for the operational-excellence survey findings tracked here.",
-    },
   },
 
   // --- Category: Infrastructure -------------------------------------

--- a/lib/oit-ea-portfolio.ts
+++ b/lib/oit-ea-portfolio.ts
@@ -1,0 +1,900 @@
+// lib/oit-ea-portfolio.ts
+//
+// OIT's FY2027 Enterprise Applications project portfolio, modeled in
+// OIT's own tracking structure, plus a crosswalk to lib/portfolio.ts.
+//
+// Source: "FY2027 EA Projects and Priorities.xlsx", shared by OIT in
+// July 2026 — 61 rows across five work categories. This module is a
+// point-in-time transcription, not a live feed: OIT maintains the
+// spreadsheet, and there is no API to sync from. Re-transcribe when OIT
+// shares a newer cut and update `SOURCE_AS_OF`.
+//
+// Why model their structure rather than fold their rows into ours:
+// OIT tracks commitment (priority, owning team, TPM, effort by
+// discipline), while lib/portfolio.ts tracks product lifecycle (status,
+// deployment target, replacement economics). Neither vocabulary
+// subsumes the other. Keeping OIT's columns intact means the crosswalk
+// stays honest about which facts came from whom — and `portfolioSlug`
+// is the single seam between the two inventories, checked by
+// `npm run verify:portfolio`.
+//
+// Transcription rules applied (source fidelity preserved in
+// `sourceName` wherever the display name was cleaned):
+//   - Team labels normalized: "Product Mgmt"/"Product Management" →
+//     "Product Management"; "Endpoint Mgmt" → "Endpoint Management".
+//   - Category "Operstions" (row 45) read as "Operations".
+//   - Effort "low" (row 43) read as "Low".
+//   - Blank and whitespace-only effort cells become `undefined` — OIT
+//     leaves a discipline blank when it contributes no effort. That is
+//     distinct from the explicit "Unknown" they record when the effort
+//     is real but unsized.
+//   - Three source typos corrected for display ("PageUP", "oboarding",
+//     "Mananger"); the source spelling is retained in `sourceName`.
+
+/** The cut of OIT's spreadsheet this module transcribes. */
+export const SOURCE_AS_OF = "2026-07-25";
+
+/** OIT's fiscal-year label for this portfolio (UI FY runs Jul 1 – Jun 30). */
+export const SOURCE_FISCAL_YEAR = "FY2027";
+
+// ---- OIT's tracking dimensions ---------------------------------------
+
+/** OIT's "Priority" column. */
+export type OitPriority = "Critical" | "High" | "Medium" | "Low";
+
+/** OIT's "Category" column — the kind of work, not its subject matter. */
+export type OitWorkCategory =
+  | "Project"
+  | "Operations"
+  | "Ongoing Initiative"
+  | "Infrastructure"
+  | "Administrative";
+
+/** OIT's "Primary Team" column. */
+export type OitTeam =
+  | "Systems"
+  | "Development"
+  | "Enterprise Applications"
+  | "Application Administration"
+  | "Product Management"
+  | "Endpoint Management";
+
+/**
+ * OIT's effort scale. "Unknown" is a value they record deliberately —
+ * effort exists but has not been sized. A discipline that contributes
+ * nothing is left blank in the sheet and `undefined` here.
+ */
+export type OitEffort = "High" | "Medium" | "Low" | "Unknown";
+
+/**
+ * OIT sizes each project against four disciplines rather than one
+ * aggregate estimate — the four columns are the load each team carries.
+ */
+export interface OitEffortProfile {
+  /** "TPM/Manager Effort" — coordination and product-management load. */
+  tpmManager?: OitEffort;
+  /** "Dev Effort" — application development load. */
+  development?: OitEffort;
+  /** "Admin Effort" — application-administration load. */
+  administration?: OitEffort;
+  /** "Systems Effort" — infrastructure and systems-engineering load. */
+  systems?: OitEffort;
+}
+
+/** How firmly a row maps to a lib/portfolio.ts entry. */
+export type CrosswalkConfidence =
+  /** The two inventories describe the same effort; no open question. */
+  | "confirmed"
+  /** Strong evidence on both sides, one unresolved detail noted. */
+  | "probable"
+  /** Plausible on subject matter alone; needs OIT confirmation. */
+  | "candidate";
+
+/**
+ * A row of OIT's portfolio that lands on a surface this site already
+ * maintains without being a project in our inventory — OIT's governance
+ * and data-standards work, mostly.
+ */
+export interface RelatedSurface {
+  label: string;
+  href: string;
+  note: string;
+}
+
+export interface OitEaProject {
+  /** Stable kebab id derived from the project name. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Verbatim source spelling, when it differs from `name`. */
+  sourceName?: string;
+  priority: OitPriority;
+  category: OitWorkCategory;
+  primaryTeam: OitTeam;
+  /**
+   * OIT's "TPM or Manager (Primary)". Usually a named person; OIT
+   * records a team name where no individual is assigned.
+   */
+  tpmOrManager: string;
+  effort: OitEffortProfile;
+  /** OIT's "Notes" column — mostly completion targets. */
+  notes?: string;
+
+  /** Matching lib/portfolio.ts slug, where the same effort appears in both. */
+  portfolioSlug?: string;
+  crosswalkConfidence?: CrosswalkConfidence;
+  /** What supports the match, and what is still open. Required with a slug. */
+  crosswalkNote?: string;
+
+  /** A site surface this row touches without being a portfolio project. */
+  relatedSurface?: RelatedSurface;
+}
+
+// ---- The portfolio ---------------------------------------------------
+
+export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
+  // --- Category: Project --------------------------------------------
+  {
+    id: "nutanix-kubernetes-platform",
+    name: "Nutanix Kubernetes Platform",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Medium" },
+  },
+  {
+    id: "pageup-deployment",
+    name: "PageUp deployment",
+    sourceName: "PageUP deployment",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Business Systems",
+    effort: { development: "High", administration: "Low" },
+  },
+  {
+    id: "data-governance-enablement",
+    name: "Data Governance Enablement",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Enterprise Applications",
+    tpmOrManager: "Kali Armitage",
+    effort: { tpmManager: "High", administration: "Low" },
+    relatedSurface: {
+      label: "Data Model",
+      href: "/standards/data-model",
+      note: "The AI4RA Unified Data Model catalog and controlled vocabularies this site tracks are the data-standards layer OIT's enablement work governs.",
+    },
+  },
+  {
+    id: "databricks-platform-deployment",
+    name: "Databricks Platform Deployment",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: {
+      tpmManager: "High",
+      development: "High",
+      administration: "High",
+      systems: "High",
+    },
+    portfolioSlug: "data-infrastructure-pilot",
+    crosswalkConfidence: "candidate",
+    crosswalkNote:
+      "Both efforts stand up a lakehouse for institutional data. Whether the Data Infrastructure Pilot is meant to land on OIT's Databricks platform, or is a parallel IIDS track, has not been confirmed with OIT.",
+  },
+  {
+    id: "nacubo-dashboards-data-architecture",
+    name: "NACUBO Dashboards Data Architecture and Pipelines",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Enterprise Applications",
+    tpmOrManager: "Kali Armitage",
+    effort: { tpmManager: "High", development: "High", administration: "Low" },
+  },
+  {
+    id: "inbox-idaho",
+    name: "Inbox Idaho",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "High", development: "High", administration: "High" },
+  },
+  {
+    id: "veras-replacement",
+    name: "VERAS Replacement",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Enterprise Applications",
+    tpmOrManager: "Trevor Humble",
+    effort: {
+      tpmManager: "Medium",
+      development: "Medium",
+      administration: "Low",
+      systems: "Low",
+    },
+    portfolioSlug: "openera",
+    crosswalkConfidence: "probable",
+    crosswalkNote:
+      "OpenERA declares VERAS as the enterprise system it replaces ($150k/yr, renewal March 2027), and OIT carries VERAS replacement as a Critical FY27 commitment. Open question: whether OIT's row denotes OpenERA itself or the Nexus sponsored-programs module — these are separate efforts and should not be conflated.",
+  },
+  {
+    id: "nexus",
+    name: "Nexus",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Enterprise Applications",
+    tpmOrManager: "Trevor Humble",
+    effort: {
+      tpmManager: "Medium",
+      development: "Medium",
+      administration: "Low",
+      systems: "Low",
+    },
+    portfolioSlug: "nexus",
+    crosswalkConfidence: "confirmed",
+    crosswalkNote:
+      "The same platform on both sides: OIT's Enterprise Applications team owns delivery; our inventory tracks it as the OIT-managed landing zone where UI application modules deploy.",
+  },
+  {
+    id: "ai-development-decision-framework",
+    name: "AI Development Decision Framework",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Enterprise Applications",
+    tpmOrManager: "Kali Armitage",
+    effort: { tpmManager: "Medium" },
+    relatedSurface: {
+      label: "OIT Pathway",
+      href: "/standards/oit-pathway",
+      note: "The Enterprise AI Development Framework and AI-Assisted Builder Guide tracked on that page are the decision framework this row funds.",
+    },
+  },
+  {
+    id: "edabroad-platform-assessment",
+    name: "EdAbroad Platform Assessment",
+    priority: "Critical",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "High" },
+  },
+  {
+    id: "endpoint-toolbox",
+    name: "Endpoint Toolbox",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "High" },
+  },
+  {
+    id: "palo-alto-network-security-gateways",
+    name: "Palo Alto Network Security and Application Gateways",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "High" },
+  },
+  {
+    id: "replace-promax-servers",
+    name: "Replace ProMax Servers with SNS Servers",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Kariann Owens",
+    effort: {
+      tpmManager: "Low",
+      development: "Low",
+      administration: "Low",
+      systems: "Medium",
+    },
+    notes: "Completion target September 2026",
+  },
+  {
+    id: "dotnet-application-upgrades",
+    name: ".Net Application Upgrades",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Randi Croyle",
+    effort: { development: "Medium" },
+  },
+  {
+    id: "softdocs-admin-department-level-security",
+    name: "Softdocs - Admin - Department Level Security",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", administration: "Medium" },
+  },
+  {
+    id: "softdocs-ar-title-iv-forms",
+    name: "Softdocs - AR - Title IV Forms and Integration",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "High", development: "High", administration: "Medium" },
+  },
+  {
+    id: "softdocs-hr-performance-evaluation",
+    name: "Softdocs - HR - Performance Evaluation Enhancements",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Low", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "softdocs-hr-annual-contract",
+    name: "Softdocs - HR - Annual Contract Enhancements",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Low", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "softdocs-prov-faculty-performance-evaluation",
+    name: "Softdocs - PROV - Faculty Performance Evaluation",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Low", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "softdocs-prov-annual-contract",
+    name: "Softdocs - PROV - Annual Contract Enhancements",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Low", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "sunapsis-to-banner-feed",
+    name: "Sunapsis to Banner Feed",
+    priority: "High",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "Medium", development: "High", administration: "Medium" },
+  },
+  {
+    id: "replace-ucm-print-online",
+    name: "Replace UCM Print Online",
+    priority: "Low",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Kariann Owens",
+    effort: {
+      tpmManager: "High",
+      development: "Low",
+      administration: "Medium",
+      systems: "Medium",
+    },
+    notes: "Completion target December 2027",
+  },
+  {
+    id: "service-desk-phase-2",
+    name: "Service Desk Phase 2",
+    priority: "Low",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: { tpmManager: "Low", administration: "Low" },
+  },
+  {
+    id: "idaho-rise-ado-onboarding",
+    name: "Idaho Rise ADO onboarding and infrastructure migration",
+    sourceName: "Idaho Rise ADO oboarding and infrastructure migration",
+    priority: "Low",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: { administration: "Low", systems: "Low" },
+  },
+  {
+    id: "bcdr",
+    name: "BCDR",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { administration: "Medium", systems: "Medium" },
+  },
+  {
+    id: "jaggaer-pay-implementation",
+    name: "Jaggaer Pay implementation",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Business Systems",
+    effort: { development: "Low", administration: "Medium" },
+  },
+  {
+    id: "service-portal-redesign",
+    name: "Service Portal Redesign",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Chryss Crotser",
+    effort: { tpmManager: "Medium", administration: "Low" },
+  },
+  {
+    id: "status-page",
+    name: "Status Page",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: { tpmManager: "Low", administration: "Medium" },
+  },
+  {
+    id: "oke-observability",
+    name: "OKE Observability",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: {
+      development: "Unknown",
+      administration: "Medium",
+      systems: "Medium",
+    },
+  },
+  {
+    id: "softdocs-hr-image-only-import",
+    name: "Softdocs - HR - Image Only Import",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Low", administration: "Medium" },
+  },
+  {
+    id: "softdocs-admin-name-change-handling",
+    name: "Softdocs - Admin - Name Change handling",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", administration: "Medium" },
+  },
+  {
+    id: "softdocs-reg-form-development",
+    name: "Softdocs - REG - Form Development",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", administration: "Medium" },
+  },
+  {
+    id: "softdocs-ap-related-pcard-forms",
+    name: "Softdocs - AP - Related Pcard Forms",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", development: "Low", administration: "Low" },
+  },
+  {
+    id: "softdocs-hr-staff-salary-change-permanent",
+    name: "Softdocs - HR - Staff Salary Change (Permanent)",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "softdocs-hr-staff-salary-change-temporary",
+    name: "Softdocs - HR - Staff Salary Change (Temporary)",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", development: "Medium", administration: "Low" },
+  },
+  {
+    id: "softdocs-prov-faculty-summer-contract-2027",
+    name: "Softdocs - PROV - Faculty Summer Contract 2027",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "High", development: "High" },
+  },
+  {
+    id: "softdocs-rotc-form-commissioning",
+    name: "Softdocs - ROTC - Form Commissioning",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Development",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium", development: "Low", administration: "Low" },
+  },
+  {
+    id: "data-interns-governance-project",
+    name: "Data Interns Governance Project",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "Medium", administration: "Low" },
+    relatedSurface: {
+      label: "Data Model",
+      href: "/standards/data-model",
+      note: "Data-governance capacity work adjacent to the UDM catalog and controlled vocabularies tracked here.",
+    },
+  },
+  {
+    id: "disability-resurvey-form",
+    name: "Disability Resurvey Form",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Skye Swoboda-Colberg",
+    effort: { tpmManager: "Medium" },
+  },
+  {
+    id: "myui-app",
+    name: "MyUI App",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "Medium", administration: "High" },
+    notes: "Q3 and Q4 project",
+    relatedSurface: {
+      label: "Op Excellence Survey",
+      href: "/standards/operational-excellence",
+      note: "A real MyUI mobile app was one of the most-requested items in the student survey.",
+    },
+  },
+  {
+    id: "myui-custom-card-resurvey",
+    name: "MyUI Custom Card Resurvey",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "High", development: "High", administration: "Medium" },
+    notes: "Q3 and Q4 project",
+  },
+  {
+    id: "cnr-ticketing-app",
+    name: "CNR Ticketing App",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Chryss Crotser",
+    effort: {
+      tpmManager: "Medium",
+      development: "Low",
+      administration: "Low",
+      systems: "Low",
+    },
+  },
+  {
+    id: "student-accounts-kb",
+    name: "Student Accounts KB",
+    priority: "Medium",
+    category: "Project",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Chryss Crotser",
+    effort: {
+      tpmManager: "Medium",
+      development: "Low",
+      administration: "Low",
+      systems: "Low",
+    },
+  },
+
+  // --- Category: Operations -----------------------------------------
+  {
+    id: "certificate-lifecycle-and-service-migration",
+    name: "Certificate Lifecycle and Service Migration",
+    priority: "High",
+    category: "Operations",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "High" },
+  },
+  {
+    id: "student-computing-labs-upgrades",
+    name: "Student Computing Labs Software Upgrades and Reimaging",
+    priority: "High",
+    category: "Operations",
+    primaryTeam: "Endpoint Management",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Medium" },
+  },
+  {
+    id: "uidaho-takeover-vercel",
+    name: "UIdaho takeover Vercel",
+    priority: "High",
+    category: "Operations",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Kariann Owens",
+    effort: {
+      tpmManager: "Medium",
+      development: "Low",
+      administration: "High",
+      systems: "Low",
+    },
+    notes: "Completion target (needed immediately)",
+  },
+  {
+    id: "ucm-product-manager-team",
+    name: 'UCM Product Manager "Team"',
+    sourceName: 'UCM Product Mananger "Team"',
+    priority: "High",
+    category: "Operations",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Kariann Owens",
+    effort: {
+      tpmManager: "High",
+      development: "Medium",
+      administration: "Low",
+      systems: "Low",
+    },
+    notes: "Completion target September 2026",
+  },
+  {
+    id: "q3-banner-upgrade",
+    name: "Q3 Banner Upgrade",
+    priority: "High",
+    category: "Operations",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: { development: "Low", administration: "High" },
+  },
+  {
+    id: "nagios-upgrades-and-sso",
+    name: "Nagios Upgrades and SSO",
+    priority: "Low",
+    category: "Operations",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { development: "Unknown", systems: "Low" },
+  },
+  {
+    id: "sql-server-upgrade-and-migration",
+    name: "SQL Server Upgrade and Migration",
+    priority: "Low",
+    category: "Operations",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Randy Wood",
+    effort: { administration: "Low", systems: "Low" },
+  },
+  {
+    id: "integrating-systems-into-azdo",
+    name: "Integrating Systems into AzDO and Tortoise Sprints",
+    priority: "Medium",
+    category: "Operations",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Medium" },
+  },
+  {
+    id: "terraform-for-manual-processes",
+    name: "Terraform for Manual Processes - Endpoints and Servers",
+    priority: "Medium",
+    category: "Operations",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "High" },
+  },
+  {
+    id: "admin-remodel-and-server-moves",
+    name: "Admin Remodel and Server Moves",
+    priority: "Medium",
+    category: "Operations",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Medium" },
+  },
+  {
+    id: "uidaho-takeover-sitecore-deployments",
+    name: "UIdaho takeover Sitecore Deployments",
+    priority: "Medium",
+    category: "Operations",
+    primaryTeam: "Application Administration",
+    tpmOrManager: "Kariann Owens",
+    effort: {
+      tpmManager: "High",
+      development: "High",
+      administration: "Low",
+      systems: "Low",
+    },
+    notes: "Completion target Summer 2027",
+  },
+
+  // --- Category: Ongoing Initiative ---------------------------------
+  {
+    id: "ui-ux-design-student-partnership",
+    name: "UI/UX Design Student Partnership",
+    priority: "Low",
+    category: "Ongoing Initiative",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Trevor Humble",
+    effort: { tpmManager: "High" },
+    notes: "Fall semester 2026",
+  },
+  {
+    id: "itsm-steering-committee",
+    name: "ITSM Steering Committee",
+    priority: "Medium",
+    category: "Ongoing Initiative",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Chryss Crotser",
+    effort: { administration: "High" },
+  },
+  {
+    id: "dev-architecture-review",
+    name: "Dev Architecture Review",
+    priority: "Medium",
+    category: "Ongoing Initiative",
+    primaryTeam: "Development",
+    tpmOrManager: "Randi Croyle",
+    effort: { development: "Medium" },
+  },
+  {
+    id: "ear-process",
+    name: "EAR process",
+    priority: "Medium",
+    category: "Ongoing Initiative",
+    primaryTeam: "Development",
+    tpmOrManager: "Randi Croyle",
+    effort: { development: "Low" },
+  },
+  {
+    id: "operational-excellence-cop",
+    name: "Operational Excellence CoP",
+    priority: "Medium",
+    category: "Ongoing Initiative",
+    primaryTeam: "Product Management",
+    tpmOrManager: "Kali Armitage",
+    effort: { tpmManager: "Medium" },
+    relatedSurface: {
+      label: "Op Excellence Survey",
+      href: "/standards/operational-excellence",
+      note: "The community of practice this row funds is the standing home for the operational-excellence survey findings tracked here.",
+    },
+  },
+
+  // --- Category: Infrastructure -------------------------------------
+  {
+    id: "whole-room-ups-deployment",
+    name: "Whole-room UPS Deployment - Library and Admin",
+    priority: "Medium",
+    category: "Infrastructure",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Low" },
+  },
+
+  // --- Category: Administrative -------------------------------------
+  {
+    id: "pluralsight-licensing-and-onboarding",
+    name: "Pluralsight Licensing and Onboarding with SSO",
+    priority: "Low",
+    category: "Administrative",
+    primaryTeam: "Systems",
+    tpmOrManager: "Ben Kirchmeier",
+    effort: { systems: "Low" },
+  },
+] as const;
+
+// ---- Ordering + labels -----------------------------------------------
+
+/** Highest commitment first — the order OIT's priority column implies. */
+export const OIT_PRIORITY_ORDER: readonly OitPriority[] = [
+  "Critical",
+  "High",
+  "Medium",
+  "Low",
+] as const;
+
+export const OIT_CATEGORY_ORDER: readonly OitWorkCategory[] = [
+  "Project",
+  "Operations",
+  "Ongoing Initiative",
+  "Infrastructure",
+  "Administrative",
+] as const;
+
+export const OIT_EFFORT_ORDER: readonly OitEffort[] = [
+  "High",
+  "Medium",
+  "Low",
+  "Unknown",
+] as const;
+
+/** The four effort disciplines, in OIT's column order. */
+export const OIT_EFFORT_DISCIPLINES = [
+  { key: "tpmManager", label: "TPM / Manager" },
+  { key: "development", label: "Development" },
+  { key: "administration", label: "Administration" },
+  { key: "systems", label: "Systems" },
+] as const satisfies readonly {
+  key: keyof OitEffortProfile;
+  label: string;
+}[];
+
+export const CROSSWALK_CONFIDENCE_LABELS: Record<CrosswalkConfidence, string> = {
+  confirmed: "Confirmed match",
+  probable: "Probable match",
+  candidate: "Candidate match",
+};
+
+// ---- Lookups ---------------------------------------------------------
+
+/** Every row that crosswalks to a portfolio entry. */
+export function crosswalkedProjects(): OitEaProject[] {
+  return OIT_EA_PROJECTS.filter((p) => p.portfolioSlug !== undefined);
+}
+
+/** OIT's row for a portfolio slug, when one exists. */
+export function oitProjectForSlug(slug: string): OitEaProject | null {
+  return OIT_EA_PROJECTS.find((p) => p.portfolioSlug === slug) ?? null;
+}
+
+/** Every row that touches a site surface without being a portfolio project. */
+export function surfaceLinkedProjects(): OitEaProject[] {
+  return OIT_EA_PROJECTS.filter(
+    (p) => p.relatedSurface !== undefined && p.portfolioSlug === undefined,
+  );
+}
+
+export function projectsByPriority(priority: OitPriority): OitEaProject[] {
+  return OIT_EA_PROJECTS.filter((p) => p.priority === priority);
+}
+
+export function projectsByCategory(category: OitWorkCategory): OitEaProject[] {
+  return OIT_EA_PROJECTS.filter((p) => p.category === category);
+}
+
+/** Row counts per priority, in `OIT_PRIORITY_ORDER`. */
+export function priorityCounts(): { priority: OitPriority; count: number }[] {
+  return OIT_PRIORITY_ORDER.map((priority) => ({
+    priority,
+    count: projectsByPriority(priority).length,
+  }));
+}
+
+/** Row counts per owning team, busiest first. */
+export function teamCounts(): { team: OitTeam; count: number }[] {
+  const counts = new Map<OitTeam, number>();
+  for (const p of OIT_EA_PROJECTS) {
+    counts.set(p.primaryTeam, (counts.get(p.primaryTeam) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([team, count]) => ({ team, count }))
+    .sort((a, b) => b.count - a.count || a.team.localeCompare(b.team));
+}
+
+/**
+ * How many rows draw High effort from each discipline — the closest
+ * thing OIT's structure gives to a capacity signal.
+ */
+export function highEffortCounts(): {
+  key: keyof OitEffortProfile;
+  label: string;
+  count: number;
+}[] {
+  return OIT_EFFORT_DISCIPLINES.map(({ key, label }) => ({
+    key,
+    label,
+    count: OIT_EA_PROJECTS.filter((p) => p.effort[key] === "High").length,
+  }));
+}

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -949,6 +949,7 @@ export const projects: Project[] = [
       "Establishes governed lakehouse access to institutional data sources, with documentation and data dictionaries, as the shared substrate for AI4UI applications.",
     operationalExcellenceOutcome:
       "Aligns the data used and created by AI4UI applications on one governed foundation instead of per-project extracts — the E.1 data-warehouse priority made concrete.",
+    tech: ["Databricks"],
     relatedSlugs: ["dgx-stack", "nexus"],
     workCategories: ["ai-infrastructure"],
     strategicPlanAlignment: ["E.1", "E.2"],

--- a/scripts/verify-portfolio.ts
+++ b/scripts/verify-portfolio.ts
@@ -17,6 +17,7 @@
 import { projects } from "../lib/portfolio.js";
 import { verifyAll, type VerificationProblem } from "../lib/portfolio-verification.js";
 import { priorities } from "../lib/strategic-plan/catalog.js";
+import { OIT_EA_PROJECTS } from "../lib/oit-ea-portfolio.js";
 
 function format(p: VerificationProblem): string {
   const tag = p.severity === "error" ? "ERROR " : "WARN  ";
@@ -43,14 +44,51 @@ function verifyStrategicPlanAlignment(): VerificationProblem[] {
   return problems;
 }
 
+// The crosswalk in lib/oit-ea-portfolio.ts is the one seam between OIT's
+// FY2027 inventory and ours. A `portfolioSlug` that no longer resolves —
+// or a claimed match with no stated basis — is drift, not a match.
+function verifyOitCrosswalk(): VerificationProblem[] {
+  const validSlugs = new Set(projects.map((p) => p.slug));
+  const problems: VerificationProblem[] = [];
+  for (const row of OIT_EA_PROJECTS) {
+    if (row.portfolioSlug === undefined) continue;
+    if (!validSlugs.has(row.portfolioSlug)) {
+      problems.push({
+        slug: row.portfolioSlug,
+        claimedStatus: "tracked",
+        problem: `OIT crosswalk row "${row.name}" points at slug "${row.portfolioSlug}", which is not present in lib/portfolio.ts`,
+        rule: "oit-crosswalk",
+        severity: "error",
+      });
+    }
+    if (!row.crosswalkConfidence || !row.crosswalkNote) {
+      problems.push({
+        slug: row.portfolioSlug,
+        claimedStatus: "tracked",
+        problem: `OIT crosswalk row "${row.name}" claims a match without both crosswalkConfidence and crosswalkNote`,
+        rule: "oit-crosswalk",
+        severity: "error",
+      });
+    }
+  }
+  return problems;
+}
+
 function main(): void {
   const lifecycleProblems = verifyAll(projects);
   const stratPlanProblems = verifyStrategicPlanAlignment();
-  const all = [...lifecycleProblems, ...stratPlanProblems];
+  const oitCrosswalkProblems = verifyOitCrosswalk();
+  const all = [
+    ...lifecycleProblems,
+    ...stratPlanProblems,
+    ...oitCrosswalkProblems,
+  ];
   const errors = all.filter((p) => p.severity === "error");
   const warnings = all.filter((p) => p.severity === "warning");
 
-  console.log(`Verifying ${projects.length} projects against ADR 0001 rules and strategic-plan alignment ...\n`);
+  console.log(
+    `Verifying ${projects.length} projects against ADR 0001 rules, strategic-plan alignment, and the OIT FY2027 crosswalk ...\n`
+  );
 
   if (warnings.length > 0) {
     console.log(`Warnings (${warnings.length}):`);


### PR DESCRIPTION
OIT shared their FY2027 Enterprise Applications inventory — 61 committed efforts tracked by **priority**, **owning team**, **TPM/manager**, and **effort across four disciplines** (TPM/manager, development, administration, systems).

## Why a separate module

OIT's vocabulary tracks *commitment*; `lib/portfolio.ts` tracks *product lifecycle* (status, deployment target, replacement economics). Neither subsumes the other. `lib/oit-ea-portfolio.ts` keeps OIT's columns intact rather than folding their rows into ours, so the crosswalk stays honest about which facts came from whom. `portfolioSlug` is the single seam between the two inventories.

All 61 rows were transcribed and then diffed cell-by-cell against the source spreadsheet. Normalizations (team-label variants, a category typo, blank-vs-`Unknown` effort) are documented in the module header; `sourceName` preserves the original spelling wherever a display name was cleaned.

## Three matches, all owner-confirmed

| OIT row | Our entry | |
|---|---|---|
| Nexus | `nexus` | The same platform on both sides |
| VERAS Replacement | `openera` | OpenERA is the system that will replace VERAS. Our entry carries the incumbent economics — $150k/yr, renewal Mar 2027. |
| Databricks Platform Deployment | `data-infrastructure-pilot` | Databricks is the main technical platform deliverable of the pilot — one effort, not two parallel tracks. Now also recorded on the pilot's tech stack. |

Each was reviewed by the portfolio owner (July 2026) rather than inferred from a shared subject.

## What did *not* survive review

Five rows initially linked to standards surfaces on subject-matter adjacency. Four could not be supported even as relationships and were removed: the AI Development Decision Framework against the OIT pathway, the Operational Excellence CoP and MyUI App against the survey, and the Data Interns project against the data model.

Only **Data Governance Enablement** remains, and its note says plainly that OIT's scope is institution-wide and considerably broader than the UDM work tracked here — related, not equivalent.

The `RelatedSurface` doc comment records the bar and names the rows that failed it, so a future transcription doesn't re-derive the same adjacencies and reach the same wrong answer.

## Enforcement

`npm run verify:portfolio` fails on a crosswalk `portfolioSlug` that no longer resolves, or on a claimed match missing either `crosswalkConfidence` or `crosswalkNote` — a match without a stated basis is drift, not a match.

## Surfaces

- `/standards/oit-portfolio` — the crosswalk first, then how OIT sizes the year (by priority, by team, by discipline drawing high effort), then all 61 rows grouped by their work category.
- An "Also tracked by OIT" block on the three matched project detail pages, rendered in OIT's vocabulary.

## Verification

- `npm run build` passes; `/standards/oit-portfolio` prerenders static.
- `npm run lint` clean; `npm run verify:portfolio` passes (29 projects, 0 errors, 2 pre-existing `lastCommitDate` warnings).
- Both surfaces checked in the dev server — content correct, no console errors.

## Note

The source spreadsheet is **not** committed — it's an OIT-internal document and this repo is shared. `SOURCE_AS_OF` records the cut date; re-transcribe and bump it when OIT shares a newer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)