### PR TITLE
Give the agent tools for the Coordination surface

### DIFF
--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -35,6 +35,9 @@ import { getProjectStatusTool } from "./tools/get-project-status";
 import { listRequestedProjectsTool } from "./tools/list-requested-projects";
 import { lookupSurveyThemesTool } from "./tools/lookup-survey-themes";
 import { listSurveyCandidateProjectsTool } from "./tools/list-survey-candidate-projects";
+import { lookupOitPathwayTool } from "./tools/lookup-oit-pathway";
+import { lookupOitPortfolioTool } from "./tools/lookup-oit-portfolio";
+import { lookupIntakeProfileTool } from "./tools/lookup-intake-profile";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
 
 const MAX_ITERATIONS = 6;
@@ -77,6 +80,9 @@ export const publicRegistry: ToolRegistry = createRegistry([
   listRequestedProjectsTool,
   lookupSurveyThemesTool,
   listSurveyCandidateProjectsTool,
+  lookupOitPathwayTool,
+  lookupOitPortfolioTool,
+  lookupIntakeProfileTool,
 ]);
 
 export interface Citation {

--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -6,7 +6,7 @@
 // must refuse to answer when no tool returned relevant data, rather than
 // falling back to general knowledge.
 
-export const SYSTEM_PROMPT = `You are the conversational assistant for the University of Idaho IIDS (Institute for Interdisciplinary Data Sciences) institutional AI initiative site. You answer plain-language questions about IIDS-coordinated AI work — projects, owners, status, blockers, governance standards, reports, and strategic-plan alignment.
+export const SYSTEM_PROMPT = `You are the conversational assistant for the University of Idaho IIDS (Institute for Interdisciplinary Data Sciences) institutional AI initiative site. You answer plain-language questions about IIDS-coordinated AI work — projects, owners, status, blockers, governance standards, reports, strategic-plan alignment, and how work moves through the institution's intake and deployment process.
 
 # How you work
 
@@ -26,7 +26,10 @@ For every user question:
 - Faculty/staff or student survey — "what did the survey say" / pain points / "what are people asking for": **lookup_survey_themes**. "Which projects emerge from the survey" / unmet demand / survey-driven gaps: **list_survey_candidate_projects** (these are triage proposals, never approved work — say so).
 - "How does the survey align with ongoing/requested projects": **list_survey_candidate_projects** (each candidate carries a coverage verdict and related portfolio links) plus **list_requested_projects** to cross-reference the intake backlog — call both, then connect them.
 - The faculty/staff and student surveys are SEPARATE instruments. When the user scopes to one ("the student survey…"), pass \`audience\` to the survey tools and answer for that audience only — say which items are shared with the other audience rather than silently merging them.
-- Money questions — "which projects save money" / "what replaces enterprise systems" / bottom-line ROI: **search_portfolio** (every row carries \`enterpriseSystemReplacement\` — incumbent system, annual cost, renewal date); the roll-up view is [/coordination/intake-crosswalk](/coordination/intake-crosswalk).
+- OIT's process — "has X been through OIT" / "what projects have been initiated within OIT's process" / "what does OIT require before deployment" / stages, gates, scope: **lookup_oit_pathway**. A project on the pathway has ENTERED a process with gates, not passed it — never call a pathway position an approval.
+- OIT's own work — "what is OIT working on" / "what's on OIT's plate this year" / "who is the TPM for X" / "how does our work overlap with OIT's": **lookup_oit_portfolio**. These are OIT's projects, not ours. Only rows carrying an explicit crosswalk are the same effort as one of our projects; shared subject matter is not evidence of a match, so do not pair projects up because they sound related.
+- Intake vocabulary — "what track is X on" / "which projects are fast-lane" / "what data does X touch" / "how would this be classified": **lookup_intake_profile**. Data classification and AI-risk tier are pending on every project (the CADSO office has not made those calls) — say pending; never infer a classification or risk tier yourself.
+- Money questions — "which projects save money" / "what replaces enterprise systems" / bottom-line ROI: **lookup_intake_profile** with \`replacesEnterpriseSystem: true\` for the roll-up (incumbent system, annual cost, renewal date, portfolio-wide total), or **search_portfolio** when the user names a specific project. The roll-up surface is [/coordination/intake-crosswalk](/coordination/intake-crosswalk).
 - "What's blocking X" / "what's stalled" / "where are we waiting": **list_active_blockers** or **search_blockers** (filter by category or named party).
 - "What standards…" / "OIT standards" / "software standards": **list_standards** (optionally filter by status), then **get_standard** for the full detail of a specific item.
 - "What's the latest report" / "show me the briefs" / "what has IIDS published": **list_reports** (optionally filter by kind), then **get_report** for the abstract.
@@ -36,6 +39,8 @@ For every user question:
 - GitHub issues / "what's open in the tracker" / "what bug is X": **list_open_issues** (optionally filter by label), **search_issues** by title, **get_issue** for full body.
 
 When a question mentions a name you don't recognise, do not assume it's out-of-scope — call **search_portfolio** with that name first. Only refuse if the search comes back empty.
+
+Questions about *process* — how something gets approved, what OIT requires, what happens after a request is filed, how our work relates to OIT's — are in scope and have tools. Reach for **lookup_oit_pathway**, **lookup_oit_portfolio**, or **lookup_intake_profile** before concluding you have no data.
 
 # Strict citation policy
 

--- a/lib/agent/tools/lookup-intake-profile.ts
+++ b/lib/agent/tools/lookup-intake-profile.ts
@@ -1,0 +1,144 @@
+// lookup_intake_profile — how our projects sit against the Chief AI &
+// Data Science Officer's Unified Technology Request vocabulary.
+//
+// The crosswalk surface (/coordination/intake-crosswalk) answers "which
+// track is this on, who owns it, what data does it touch, what does it
+// replace". None of that was reachable by the agent: search_portfolio
+// returns our own lifecycle vocabulary, not the intake one.
+//
+// Two fields are deliberately empty everywhere: dataClassification and
+// aiRiskTier are the CADSO office's calls to make and have not been
+// made. They resolve to null rather than to a guess, and the tool
+// reports the pending counts so the model says "pending" instead of
+// inferring a tier from the project description.
+
+import "server-only";
+import {
+  allGovernanceProfiles,
+  governanceCoverage,
+  BUILD_TYPE_LABEL,
+  INTAKE_TRACK_LABEL,
+  DATA_CLASSIFICATION_LABEL,
+  AI_RISK_LABEL,
+  type ResolvedProfile,
+} from "@/lib/governance-profile";
+import { ROI_RUBRIC_READY, formatAnnualUsd } from "@/lib/roi-rubric";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const CANONICAL_URL = "/coordination/intake-crosswalk";
+
+function pickString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function serialise(p: ResolvedProfile) {
+  return {
+    slug: p.slug,
+    name: p.name,
+    url: `/portfolio/${p.slug}`,
+    businessNeed: p.businessNeed,
+    whyItExists: p.whyItExists,
+    homeUnits: p.homeUnits,
+    functionalOwners: p.functionalOwners.map((o) => o.name),
+    technicalLead: p.technicalLead,
+    intakeTrack: INTAKE_TRACK_LABEL[p.intakeTrack],
+    buildType: BUILD_TYPE_LABEL[p.buildType],
+    dataDomains: p.dataDomains,
+    dataClassification: p.dataClassification
+      ? DATA_CLASSIFICATION_LABEL[p.dataClassification]
+      : "Pending — the CADSO office's classification call",
+    aiRiskTier: p.aiRiskTier
+      ? AI_RISK_LABEL[p.aiRiskTier]
+      : "Pending — AI-risk review not yet completed",
+    fundingSource: p.fundingSource,
+    replaces: p.bottomLineRoi
+      ? {
+          system: p.bottomLineRoi.systemName,
+          annualCost: formatAnnualUsd(p.bottomLineRoi.annualUsd),
+          renewalDate: p.bottomLineRoi.renewalDate ?? null,
+          status: p.enterpriseReplacementStatus,
+        }
+      : null,
+  };
+}
+
+export const lookupIntakeProfileTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_intake_profile",
+      description:
+        "How our projects map onto the Chief AI & Data Science Officer's Unified Technology Request intake vocabulary: intake track (fast-lane / A / B / C / external), build type (built in-house, bought, hybrid), data domains touched, data classification, AI-risk tier, funding source, and what enterprise system the project replaces with the incumbent's annual cost and renewal date. Use for: 'what track is X on', 'which projects are fast-lane', 'what data does X touch', 'which projects replace licensed software', 'what would this cost us to keep'. Data classification and AI-risk tier are PENDING on every project — those are the CADSO office's determinations and have not been made. Report them as pending; never infer a classification or risk tier from a project description.",
+      parameters: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description:
+              "Optional portfolio slug for one project's full intake profile.",
+          },
+          track: {
+            type: "string",
+            description:
+              "Optional filter: 'fast-lane', 'track-a', 'track-b', 'track-c', or 'external'.",
+          },
+          replacesEnterpriseSystem: {
+            type: "boolean",
+            description:
+              "When true, return only projects that replace a licensed enterprise system (the hard-dollar savings cases).",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const slug = pickString(rawArgs, "slug");
+    const track = pickString(rawArgs, "track");
+    const replacesOnly = rawArgs.replacesEnterpriseSystem === true;
+
+    const all = allGovernanceProfiles();
+    const coverage = governanceCoverage(all);
+
+    let rows = all;
+    if (slug) rows = rows.filter((p) => p.slug === slug);
+    if (track) rows = rows.filter((p) => p.intakeTrack === track);
+    if (replacesOnly) rows = rows.filter((p) => p.bottomLineRoi !== null);
+
+    return {
+      data: {
+        note: "Intake vocabulary mirrors the Unified Technology Request. Data classification and AI-risk tier are the CADSO office's calls and are pending on every project — report them as pending, do not infer them.",
+        roiRubric: ROI_RUBRIC_READY
+          ? "Published."
+          : "Not yet published by the CADSO office. Replacement economics below are incumbent license costs on the record, not projected savings.",
+        totalProfiled: coverage.total,
+        returned: rows.length,
+        pending: {
+          dataClassification: coverage.classificationPending,
+          aiRiskTier: coverage.aiRiskPending,
+          roiScore: coverage.roiPending,
+        },
+        replacementEconomics: {
+          projectsReplacingLicensedSystems: coverage.bottomLineCount,
+          totalIncumbentAnnualCost: formatAnnualUsd(
+            coverage.bottomLineTotalUsd,
+          ),
+        },
+        trackBreakdown: Object.entries(coverage.byTrack).map(
+          ([track, count]) => ({
+            track,
+            label: INTAKE_TRACK_LABEL[track as keyof typeof INTAKE_TRACK_LABEL],
+            count,
+          }),
+        ),
+        projects: rows.map(serialise),
+      },
+      canonicalUrl: CANONICAL_URL,
+      links: rows.map((p) => ({ label: p.name, url: `/portfolio/${p.slug}` })),
+    };
+  },
+};

--- a/lib/agent/tools/lookup-oit-pathway.ts
+++ b/lib/agent/tools/lookup-oit-pathway.ts
@@ -1,0 +1,120 @@
+// lookup_oit_pathway — the OIT deployment process for teams building
+// outside OIT, and which of our projects have entered it.
+//
+// This is the "has this been through OIT's process?" tool. The pathway
+// data (lib/oit-pathway.ts) is a typed reading of two OIT wiki drafts:
+// the Enterprise AI Development Framework (tech standards) and the
+// AI-Assisted Builder Guide (the six-stage process). Before this tool
+// existed the agent had no way to answer pathway questions and refused
+// them — the data was only reachable by browsing /coordination/oit-pathway.
+//
+// Positions are stated as "entering Stage N", never as approvals. The
+// source module is careful about that distinction and so is this tool:
+// a project on the pathway has not been blessed by OIT, it has entered
+// a process with gates it has not yet passed.
+
+import "server-only";
+import {
+  IN_SCOPE_TRIGGERS,
+  OIT_SOURCE_DOCS,
+  OUT_OF_SCOPE_EXAMPLES,
+  PATHWAY_MILESTONES,
+  PATHWAY_PROJECTS,
+  PATHWAY_RULES,
+  PATHWAY_STAGES,
+} from "@/lib/oit-pathway";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const CANONICAL_URL = "/coordination/oit-pathway";
+
+function pickString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+export const lookupOitPathwayTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_oit_pathway",
+      description:
+        "The OIT deployment pathway for teams building outside OIT, and which IIDS projects have entered it. Use for: 'what projects have been initiated within OIT's process', 'has X gone through OIT', 'what does OIT require before deployment', 'what are the stages/gates', 'is X in scope for the framework'. Returns the six-stage lifecycle with its gates, the six standing rules, the scope triggers that pull a project in, and each project's position with the questions its gates will ask. IMPORTANT: a project on the pathway has ENTERED a process, not passed it — never describe a position as an approval, and never assert a project has cleared a gate unless the position says so.",
+      parameters: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            description:
+              "Optional portfolio slug (e.g. 'openera', 'ucm-daily-register') to return just that project's pathway position and gate questions. Omit for the whole pathway plus every project on it.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const slug = pickString(rawArgs, "slug");
+
+    const projects = slug
+      ? PATHWAY_PROJECTS.filter((p) => p.slug === slug)
+      : PATHWAY_PROJECTS;
+
+    const projectPayload = projects.map((p) => ({
+      slug: p.slug,
+      name: p.name,
+      portfolioUrl: `/portfolio/${p.slug}`,
+      whyInScope: p.scopeTrigger,
+      position: p.position,
+      standingFacts: p.standingFacts,
+      questionsItsGatesWillAsk: p.gateQuestions,
+    }));
+
+    // A slug lookup that matches nothing is a real answer ("that project
+    // is not on the pathway"), not an error — the model needs the full
+    // roster to say so accurately.
+    const notOnPathway = slug !== undefined && projects.length === 0;
+
+    return {
+      data: {
+        note: "Positions describe entry into a process with gates, not approval. No project below has cleared its gates.",
+        projectsOnPathway: projectPayload,
+        ...(notOnPathway
+          ? {
+              lookupResult: `No project with slug "${slug}" has entered the OIT pathway.`,
+              projectsCurrentlyOnPathway: PATHWAY_PROJECTS.map((p) => p.slug),
+            }
+          : {}),
+        totalProjectsOnPathway: PATHWAY_PROJECTS.length,
+        lifecycle: PATHWAY_STAGES.map((s) => ({
+          stage: s.number,
+          name: s.name,
+          ledBy: s.ledBy,
+          summary: s.summary,
+          gate: s.gate ?? null,
+        })),
+        operatingMilestones: PATHWAY_MILESTONES.map((m) => ({
+          id: m.id,
+          stage: m.stage,
+          name: m.name,
+          ledBy: m.ledBy,
+          summary: m.summary,
+          completeWhen: m.completeWhen,
+          boundary: m.boundary,
+          openQuestions: m.openQuestions ?? [],
+        })),
+        standingRules: PATHWAY_RULES,
+        inScopeTriggers: IN_SCOPE_TRIGGERS,
+        outOfScopeExamples: OUT_OF_SCOPE_EXAMPLES,
+        sourceDocuments: OIT_SOURCE_DOCS,
+      },
+      canonicalUrl: CANONICAL_URL,
+      links: projects.map((p) => ({
+        label: p.name,
+        url: `/portfolio/${p.slug}`,
+      })),
+    };
+  },
+};

--- a/lib/agent/tools/lookup-oit-portfolio.ts
+++ b/lib/agent/tools/lookup-oit-portfolio.ts
@@ -1,0 +1,154 @@
+// lookup_oit_portfolio — OIT's own FY2027 Enterprise Applications
+// portfolio, and the rows it shares with our inventory.
+//
+// This answers "what is OIT working on" and "how does our work line up
+// with theirs" — questions the portfolio tools cannot, because OIT's
+// rows are not our projects. lib/oit-ea-portfolio.ts keeps OIT's columns
+// in OIT's vocabulary (priority, owning team, TPM, effort by discipline)
+// rather than folding them into ours.
+//
+// The crosswalk is deliberately conservative: only three of 61 rows are
+// linked, each with an owner-affirmed note. Subject-matter adjacency is
+// not evidence two rows are the same project (owner decision, July 2026),
+// and the tool says so in-band so the model does not "helpfully" pair up
+// projects that merely sound related.
+
+import "server-only";
+import {
+  CROSSWALK_CONFIDENCE_LABELS,
+  OIT_EA_PROJECTS,
+  SOURCE_AS_OF,
+  SOURCE_FISCAL_YEAR,
+  crosswalkedProjects,
+  priorityCounts,
+  surfaceLinkedProjects,
+  teamCounts,
+  type OitEaProject,
+} from "@/lib/oit-ea-portfolio";
+import type { ToolHandler, ToolResult } from "./registry";
+
+const CANONICAL_URL = "/coordination/oit-portfolio";
+
+function pickString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+function serialise(p: OitEaProject) {
+  return {
+    id: p.id,
+    name: p.name,
+    priority: p.priority,
+    category: p.category,
+    primaryTeam: p.primaryTeam,
+    tpmOrManager: p.tpmOrManager,
+    effort: p.effort,
+    notes: p.notes ?? null,
+    ourProject: p.portfolioSlug
+      ? {
+          slug: p.portfolioSlug,
+          url: `/portfolio/${p.portfolioSlug}`,
+          confidence: p.crosswalkConfidence
+            ? CROSSWALK_CONFIDENCE_LABELS[p.crosswalkConfidence]
+            : null,
+          basis: p.crosswalkNote ?? null,
+        }
+      : null,
+  };
+}
+
+export const lookupOitPortfolioTool: ToolHandler = {
+  definition: {
+    type: "function",
+    function: {
+      name: "lookup_oit_portfolio",
+      description: `OIT's own ${SOURCE_FISCAL_YEAR} Enterprise Applications portfolio — what OIT has committed to this fiscal year, in OIT's tracking structure (priority, work category, owning team, TPM/manager, and effort split across TPM / development / administration / systems). Use for: 'what is OIT working on', 'what is OIT's committed load', 'how does our work overlap with OIT's', 'who is the TPM for X'. These are OIT's projects, NOT IIDS projects — use search_portfolio for ours. Only rows carrying an explicit crosswalk are the same work as one of our projects; shared subject matter is NOT evidence of a match, so never claim an OIT row and one of our projects are the same effort unless the row's crosswalk says so.`,
+      parameters: {
+        type: "object",
+        properties: {
+          priority: {
+            type: "string",
+            description:
+              "Optional filter: 'Critical', 'High', 'Medium', or 'Low'.",
+          },
+          team: {
+            type: "string",
+            description:
+              "Optional filter on OIT's primary team, e.g. 'Enterprise Applications', 'Development', 'Systems'.",
+          },
+          crosswalkedOnly: {
+            type: "boolean",
+            description:
+              "When true, return only the rows confirmed as the same work one of our projects tracks.",
+          },
+          query: {
+            type: "string",
+            description:
+              "Optional case-insensitive substring match on the OIT project name.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  async execute(rawArgs): Promise<ToolResult> {
+    const priority = pickString(rawArgs, "priority");
+    const team = pickString(rawArgs, "team");
+    const query = pickString(rawArgs, "query")?.toLowerCase();
+    const crosswalkedOnly = rawArgs.crosswalkedOnly === true;
+
+    let rows: OitEaProject[] = [...OIT_EA_PROJECTS];
+    if (crosswalkedOnly) rows = rows.filter((p) => p.portfolioSlug);
+    if (priority) {
+      rows = rows.filter(
+        (p) => p.priority.toLowerCase() === priority.toLowerCase(),
+      );
+    }
+    if (team) {
+      rows = rows.filter(
+        (p) => p.primaryTeam.toLowerCase() === team.toLowerCase(),
+      );
+    }
+    if (query) {
+      rows = rows.filter(
+        (p) =>
+          p.name.toLowerCase().includes(query) ||
+          (p.sourceName?.toLowerCase().includes(query) ?? false),
+      );
+    }
+
+    return {
+      data: {
+        fiscalYear: SOURCE_FISCAL_YEAR,
+        sourceAsOf: SOURCE_AS_OF,
+        note: `Point-in-time transcription of OIT's ${SOURCE_FISCAL_YEAR} portfolio spreadsheet. These are OIT's commitments, not IIDS projects.`,
+        crosswalkPolicy:
+          "Only rows with an explicit crosswalk are the same work as one of our projects. Subject-matter adjacency is not treated as evidence of a match.",
+        totalInPortfolio: OIT_EA_PROJECTS.length,
+        totalCrosswalked: crosswalkedProjects().length,
+        returned: rows.length,
+        projects: rows.map(serialise),
+        priorityBreakdown: priorityCounts(),
+        teamBreakdown: teamCounts(),
+        rowsTouchingOurSurfacesWithoutBeingOurProjects: surfaceLinkedProjects().map(
+          (p) => ({
+            name: p.name,
+            surface: p.relatedSurface?.label ?? null,
+            url: p.relatedSurface?.href ?? null,
+            note: p.relatedSurface?.note ?? null,
+          }),
+        ),
+      },
+      canonicalUrl: CANONICAL_URL,
+      links: rows
+        .filter((p) => p.portfolioSlug)
+        .map((p) => ({
+          label: p.name,
+          url: `/portfolio/${p.portfolioSlug}`,
+        })),
+    };
+  },
+};


### PR DESCRIPTION
> **what IIDS projects have been initiated within OIT's process?**
> I don't have data on that. Try browsing [/portfolio](/portfolio) for the active project list.

The refusal was *correct behaviour* for the tool set the agent had. The whole Coordination surface was invisible to it: `lib/oit-pathway.ts`, `lib/oit-ea-portfolio.ts`, and `lib/governance-profile.ts` had no tool exposing them, so no tool could return relevant data and the strict-citation policy did exactly what it should. The bug is missing tools, not a bad refusal.

## Three new read-only tools

| Tool | Answers | Source |
|---|---|---|
| `lookup_oit_pathway` | "has X been through OIT", "what does OIT require", stages and gates | `lib/oit-pathway.ts` |
| `lookup_oit_portfolio` | "what is OIT working on", "who's the TPM for X", overlap with our work | `lib/oit-ea-portfolio.ts` |
| `lookup_intake_profile` | "what track is X on", "which projects replace licensed software" | `lib/governance-profile.ts` |

## Caveats travel with the data, not just the prompt

Each tool states its constraints in its own payload, so they survive a long context:

- A pathway position is **entry into a process with gates, not approval**. No project below has cleared its gates.
- **Subject-matter adjacency is not evidence** that an OIT row and one of our projects are the same effort — only explicit crosswalks count (3 of 61).
- **Data classification and AI-risk tier are pending on all 29 projects.** Those are the CADSO office's calls; the tool returns "Pending" strings rather than nulls the model might fill in.

`lookup_oit_pathway` with a slug that isn't on the pathway returns that as an *answer* plus the full roster, so the model says "MindRouter has not entered the pathway; OpenERA and UCM Daily Register have" instead of refusing.

## Verification

Handlers exercised directly (`tsx`, `server-only` stubbed):

- pathway → 2 projects (OpenERA, UCM Daily Register, both Stage 1), 6 stages, 6 rules; miss case returns the roster
- OIT portfolio → 61 total, 3 crosswalked (Databricks→data-infrastructure-pilot, VERAS→openera, Nexus→nexus), 10 Critical
- intake → 29 profiled, 4 replacing licensed systems totalling $447,000/yr, classification pending 29/29

`npm run build`, `npm run lint`, `npx tsc --noEmit`, `npm run verify:portfolio` all clean. End-to-end chat verification needs MindRouter credentials, which only the deployed environments have — will confirm on dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)