### PR TITLE
Correct the named intake human and the MindRouter model in docs

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -176,7 +176,7 @@ Keep the existing 9-step assessment quiz — already a better product than TDX.
 Close these gaps:
 
 1. **Named-human acknowledgment + SLA.** Form submits → user gets email within
-   minutes from a named IIDS person. Default: "Colin Armitage will follow up within
+   minutes from a named IIDS person. Default: "Colin Addington will follow up within
    2 business days." The named-human signal is the single biggest TDX
    differentiator.
 2. **Submitter-visible status page.** Each submission gets `/intake/[token]` (no

--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -39,7 +39,7 @@ export default function ArchitectureDocsPage() {
 ┌────────────────────────┐    ┌──────────────────────────────┐
 │     PostgreSQL 16      │    │   MindRouter (On-Prem LLM)   │
 │  ┌──────────────────┐  │    │  OpenAI-compatible API        │
-│  │ submissions      │  │    │  gpt-oss-120b model           │
+│  │ submissions      │  │    │  qwen3.6-27b model            │
 │  │ submission_details│  │    │  https://mindrouter.uidaho.edu│
 │  │ submission_notes  │  │    └──────────────────────────────┘
 │  │ applications     │  │

--- a/app/docs/deployment/page.tsx
+++ b/app/docs/deployment/page.tsx
@@ -82,7 +82,7 @@ GITHUB_TOKEN=
 # MindRouter AI (required for AI features)
 MINDROUTER_API_KEY=mr2_...
 MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu
-MINDROUTER_MODEL=openai/gpt-oss-120b
+MINDROUTER_MODEL=qwen/qwen3.6-27b
       `}</pre>
 
       <InfoBox type="warning" title="Security">

--- a/app/docs/mindrouter/page.tsx
+++ b/app/docs/mindrouter/page.tsx
@@ -18,8 +18,11 @@ export default function MindRouterDocsPage() {
         infrastructure with full data sovereignty.
       </p>
       <p>
-        This site uses MindRouter for two features: <strong>AI-powered idea analysis</strong> and
-        the <strong>AI Assistant chat panel</strong> in the Submit-a-Project assessment.
+        This site uses MindRouter for three features: <strong>AI-powered idea analysis</strong>,
+        the <strong>AI Assistant chat panel</strong> in the Submit-a-Project assessment, and the
+        <strong> site assistant</strong> reachable from every page, which answers questions about
+        the portfolio, standards, and reports by calling read-only tools against site data
+        (<code>POST /api/ask</code>).
       </p>
 
       <h2>Architecture</h2>
@@ -27,7 +30,7 @@ export default function MindRouterDocsPage() {
 Browser (Client)                  This site (Server)             MindRouter
 ─────────────────                 ─────────────────              ────────────
 "Analyze" click  ──POST──►  /api/ai/analyze-idea  ──POST──►  /v1/chat/completions
-                                  (JSON mode)                 (gpt-oss-120b)
+                                  (JSON mode)                 (qwen3.6-27b)
                  ◄──JSON──  Structured analysis    ◄──JSON──  Structured output
 
 Chat message     ──POST──►  /api/ai/refine         ──POST──►  /v1/chat/completions
@@ -115,14 +118,19 @@ Chat message     ──POST──►  /api/ai/refine         ──POST──►
       <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
 MINDROUTER_API_KEY=mr2_...        # Required. Bearer token for auth.
 MINDROUTER_BASE_URL=https://mindrouter.uidaho.edu  # Default.
-MINDROUTER_MODEL=openai/gpt-oss-120b              # Current model.
+MINDROUTER_MODEL=qwen/qwen3.6-27b                  # Default.
       `}</pre>
 
       <InfoBox type="tip" title="Model selection">
-        MindRouter hosts 60+ models. The current default is <code>openai/gpt-oss-120b</code>
-        which provides excellent structured output quality. Other good options include
-        <code>llama3.3:70b</code>, <code>qwen2.5:72b</code>, and <code>mistral-large:123b</code>.
-        Change the model by updating the <code>MINDROUTER_MODEL</code> environment variable.
+        The default is <code>qwen/qwen3.6-27b</code>, set in{" "}
+        <code>lib/mindrouter.ts</code> — that constant is the source of truth,
+        not this page. It was chosen in May 2026 on the recommendation of Luke
+        Sheneman, who operates the MindRouter cluster. The sibling{" "}
+        <code>qwen/qwen3.6-35b</code> is the lower-latency option; set{" "}
+        <code>MINDROUTER_MODEL</code> to override per environment when latency
+        matters more than accuracy. Model identifiers change as the cluster is
+        re-provisioned — query the models endpoint below rather than trusting a
+        list written down here.
       </InfoBox>
 
       <h2>Graceful Degradation</h2>

--- a/lib/intake-config.ts
+++ b/lib/intake-config.ts
@@ -8,9 +8,9 @@
 export const intakeConfig = {
   /** The IIDS staff member named on the post-submit confirmation. */
   intakeOwner: {
-    name: "Colin Armitage",
+    name: "Colin Addington",
     title: "IIDS",
-    email: "carmitage@uidaho.edu",
+    email: "caddington@uidaho.edu",
   },
   /** Service-level commitment shown to submitters at confirmation time. */
   sla: {


### PR DESCRIPTION
Two factual errors surfaced by a documentation audit. Both were live.

## The named human on the intake surface did not exist

`lib/intake-config.ts` published **Colin Armitage / carmitage@uidaho.edu** as the IIDS staff member who responds within two business days. The actual person is **Colin Addington / caddington@uidaho.edu** — as recorded on nine `iidsSponsor`/`supportContact` entries in `lib/portfolio.ts`, in `lib/rubric.ts`, on `/portfolio/pipeline`, and in the ClickUp workspace roster. The surname appears to have been crossed with a different workspace member.

This has been on `/builder-guide` results and `/intake/[token]` since Sprint 3a (May 2026), on the surface whose entire argument over TDX is that a named human answers and can be reached. The address does not resolve.

`REFACTOR.md` carried the same name in its SLA example; corrected there too.

## `/docs` named the wrong model

`/docs/mindrouter`, `/docs/deployment`, and the `/docs/architecture` diagram all stated the default was `openai/gpt-oss-120b`. It has been `qwen/qwen3.6-27b` since May 2026 (`lib/mindrouter.ts:18`), bumped on the recommendation of the MindRouter cluster operator. `.env.example` was already correct; only the docs drifted.

Rather than restate a model list that can't be verified from the repo, the page now points at `lib/mindrouter.ts` as the source of truth and at the `/v1/models` endpoint for what the cluster actually hosts. The one sibling identifier named (`qwen/qwen3.6-35b`) comes from the code comment, not from memory.

Also corrects the MindRouter page's claim that the site uses MindRouter for *two* features — the site assistant behind `POST /api/ask` is a third.

## Verification

`npm run build` passes; `npm run lint` clean. No data or schema changes.

## Follow-ups (not in this PR)

Part of a three-branch audit response. Next: `README.md`/`CONTRIBUTING.md`/`.impeccable.md` reconciliation, and an ADR for the site assistant. Separately flagged for a decision: `/internal/portfolio` is a live second portfolio view that contradicts the documented "no internal copy" directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)