### PR TITLE
Make scripts/migrate.ts the sole migration authority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,8 @@ npm run lint                   # ESLint
 
 # Portfolio data + ADR 0001 enforcement
 npm run migrate                # Apply pending SQL migrations against $DATABASE_URL
+                               # (sole authority — never pipe a .sql into psql;
+                               #  hand-applied files desync schema_migrations)
 npm run seed:portfolio         # lib/portfolio.ts → applications table (dev DB)
 npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this)
 npm run refresh:commit-dates   # Hit GitHub API → regenerate lib/portfolio-meta.ts
@@ -430,6 +432,11 @@ docker compose --profile prod up -d --build       # Production (port 9260)
 docker compose --profile dev up -d --build        # Dev (port 9270)
 docker compose --profile prod logs -f
 docker compose --profile prod down
+
+# Migrations — scripts/migrate.ts is the sole authority. Dev applies them
+# automatically via the migrate-dev one-shot (the app container is gated on
+# its clean exit). Production is deliberate:
+docker compose --profile migrate run --rm migrate-prod
 ```
 
 ### Deploy via Claude Code

--- a/app/docs/deployment/page.tsx
+++ b/app/docs/deployment/page.tsx
@@ -93,35 +93,40 @@ MINDROUTER_MODEL=openai/gpt-oss-120b
 
       <h2>Database Migrations</h2>
       <p>
-        Migrations live in <code>db/migrations/</code> and are numbered sequentially:
+        Migrations live in <code>db/migrations/</code>, numbered sequentially and applied in
+        that order. They are a mix of schema changes (<code>007_lifecycle_taxonomy.sql</code>)
+        and data migrations (<code>016_update_ucm_and_water_law_statuses.sql</code>).
       </p>
-      <ul>
-        <li><code>001_submissions.sql</code> — submissions, submission_details tables</li>
-        <li><code>002_extended_questions.sql</code> — New columns + submission_notes table</li>
-        <li><code>003_application_registry.sql</code> — applications, similarity_matches, GIN indexes, trigger</li>
-      </ul>
 
       <h3>Running Migrations</h3>
       <p>
-        On first database creation, all migrations in <code>db/migrations/</code> run automatically
-        via Docker&apos;s <code>initdb.d</code> mount. For subsequent migrations on an existing database:
+        <code>scripts/migrate.ts</code> is the only thing that applies migrations. It records
+        each one in the <code>schema_migrations</code> table and skips anything already
+        recorded, so it is safe to run at any time.
       </p>
       <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
-# Run a specific migration
-ssh devops@openera.insight.uidaho.edu \\
-  "docker exec -i aispeg-postgres-prod \\
-   psql -U aispeg -d aispeg" < db/migrations/003_application_registry.sql
+# Local, against the dev database
+npm run migrate
 
-# Verify tables
-ssh devops@openera.insight.uidaho.edu \\
-  "docker exec aispeg-postgres-prod \\
-   psql -U aispeg -d aispeg -c '\\dt'"
+# Dev deployment — applied automatically by the migrate-dev
+# one-shot before the app container starts
+docker compose --profile dev up -d --build
+
+# Production — deliberate, run on demand
+ssh devops@openera.insight.uidaho.edu
+docker compose --profile migrate run --rm migrate-prod
+
+# Verify what has been applied
+docker exec aispeg-postgres-prod \\
+  psql -U aispeg -d aispeg -c 'select version from schema_migrations order by version'
       `}</pre>
 
-      <InfoBox type="info" title="Idempotent migrations">
-        All migrations use <code>IF NOT EXISTS</code> and <code>IF NOT EXISTS</code> guards,
-        so they&apos;re safe to run multiple times. Each migration is wrapped in a
-        <code>BEGIN/COMMIT</code> transaction.
+      <InfoBox type="warning" title="Never pipe a .sql file straight into psql">
+        A hand-applied migration changes the schema without recording itself in
+        <code>schema_migrations</code>, so the runner will later try to apply it again and
+        fail on the second attempt. Individual migrations are <em>not</em> reliably
+        idempotent — several add columns without an <code>IF NOT EXISTS</code> guard, and the
+        data migrations would duplicate rows. Idempotency lives in the runner, not the files.
       </InfoBox>
 
       <h2>Port Mapping (All Insight Apps)</h2>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,14 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-aispeg}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-aispeg_secret}
     volumes:
+      # db/migrations is deliberately NOT mounted into
+      # /docker-entrypoint-initdb.d. Postgres would run every file on first
+      # init of the volume, but only four of them record themselves in
+      # schema_migrations — so scripts/migrate.ts would then collide trying
+      # to re-apply the rest (#266). scripts/migrate.ts is the sole
+      # authority. On prod that step is deliberate and human-run; see
+      # "Applying migrations" in README / app/docs/deployment.
       - aispeg-pg-prod-data:/var/lib/postgresql/data
-      - ./db/migrations:/docker-entrypoint-initdb.d:ro
     networks:
       aispeg-net:
         ipv4_address: 10.10.9.10
@@ -55,6 +61,31 @@ services:
     profiles:
       - prod
 
+  # Production migrations, run on demand. Deliberately under its own
+  # `migrate` profile so `--profile prod up` never starts it: applying a
+  # migration to production stays a decision someone makes, not a side
+  # effect of a deploy. Invoke it explicitly:
+  #
+  #   docker compose --profile migrate run --rm migrate-prod
+  #
+  # Use this rather than piping a .sql file into psql — the runner records
+  # what it applied in schema_migrations, and hand-applied files are
+  # exactly how a database drifts out of sync with it (#266).
+  migrate-prod:
+    build:
+      context: .
+      target: builder
+    container_name: aispeg-migrate-prod
+    restart: "no"
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-aispeg}:${POSTGRES_PASSWORD:-aispeg_secret}@10.10.9.10:5432/${POSTGRES_DB:-aispeg}
+    command: ["npx", "tsx", "scripts/migrate.ts"]
+    networks:
+      aispeg-net:
+        ipv4_address: 10.10.9.13
+    profiles:
+      - migrate
+
   # ── Development ─────────────────────────────────────
   postgres-dev:
     image: postgres:16-alpine
@@ -65,8 +96,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-aispeg}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-aispeg_secret}
     volumes:
+      # Not mounted as initdb.d — see the note on postgres-prod. On dev the
+      # migrate-dev service below applies migrations instead.
       - aispeg-pg-dev-data:/var/lib/postgresql/data
-      - ./db/migrations:/docker-entrypoint-initdb.d:ro
     networks:
       aispeg-net:
         ipv4_address: 10.10.9.11
@@ -82,6 +114,38 @@ services:
       timeout: 5s
       retries: 5
 
+  # One-shot migration runner. Targets the `builder` stage because the
+  # production runner image is a Next standalone bundle — it has no tsx, no
+  # scripts/, and no db/migrations/. The builder stage already has all
+  # three and shares its layers with the app build, so this costs nothing
+  # extra to produce and never ships to the runtime image.
+  #
+  # Dev only, by design. Production migrations stay a deliberate human step
+  # so a bad migration can't land unattended — several migrations under
+  # db/migrations/ are data migrations, not just additive DDL.
+  migrate-dev:
+    build:
+      context: .
+      target: builder
+    container_name: aispeg-migrate-dev
+    # A one-shot must not be restarted; it exits 0 when there's nothing
+    # pending, and the app is gated on that clean exit.
+    restart: "no"
+    depends_on:
+      postgres-dev:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-aispeg}:${POSTGRES_PASSWORD:-aispeg_secret}@10.10.9.11:5432/${POSTGRES_DB:-aispeg_dev}
+    # Not `npm run migrate` — that script expects --env-file=.env.local,
+    # which doesn't exist in the image. DATABASE_URL comes from the
+    # environment above.
+    command: ["npx", "tsx", "scripts/migrate.ts"]
+    networks:
+      aispeg-net:
+        ipv4_address: 10.10.9.12
+    profiles:
+      - dev
+
   aispeg-dev:
     build: .
     container_name: aispeg-dev
@@ -89,6 +153,8 @@ services:
     depends_on:
       postgres-dev:
         condition: service_healthy
+      migrate-dev:
+        condition: service_completed_successfully
     environment:
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       CLICKUP_API_TOKEN: ${CLICKUP_API_TOKEN:-}


### PR DESCRIPTION
Closes #266.

## The bug

`./db/migrations:/docker-entrypoint-initdb.d:ro` was mounted on **both** Postgres services. On first init of a volume, Postgres runs every `.sql` file itself — but only 4 of the 19 record their own version in `schema_migrations` (005, 006, 007, 018). `scripts/migrate.ts` then backfills 001–004 as legacy, finds 008 "pending", and dies:

```
Migration failed: error: column "strategic_plan_alignment" of relation "applications" already exists
```

Two systems applying migrations is the underlying source of drift, as the issue says.

## Scope of the change

The mount only ever fired on an **empty data directory**, so removing it is a no-op for the existing dev and prod volumes. It changes what happens the next time someone creates one — which is also why nothing could be left to chance: the production runner image is a Next standalone bundle with no `tsx`, no `scripts/`, and no `db/migrations/`, so `npm run migrate` cannot run inside the app container as built.

Per the owner's call — **auto-migrate on dev, deliberate on prod**:

- **`migrate-dev`** (dev profile) applies migrations before the app starts, with `aispeg-dev` gated on `service_completed_successfully`. It targets the existing `builder` stage, which already has tsx, `scripts/`, and `db/migrations/` and shares layers with the app build — no extra build cost, nothing added to the runtime image. This also retires the standing friction where a PR adding a migration needed a manual `psql` apply before dev came up clean.
- **`migrate-prod`** sits under its own `migrate` profile, so `--profile prod up` never starts it:

```bash
docker compose --profile migrate run --rm migrate-prod
```

  Production migrations stay a decision someone makes rather than a side effect of a deploy. Several files under `db/migrations/` are data migrations (013 seeds, 014–017 status updates, 019 candidates), not additive DDL.

## Docs

`app/docs/deployment` was describing the broken model and, worse, instructing operators to pipe `.sql` files straight into `psql` — which changes the schema without recording it in `schema_migrations` and is precisely how a database drifts out of sync with the runner. Rewritten, along with the InfoBox claiming every migration is `IF NOT EXISTS`-guarded and safe to re-run; 008 is the counter-example that produced this issue. Idempotency lives in the runner, not the files. `CLAUDE.md` updated to match.

## Verification

- All three profiles validate; `up` starts only the intended services (`migrate-prod` is absent from both `prod` and `dev`)
- **Reproduced the original failure** against a throwaway Postgres with the mount in place — same error as the issue, and confirmed exactly which 4 migrations self-register
- **Fixed path**: empty database → all 19 migrations apply → 28 applications seeded → second run is a clean no-op
- **The one-shot's exact command inside the built builder image**: exit `0` with migrations pending, exit `0` on a no-op re-run, exit `1` against an unreachable database — so the dev app is gated correctly in all three cases
- `npm run build` and `npm run lint` clean

## Note for whoever merges

The dev app container is now gated on the migrate one-shot succeeding. If the **existing** dev volume has migrations that were applied by hand without being recorded in `schema_migrations`, the runner will try to re-apply them and the app won't start. Worth checking before deploying:

```bash
docker exec aispeg-postgres-dev psql -U aispeg -d aispeg_dev -c 'select version from schema_migrations order by version'
```

If any of the 19 are missing, record them with `INSERT INTO schema_migrations (version) VALUES ('...') ON CONFLICT DO NOTHING;` before bringing dev up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)