### PR TITLE
Rename middleware.ts to proxy.ts for the Next 16 file convention

### DIFF
--- a/app/internal/agent-log/page.tsx
+++ b/app/internal/agent-log/page.tsx
@@ -1,7 +1,7 @@
 // /internal/agent-log — auth-gated review of recent /api/ask traffic.
 // Slice #113 of Epic #107.
 //
-// The middleware (middleware.ts) gates /internal/* with basic auth.
+// The proxy (proxy.ts) gates /internal/* with basic auth.
 // Reads from agent_queries (Migration 009).
 
 import Link from "next/link";

--- a/app/internal/sync/route.ts
+++ b/app/internal/sync/route.ts
@@ -1,6 +1,6 @@
 // POST /internal/sync — manual ClickUp sync trigger (ADR 0004).
 //
-// Lives under /internal so the existing Basic-auth middleware covers it
+// Lives under /internal so the existing Basic-auth proxy covers it
 // (fails closed 503 when credentials are unset). Used by the "Sync now"
 // button on /internal and by the host cron:
 //

--- a/components/SyncNowButton.tsx
+++ b/components/SyncNowButton.tsx
@@ -3,7 +3,7 @@
 // The one client component in the ClickUp ingestion feature: fires the
 // manual sync (POST /internal/sync) and reports the run summary inline.
 // Rendered only on /internal, so the request rides the Basic-auth
-// credentials the middleware already collected.
+// credentials the proxy already collected.
 
 import { useState } from "react";
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,10 +3,13 @@ import { NextRequest, NextResponse } from "next/server";
 // Basic auth gate for /internal/*. v1 only — replace with UI SSO later.
 //
 // Requires BASIC_AUTH_USER and BASIC_AUTH_PASS in the environment. If
-// either is unset the middleware fails closed (503) rather than letting
-// the route through without authentication.
+// either is unset this fails closed (503) rather than letting the route
+// through without authentication.
+//
+// Named `proxy` per the Next 16 file convention that supersedes
+// `middleware` — the function name has to match the filename (#267).
 
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   // /internal/requests went public at /portfolio/pipeline (ADR 0005
   // amendment, 2026-07-24) — redirect before the auth gate so old links
   // land on the public queue without a credential prompt.


### PR DESCRIPTION
Closes #267.

Next 16.1.6 emits a deprecation warning on every dev server start:

```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

Still functional today, slated for removal in a future major.

## Change

Next resolves the file as `(?:src/)?proxy` and requires the exported function to be either a default export or named to match the filename — so `export function middleware` becomes `export function proxy` alongside the file rename. Comments in three other files that referred to "the middleware" now say "the proxy".

## Verification

That file carries two behaviors worth confirming rather than assuming, since both were circulated externally. Against a running dev server:

| | Result |
|---|---|
| `/internal/requests` | `307` → `http://localhost:3000/portfolio/pipeline`, no credential prompt (the redirect runs before the auth gate, by design) |
| `/internal/agent-log` | `401` with `WWW-Authenticate: Basic realm="IIDS Internal"` |
| `/`, `/portfolio`, `/coordination`, `/standards` | `200` — matcher scope unchanged |

Startup warning is gone; `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)