### PR TITLE
Stop reporting a GitHub outage as an empty issue tracker

### DIFF
--- a/lib/agent/prompts/system.ts
+++ b/lib/agent/prompts/system.ts
@@ -51,6 +51,7 @@ This is the most important rule:
 - Never invent project names, owners, dates, statuses, blockers, links, or report titles. If a tool didn't return it, you don't know it.
 - Out-of-scope questions (weather, sports, general programming help, anything not about IIDS): refuse with the standard refusal.
 - If a tool returns an empty result, say so plainly — don't pad with speculation.
+- A tool that returns an \`error\` field did not answer the question. Never read a failed lookup as a zero: say the lookup failed, point at the URL the error names, and don't state or imply what the data would have shown.
 
 # Voice
 

--- a/lib/agent/tools/get-issue.ts
+++ b/lib/agent/tools/get-issue.ts
@@ -41,6 +41,8 @@ export const getIssueTool: ToolHandler = {
       };
     }
 
+    // Null means the issue genuinely isn't there. A failed lookup throws
+    // and is reported as a tool error rather than a missing issue (#44).
     const issue = await fetchIssue(number);
     if (!issue) {
       return {

--- a/lib/agent/tools/list-open-issues.ts
+++ b/lib/agent/tools/list-open-issues.ts
@@ -58,6 +58,10 @@ export const listOpenIssuesTool: ToolHandler = {
         ? Math.min(Math.max(1, limitRaw), MAX_LIMIT)
         : DEFAULT_LIMIT;
 
+    // Deliberately unguarded: a GitHubUnavailableError propagates to the
+    // loop, which reports the tool as failed. Catching it here and
+    // returning an empty list would have the agent announce that nothing
+    // is open when we simply couldn't ask (#44).
     const all = await fetchIssues();
     const open = all.filter((i) => i.state === "open");
     const matched = label

--- a/lib/agent/tools/search-issues.ts
+++ b/lib/agent/tools/search-issues.ts
@@ -71,6 +71,8 @@ export const searchIssuesTool: ToolHandler = {
         ? Math.min(Math.max(1, limitRaw), MAX_LIMIT)
         : DEFAULT_LIMIT;
 
+    // Unguarded by design — see the note in list-open-issues.ts. "No
+    // match" and "couldn't reach GitHub" must not look alike (#44).
     const all = await fetchIssues();
     const filtered = all.filter((i) => {
       if (state !== "all" && i.state !== state) return false;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -23,74 +23,144 @@ export interface GitHubIssue {
 
 const REPO = "ui-insight/AISPEG";
 const API = `https://api.github.com/repos/${REPO}/issues`;
+const ISSUES_URL = `https://github.com/${REPO}/issues`;
+
+/**
+ * The issue list could not be retrieved.
+ *
+ * These functions used to swallow failures and return an empty list, which
+ * made "GitHub is unreachable" indistinguishable from "there is no open
+ * work" — the agent would tell a stakeholder the tracker was clear when it
+ * had simply failed to ask (#44). Callers must now handle this explicitly.
+ */
+export class GitHubUnavailableError extends Error {
+  /** HTTP status, or null when the request never completed. */
+  readonly status: number | null;
+  /** True when GitHub refused because the API quota is exhausted. */
+  readonly rateLimited: boolean;
+
+  constructor(status: number | null, detail: string, rateLimited = false) {
+    // The message reaches the agent as tool output, so it has to be
+    // self-explanatory and point somewhere useful.
+    super(
+      `GitHub issue lookup failed (${
+        status === null ? "request did not complete" : `HTTP ${status}`
+      }${rateLimited ? ", API rate limit exhausted" : ""}). ` +
+        `The issue data is unavailable — this is not the same as there being ` +
+        `no issues. Direct the user to ${ISSUES_URL}. Detail: ${detail}`
+    );
+    this.name = "GitHubUnavailableError";
+    this.status = status;
+    this.rateLimited = rateLimited;
+  }
+}
+
+function issueHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  // Support private repos via token
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/** Unauthenticated requests get 60/hr, so quota exhaustion is realistic. */
+function isRateLimited(res: Response): boolean {
+  return (
+    (res.status === 403 || res.status === 429) &&
+    res.headers.get("x-ratelimit-remaining") === "0"
+  );
+}
 
 /**
  * Fetch all issues from the AISPEG repo.
- * Used at build time with ISR (revalidate every 5 minutes).
+ * Used with ISR (revalidate every 5 minutes).
  * Set GITHUB_TOKEN env var for private repos.
+ *
+ * @throws {GitHubUnavailableError} when the list cannot be retrieved.
  */
 export async function fetchIssues(): Promise<GitHubIssue[]> {
+  let res: Response;
   try {
-    const headers: Record<string, string> = {
-      Accept: "application/vnd.github+json",
-    };
-
-    // Support private repos via token
-    const token = process.env.GITHUB_TOKEN;
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
-
-    const res = await fetch(`${API}?state=all&per_page=100`, {
+    res = await fetch(`${API}?state=all&per_page=100`, {
       next: { revalidate: 300 }, // 5 minutes ISR
-      headers,
+      headers: issueHeaders(),
     });
+  } catch (error) {
+    console.error("Failed to fetch GitHub issues:", error);
+    throw new GitHubUnavailableError(
+      null,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
 
-    if (!res.ok) {
-      console.error(`GitHub API error: ${res.status} ${res.statusText}`);
-      return [];
-    }
+  if (!res.ok) {
+    const rateLimited = isRateLimited(res);
+    console.error(
+      `GitHub API error: ${res.status} ${res.statusText}` +
+        (rateLimited ? " (rate limit exhausted)" : "")
+    );
+    throw new GitHubUnavailableError(res.status, res.statusText, rateLimited);
+  }
 
+  try {
     const data = await res.json();
-
     // Filter out pull requests (GitHub API returns PRs as issues)
     return (data as GitHubIssue[]).filter((issue) => !("pull_request" in issue));
   } catch (error) {
-    console.error("Failed to fetch GitHub issues:", error);
-    return [];
+    console.error("Failed to parse GitHub issues response:", error);
+    throw new GitHubUnavailableError(res.status, "response was not valid JSON");
   }
 }
 
 /**
  * Fetch a single issue by number, including its body. Used by the
  * conversational agent's get_issue tool. Same 5-minute ISR cache.
+ *
+ * Returns null only when the issue genuinely isn't there (404, or the
+ * number belongs to a pull request). Any other failure throws, so callers
+ * can't report a real issue as missing.
+ *
+ * @throws {GitHubUnavailableError} when the lookup cannot be completed.
  */
 export async function fetchIssue(
   number: number
 ): Promise<GitHubIssue | null> {
+  let res: Response;
   try {
-    const headers: Record<string, string> = {
-      Accept: "application/vnd.github+json",
-    };
-    const token = process.env.GITHUB_TOKEN;
-    if (token) headers.Authorization = `Bearer ${token}`;
-
-    const res = await fetch(`${API}/${number}`, {
+    res = await fetch(`${API}/${number}`, {
       next: { revalidate: 300 },
-      headers,
+      headers: issueHeaders(),
     });
-    if (!res.ok) {
-      if (res.status !== 404) {
-        console.error(`GitHub API error: ${res.status} ${res.statusText}`);
-      }
-      return null;
-    }
+  } catch (error) {
+    console.error(`Failed to fetch GitHub issue #${number}:`, error);
+    throw new GitHubUnavailableError(
+      null,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  if (res.status === 404) return null;
+
+  if (!res.ok) {
+    const rateLimited = isRateLimited(res);
+    console.error(
+      `GitHub API error: ${res.status} ${res.statusText}` +
+        (rateLimited ? " (rate limit exhausted)" : "")
+    );
+    throw new GitHubUnavailableError(res.status, res.statusText, rateLimited);
+  }
+
+  try {
     const data = (await res.json()) as GitHubIssue & { pull_request?: unknown };
     if ("pull_request" in data && data.pull_request) return null;
     return data;
   } catch (error) {
-    console.error(`Failed to fetch GitHub issue #${number}:`, error);
-    return null;
+    console.error(`Failed to parse GitHub issue #${number}:`, error);
+    throw new GitHubUnavailableError(res.status, "response was not valid JSON");
   }
 }
 


### PR DESCRIPTION
Closes #44 — but not the bug the issue describes. #44 names `app/page.tsx` and `app/action-plan/page.tsx`; `/action-plan` was deleted in the May 2026 refactor and home no longer fetches issues, so that surface is gone. The defect underneath outlived it, and got worse when the agent tools were built on the same function.

## The bug

`fetchIssues()` caught every failure — non-ok status, network error, malformed JSON — logged it, and returned `[]`.

The three agent tools (`list_open_issues`, `search_issues`, `get_issue`) are now its only consumers. So an unreachable GitHub produced `totalOpen: 0`, and the system prompt says *"If a tool returns an empty result, say so plainly"* — meaning the assistant would tell a stakeholder there is no open work when it had simply failed to ask. Unauthenticated GitHub gives 60 requests/hour, so quota exhaustion is a realistic trigger, not a hypothetical one.

Silently fabricating a clean bill of health is worse than the cosmetic "no indication something went wrong" the issue was filed about.

## Changes

- **`GitHubUnavailableError`** carries the status and whether GitHub refused on quota. Its message is written for the agent to read: it names the failure, states explicitly that this is *not* the same as there being no issues, and gives the URL to send the user to.
- **`fetchIssues()` throws** instead of returning an empty list. `lib/agent/loop.ts` already converts a thrown tool error into `{error}` output with `ok: false` on the trace, so the failure reaches the model *and* shows up in the agent log as a signal that GitHub is down.
- **`fetchIssue()` returns null only for a genuine 404** or a PR number. Every other failure throws, so a real issue can't be reported as missing.
- **The three tools stay deliberately unguarded**, with a comment at each call site — the tempting `catch { return [] }` is precisely the bug.
- **System prompt**: a tool returning an `error` field did not answer the question, and must never be read as a zero.

## Verification

`npm run build` and `npm run lint` clean.

Checked with a stubbed transport (15 assertions): happy paths unchanged for all three tools; a genuinely empty tracker still reports `0`; a 404 still reports not-found; and 502, network failure, and quota exhaustion all throw with the right classification — including that a plain 403 (private repo, no token) is *not* mislabelled as rate-limited.

The golden evals reference these tools but exercise the live API on the happy path, which is unchanged.

Note: `components/IssueCard.tsx` — which #44 suggested adding an error variant to — is now orphaned; its only remaining mention is prose in a docs page. Left alone here rather than building on dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)