### PR TITLE
Recover tool calls the model writes as prose

### DIFF
--- a/lib/agent/loop.ts
+++ b/lib/agent/loop.ts
@@ -39,6 +39,11 @@ import { lookupOitPathwayTool } from "./tools/lookup-oit-pathway";
 import { lookupOitPortfolioTool } from "./tools/lookup-oit-portfolio";
 import { lookupIntakeProfileTool } from "./tools/lookup-intake-profile";
 import { createRegistry, type Audience, type ToolRegistry } from "./tools/registry";
+import {
+  looksLikeImitatedToolCall,
+  mentionsKnownTool,
+  salvageToolCalls,
+} from "./salvage-tool-call";
 
 const MAX_ITERATIONS = 6;
 
@@ -56,6 +61,11 @@ const LOOP_MAX_TOKENS = 4096;
 // out-of-scope questions still resolve cleanly.
 const NO_TOOLS_NUDGE =
   "You have not called any tools yet. Do not describe what you plan to do — either call the tool(s) needed to answer now, or output the standard refusal. Never answer with placeholders or empty section headers.";
+
+// Last-resort text when every recovery path has failed. Matches the
+// refusal phrasing in the system prompt so the user sees one voice.
+const SALVAGE_FAILED_REFUSAL =
+  "I don't have data on that. Try browsing [/portfolio](/portfolio) for the active project list.";
 
 export const publicRegistry: ToolRegistry = createRegistry([
   searchPortfolioTool,
@@ -104,6 +114,13 @@ export interface AgentResponse {
   toolCalls: ToolCallTrace[];
   iterations: number;
   truncated: boolean;
+  /**
+   * How many tool calls this turn had to be recovered from assistant
+   * prose rather than read off the tool channel. Non-zero means the
+   * model is misbehaving even though the user got a good answer — worth
+   * watching if it climbs after a model change.
+   */
+  salvagedToolCalls: number;
 }
 
 export interface RunOptions {
@@ -210,21 +227,27 @@ export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
   ];
 
   const tools = registry.list();
+  const toolNames = tools.map((t) => t.function.name);
   const citations: Citation[] = [];
   const toolCalls: ToolCallTrace[] = [];
   let nudged = false;
   let needsSynthesis = false;
   let iterationsUsed = 0;
+  let salvageCount = 0;
+  // Set for one call only, when the model narrated an intent to use a
+  // tool but emitted nothing runnable. See the nudge branch below.
+  let forceToolCall = false;
 
   for (let iter = 1; iter <= MAX_ITERATIONS; iter++) {
     iterationsUsed = iter;
     const response = await chatCompletion({
       messages,
       tools,
-      tool_choice: "auto",
+      tool_choice: forceToolCall ? "required" : "auto",
       temperature: 0.2,
       max_tokens: LOOP_MAX_TOKENS,
     });
+    forceToolCall = false;
 
     const choice = response.choices[0];
     if (!choice) {
@@ -234,11 +257,33 @@ export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
         toolCalls,
         iterations: iter,
         truncated: false,
+        salvagedToolCalls: salvageCount,
       };
     }
 
     const msg = choice.message;
-    const calls = msg.tool_calls ?? [];
+    let calls = msg.tool_calls ?? [];
+
+    // Salvage pass: the model sometimes writes a tool call as prose
+    // instead of emitting it on the tool channel. When the text names a
+    // registered tool, run it — the intent is unambiguous and nudging
+    // has been observed to just produce the imitation again in a
+    // different syntax. Real tool_calls always win; this only fires when
+    // the channel came back empty.
+    if (calls.length === 0) {
+      const salvaged = salvageToolCalls(msg.content ?? "", toolNames);
+      if (salvaged.length > 0) {
+        salvageCount += salvaged.length;
+        calls = salvaged.map((s, i) => ({
+          id: `salvaged_${iter}_${i}`,
+          type: "function" as const,
+          function: {
+            name: s.name,
+            arguments: JSON.stringify(s.arguments),
+          },
+        }));
+      }
+    }
 
     if (calls.length === 0) {
       // Narration guard: a final answer before ANY tool has run is
@@ -247,6 +292,11 @@ export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
       // permits the refusal, so a clean refusal comes straight back.
       if (toolCalls.length === 0 && !nudged) {
         nudged = true;
+        // If the narration named a tool, the model meant to call one and
+        // botched the channel — make the retry mandatory rather than
+        // hoping the wording lands. A genuine out-of-scope refusal names
+        // no tool and keeps "auto", so it still comes straight back.
+        forceToolCall = mentionsKnownTool(msg.content ?? "", toolNames);
         messages.push({ role: "assistant", content: msg.content ?? "" });
         messages.push({ role: "user", content: NO_TOOLS_NUDGE });
         continue;
@@ -258,20 +308,43 @@ export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
         needsSynthesis = true;
         break;
       }
+      // A leftover imitation that salvage couldn't run (unknown tool
+      // name, unparseable args) must never reach the user as markup.
+      // With tool results in hand, force a synthesis turn; without any,
+      // refuse in the standard voice.
+      if (looksLikeImitatedToolCall(text, toolNames)) {
+        if (toolCalls.length > 0) {
+          needsSynthesis = true;
+          break;
+        }
+        return {
+          response: SALVAGE_FAILED_REFUSAL,
+          citations: dedupeCitations(citations),
+          toolCalls,
+          iterations: iter,
+          truncated: false,
+          salvagedToolCalls: salvageCount,
+        };
+      }
       return {
         response: msg.content ?? "",
         citations: dedupeCitations(citations),
         toolCalls,
         iterations: iter,
         truncated: false,
+        salvagedToolCalls: salvageCount,
       };
     }
 
     // Append the assistant's tool-call turn to the running log so the
-    // model sees its own decision when we come back around.
+    // model sees its own decision when we come back around. On a salvage
+    // the content IS the imitation markup — drop it, so the log models a
+    // well-formed tool-call turn rather than echoing the bad pattern
+    // back into the context.
+    const salvagedThisTurn = (msg.tool_calls ?? []).length === 0;
     messages.push({
       role: "assistant",
-      content: msg.content ?? null,
+      content: salvagedThisTurn ? null : msg.content ?? null,
       tool_calls: calls,
     });
 
@@ -318,5 +391,6 @@ export async function runAgent(opts: RunOptions): Promise<AgentResponse> {
     toolCalls,
     iterations: iterationsUsed,
     truncated: !needsSynthesis,
+    salvagedToolCalls: salvageCount,
   };
 }

--- a/lib/agent/salvage-tool-call.ts
+++ b/lib/agent/salvage-tool-call.ts
@@ -1,0 +1,202 @@
+// Salvage tool calls the model wrote as prose instead of emitting on the
+// native tool-calling channel.
+//
+// Observed on qwen3.6-27b through MindRouter (2026-07-24 and again
+// 2026-07-25): instead of returning `tool_calls`, the model writes a
+// textual imitation of one and that text becomes the final answer. The
+// NO_TOOLS_NUDGE in loop.ts catches some of these; when it doesn't, the
+// user sees raw markup where an answer should be. Three syntaxes have
+// been observed in the wild, all three parsed here:
+//
+//   1. Anthropic-style XML
+//      <invoke name="search_portfolio">
+//        <parameter name="query">OpenERA</parameter>
+//      </invoke>
+//   2. Tool name as the element
+//      <search_portfolio query="MindRouter">
+//   3. JSON, often fenced and/or wrapped in <details>
+//      {"tool": "search_portfolio", "parameters": {"query": "MindRouter"}}
+//
+// The model has told us exactly what it wants; it just used the wrong
+// channel. Rather than nudge and hope, the loop parses the intent and
+// runs the tool.
+//
+// This is deliberately conservative. A parse is only accepted when the
+// extracted name matches a REGISTERED tool — an unknown name means we
+// guessed wrong about what the text is, and guessing wrong here would
+// fabricate a tool call the model never intended. Everything else falls
+// through to the nudge and then to the refusal.
+
+/** A tool call recovered from assistant prose. */
+export interface SalvagedCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+function coerceScalar(raw: string): unknown {
+  const v = raw.trim();
+  if (v === "true") return true;
+  if (v === "false") return false;
+  if (v === "null") return null;
+  if (v !== "" && !Number.isNaN(Number(v))) return Number(v);
+  return v;
+}
+
+/** `<invoke name="x"><parameter name="k">v</parameter></invoke>` */
+function parseInvokeBlocks(text: string, known: Set<string>): SalvagedCall[] {
+  const out: SalvagedCall[] = [];
+  const invokeRe = /<invoke\s+name=["']([\w.-]+)["']\s*>([\s\S]*?)<\/invoke>/gi;
+  for (const m of text.matchAll(invokeRe)) {
+    const name = m[1];
+    if (!known.has(name)) continue;
+    const args: Record<string, unknown> = {};
+    const paramRe =
+      /<parameter\s+name=["']([\w.-]+)["']\s*>([\s\S]*?)<\/parameter>/gi;
+    for (const p of m[2].matchAll(paramRe)) {
+      args[p[1]] = coerceScalar(p[2]);
+    }
+    out.push({ name, arguments: args });
+  }
+  return out;
+}
+
+/** `<search_portfolio query="MindRouter">` — tool name as the element. */
+function parseNamedElements(text: string, known: Set<string>): SalvagedCall[] {
+  const out: SalvagedCall[] = [];
+  const elRe = /<([\w.-]+)((?:\s+[\w.-]+=["'][^"']*["'])*)\s*\/?>/g;
+  for (const m of text.matchAll(elRe)) {
+    const name = m[1];
+    if (!known.has(name)) continue;
+    const args: Record<string, unknown> = {};
+    const attrRe = /([\w.-]+)=["']([^"']*)["']/g;
+    for (const a of (m[2] ?? "").matchAll(attrRe)) {
+      args[a[1]] = coerceScalar(a[2]);
+    }
+    out.push({ name, arguments: args });
+  }
+  return out;
+}
+
+/**
+ * `{"tool": "x", "parameters": {...}}` and its variants. Scans every
+ * balanced `{...}` region so fenced blocks, <details> wrappers, and
+ * surrounding prose all work without special-casing each container.
+ */
+function parseJsonObjects(text: string, known: Set<string>): SalvagedCall[] {
+  const out: SalvagedCall[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "{") continue;
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    for (let j = i; j < text.length; j++) {
+      const c = text[j];
+      if (esc) {
+        esc = false;
+        continue;
+      }
+      if (c === "\\") {
+        esc = true;
+        continue;
+      }
+      if (c === '"') inStr = !inStr;
+      if (inStr) continue;
+      if (c === "{") depth++;
+      else if (c === "}") {
+        depth--;
+        if (depth === 0) {
+          const slice = text.slice(i, j + 1);
+          try {
+            const parsed = JSON.parse(slice) as Record<string, unknown>;
+            const name = parsed.tool ?? parsed.name ?? parsed.tool_name;
+            if (typeof name === "string" && known.has(name)) {
+              const rawArgs =
+                parsed.parameters ?? parsed.arguments ?? parsed.args ?? {};
+              out.push({
+                name,
+                arguments:
+                  rawArgs && typeof rawArgs === "object"
+                    ? (rawArgs as Record<string, unknown>)
+                    : {},
+              });
+            }
+          } catch {
+            // Not JSON, or not valid — nothing to salvage from this span.
+          }
+          i = j; // don't rescan the interior
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract tool calls the model wrote as text. Returns [] when the text
+ * holds nothing that unambiguously names a registered tool — the caller
+ * should then fall back to nudging or refusing.
+ *
+ * `knownToolNames` is the gate: only registered tools are ever returned.
+ */
+export function salvageToolCalls(
+  text: string,
+  knownToolNames: Iterable<string>,
+): SalvagedCall[] {
+  if (!text.trim()) return [];
+  const known = new Set(knownToolNames);
+
+  const found = [
+    ...parseInvokeBlocks(text, known),
+    ...parseNamedElements(text, known),
+    ...parseJsonObjects(text, known),
+  ];
+
+  // De-dupe: the same intent can match more than one grammar (a JSON
+  // block inside a <details> element, say). Keyed on name + args.
+  const seen = new Set<string>();
+  const unique: SalvagedCall[] = [];
+  for (const c of found) {
+    const key = `${c.name}::${JSON.stringify(c.arguments)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(c);
+  }
+  return unique;
+}
+
+/**
+ * True when assistant text looks like an imitated tool call rather than
+ * an answer. Used as a last-resort guard so raw markup is never returned
+ * to the user as the final response.
+ */
+export function looksLikeImitatedToolCall(
+  text: string,
+  knownToolNames: Iterable<string>,
+): boolean {
+  return salvageToolCalls(text, knownToolNames).length > 0;
+}
+
+/**
+ * True when the text names a registered tool at all — even with nothing
+ * parseable attached ("I'll search for OpenERA... **search_portfolio**").
+ *
+ * Weaker than salvage on purpose. It cannot tell the loop *what* to run,
+ * only that the model meant to run something, which is enough to
+ * distinguish an intended-but-botched call from a genuine refusal: a
+ * real out-of-scope refusal never names a tool. The loop uses it to
+ * decide whether the retry should force `tool_choice: "required"`.
+ */
+export function mentionsKnownTool(
+  text: string,
+  knownToolNames: Iterable<string>,
+): boolean {
+  if (!text.trim()) return false;
+  for (const name of knownToolNames) {
+    // Word-boundary match so `search_portfolio` in prose counts but a
+    // longer identifier that merely contains it does not.
+    const re = new RegExp(`(^|[^\\w-])${name}([^\\w-]|$)`);
+    if (re.test(text)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Verifying #308 on dev surfaced a **separate, pre-existing bug** that breaks basic questions. `What is MindRouter?` returned this as its answer:

```
<invoke name="search_portfolio">
<parameter name="query">OpenERA</parameter>
</invoke>
```

The model writes a *textual imitation* of a tool call instead of emitting one on the tool channel, `tool_calls` comes back empty, and the markup becomes the final response. `NO_TOOLS_NUDGE` (added 2026-07-24 for a related symptom) catches some cases, but the model frequently re-imitates in a different syntax and the loop returns that.

Three grammars observed on dev, all reproduced from real transcripts:

| Grammar | Example |
|---|---|
| Anthropic-style XML | `<invoke name="search_portfolio"><parameter name="query">OpenERA</parameter></invoke>` |
| Tool name as element | `<search_portfolio query="MindRouter">` |
| JSON, fenced / in `<details>` | `{"tool": "search_portfolio", "parameters": {"query": "MindRouter"}}` |

## Approach

The model told us exactly what it wants — it just used the wrong channel. Parse the intent and run the tool, rather than nudging and hoping.

**`lib/agent/salvage-tool-call.ts`** parses all three grammars plus the OpenAI `{"name","arguments"}` shape. Deliberately conservative: a parse is accepted **only when the extracted name matches a registered tool**. An unknown name means we misread the text, and guessing there would fabricate a call the model never intended — those fall through to the nudge and then the refusal.

**Pure narration** ("I'll search… **search_portfolio**") has nothing runnable to extract. For that, the nudge retry now sets `tool_choice: "required"` — but only when the text names a tool at all. A genuine out-of-scope refusal names no tool, keeps `"auto"`, and still returns in one pass, so `what's the weather` doesn't pay an extra round trip.

**Imitation markup can no longer reach the user.** If salvage fails and the text still looks like a call, the loop forces a synthesis turn when it has tool results, and refuses in the standard voice when it doesn't.

Two smaller things: on a salvage the assistant turn is logged with `null` content so the bad pattern isn't echoed back into context, and `AgentResponse` gains `salvagedToolCalls` so the misbehaviour stays visible in the `/api/ask` payload even when the user gets a good answer.

## Verification

Parser exercised against the captured imitations and a negative set:

```
xml-invoke           -> [{"name":"search_portfolio","arguments":{"query":"OpenERA"}}]
named-element        -> [{"name":"search_portfolio","arguments":{"query":"MindRouter"}}]
json-in-details      -> [{"name":"search_portfolio","arguments":{"query":"MindRouter"}}]
openai-style-json    -> [{"name":"lookup_oit_pathway","arguments":{"slug":"openera"}}]

must NOT salvage: plain answer · refusal · prose naming a tool ·
markdown with HTML · non-call JSON · unknown tool name  — all clean
```

`mentionsKnownTool` discriminates narration (`true`) from refusals (`false`), which is what gates the forced retry.

`npm run build`, `npm run lint`, `npx tsc --noEmit` clean. End-to-end re-test on dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)