### PR TITLE
Reconcile the orientation docs with the code they describe

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -337,10 +337,15 @@ card header. The primary chip is the public stage; the secondary chip
 is the operational status.
 
 - **Primary (public stage)** carries stage-specific color so the rollup
-  is scannable at a glance:
+  is scannable at a glance. Six buckets; the class strings live in
+  `PUBLIC_STAGE_CHIP` in `lib/portfolio.ts`, which is the source of
+  truth:
   - `Live` → Clearwater (signal: alive)
   - `Building` → Huckleberry (signal: in motion)
   - `Exploring` → Brand Silver (low intensity)
+  - `Paused` → Amber (the codebase's existing caution/blocker signal —
+    a deliberate hold reads distinctly from the brand-accent stages
+    without borrowing reserved Pride Gold)
   - `Retired` → Gray (low intensity)
   - `Tracked` → Huckleberry-tint (matches the existing tracked
     treatment from before the lifecycle taxonomy)
@@ -348,7 +353,7 @@ is the operational status.
   `surface-alt + hairline + ink-muted` treatment as work-categories
   chips, sized at `text-[10px]`. No per-status color, ever. The
   restraint principle that applies to taxonomy applies here for the
-  same reason: ten distinct colors would cross the decoration line.
+  same reason: twelve distinct colors would cross the decoration line.
 
 **`tracked` suppresses the operational chip.** Externally-owned
 projects don't follow the IIDS operational ladder, so the primary
@@ -356,16 +361,17 @@ stage chip carries the whole signal — a second neutral chip would imply
 a granularity that doesn't exist for them.
 
 **Stat-strip breakdowns.** Public stage only. The operational
-granularity isn't useful at landing-density. Format:
+granularity isn't useful at landing-density. Format — counts are
+computed at build time from the inventory, never hardcoded:
 
 ```
-14 projects across 10 home units
-6 building · 6 live · 2 tracked
+29 projects across 13 home units
+6 exploring · 8 building · 8 live · 3 paused · 1 retired · 3 tracked
 ```
 
-**Filters on `/portfolio`.** Two tiers: a top-level Stage row (5 chips
-in `PUBLIC_STAGE_ORDER`), and a drill-in Operational Status row that
-appears only when a non-`tracked` stage is active. Selecting an
+**Filters on `/portfolio`.** Two tiers: a top-level Stage row (one chip
+per entry in `PUBLIC_STAGE_ORDER`), and a drill-in Operational Status
+row that appears only when a non-`tracked` stage is active. Selecting an
 operational status implies its stage; URL params keep the two
 independent (`?stage=...` vs `?status=...`) so links can deep-link to
 either granularity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,29 @@ sprint sequencing.
   (PRs #194-196). /portfolio polish: stat-strip lede, filter demotion,
   rename "The Work" → "Projects" (PRs #207-218). UniVerso added as
   the first ui-iids portfolio entry (#221). Strategic-plan alignment
-  declared for all 15 portfolio projects (#220).
+  declared for every portfolio project (#220).
+- **July 2026** — Four decisions, four ADRs, all shipped:
+  **ClickUp ingestion** ([ADR 0004](./docs/adr/0004-clickup-ingestion-boundary.md),
+  Migrations 010–011) — read-only pull of status narrative, ROI, and the
+  scored request backlog; no write-back.
+  **OIT pathway + FY2027 EA crosswalk** — `/coordination/oit-pathway` and
+  `/coordination/oit-portfolio` (PR #283); crosswalk matches require
+  owner confirmation, not subject-matter adjacency.
+  **Unified Technology Request registry**
+  ([ADR 0005](./docs/adr/0005-unified-technology-request-registry.md),
+  Migrations 018–019) — Phase 1 registry plus `/portfolio/pipeline` as
+  the single all-origin request queue. Phases 2–4 remain; TDX sync is
+  blocked on API access.
+  **Coordination surface split**
+  ([ADR 0006](./docs/adr/0006-coordination-surface-split.md)) — the four
+  process sub-pages moved out of `/standards`; permanent redirects in
+  `next.config.mjs`.
+  ADR 0001 also gained the `paused` and `scoping` operational states and
+  the OIT-managed-production accessibility rule.
+
+The inventory currently holds **29 projects across 13 home units**. Don't
+copy a count out of this file into UI copy — compute it from
+`lib/portfolio.ts` at build time.
 
 ## Information architecture
 
@@ -203,7 +225,7 @@ app/                       # Next.js App Router
   layout.tsx               # Root layout, sidebar, metadata
   about/                   # About — strategic frame, AI4RA partnership, IIDS operator note
   portfolio/               # Projects
-  explore/                 # Explore — "by problem" axis, category-tile entry
+    pipeline/              # Unified all-origin request queue (ADR 0005)
   builder-guide/           # Submit a Project (assessment quiz)
   intake/[token]/          # Submitter-visible status page (Sprint 3a)
   reports/                 # Reports surface
@@ -218,7 +240,13 @@ app/                       # Next.js App Router
     oit-portfolio/         # OIT's FY2027 EA inventory + owner-confirmed crosswalks
     operational-excellence/ # Oct 2025 survey — themes, responses, candidate projects
   ai4ra-ecosystem/         # AI4RA partnership deep-dive (linked from /about)
-  internal/                # Ops surfaces (sync trigger, agent log). Request queue moved public → /portfolio/pipeline (2026-07-24); /internal/requests redirects there
+  internal/                # Auth-gated ops surfaces (sync trigger, agent log).
+                           #   Request queue moved public → /portfolio/pipeline
+                           #   (2026-07-24); /internal/requests redirects there.
+                           #   NOTE: /internal/portfolio still renders a second
+                           #   view of the inventory, which predates and
+                           #   contradicts the one-story directive — under
+                           #   review; don't build on it.
   admin/                   # Registry + submissions admin
   api/                     # Next.js API routes
   docs/                    # Technical + user documentation
@@ -251,6 +279,20 @@ lib/                       # Domain logic
   clickup.ts               # ClickUp REST client + typed custom-field extraction (ADR 0004)
   clickup-map.ts           # IIDS-AI4UI list ids ↔ portfolio slugs (typed map)
   clickup-sync.ts          # ClickUp → Postgres sync engine (script + /internal/sync share it)
+  clickup-data.ts          # Read module over the clickup_* projection tables
+  utr.ts                   # Unified Technology Request vocabularies (ADR 0005)
+  requests.ts              # Postgres read module for the request registry
+  governance-profile.ts    # Per-project UTR intake profile (Intake Crosswalk)
+  oit-pathway.ts           # OIT six-stage lifecycle + gates
+  project-governance.ts    # Governance-tracking facts per project
+  project-value.ts         # Replacement-cost / bottom-line-ROI facts
+  project-map-graph.ts     # Graph model behind the strategic-plan coverage map
+  roi-rubric.ts            # ROI dimensions + fiscal-year helpers (CADSO rubric pending)
+  rubric.ts                # ClickUp 11-criterion request-scoring rubric
+  agent/                   # Site assistant — tool registry, loop, prompts,
+                           #   rate limiting, query logging (POST /api/ask)
+  surveys/                 # Operational Excellence survey — themes, responses,
+                           #   candidate projects
   governance/              # Data Governance Explorer typed modules
     types.ts               # Shared interfaces (Project, Table, Column, Vocabulary*)
     canonical-udm-tables.ts # Hand-curated canonical-vs-extension tagging (v1)
@@ -266,7 +308,13 @@ lib/                       # Domain logic
     project-alignment.ts   # Reverse lookup — projects advancing each priority
     catalog.ts             # AUTO-GENERATED — pillars + priorities (do not edit)
 
-db/migrations/             # SQL migrations (001 → 010; 007 = lifecycle, 008 = strategic-plan-alignment, 010 = clickup ingestion)
+db/migrations/             # SQL migrations (001 → 019). Landmarks: 005 = friction
+                           #   ledger, 007 = lifecycle, 008 = strategic-plan
+                           #   alignment, 009 = agent query log, 010–011 = clickup
+                           #   ingestion, 012 = enterprise-replacement facts,
+                           #   018 = UTR registry, 019 = survey candidates
+
+evals/agent/               # Site-assistant eval harness (`npm run eval:agent`)
 
 scripts/                   # Node scripts run via tsx
   build-governance-catalog.ts     # vendor/data-governance/ → lib/governance/{catalog,vocabularies}.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,11 @@ Copilot**, or any LLM-powered coding assistant.
 The site was built collaboratively this way and is designed to keep working
 that way.
 
-> Before you make non-trivial changes: read [`REFACTOR.md`](./REFACTOR.md)
-> for the strategic context and current sprint state, and
-> [`CLAUDE.md`](./CLAUDE.md) for project conventions and the IA.
+> Before you make non-trivial changes: read [`CLAUDE.md`](./CLAUDE.md)
+> for the normative Agent Rules, project conventions, and the IA; and
+> [`docs/adr/`](./docs/adr/) for the durable decisions and why they were
+> made. [`REFACTOR.md`](./REFACTOR.md) gives the May 2026 strategic
+> context behind what was cut.
 
 ---
 
@@ -28,36 +30,58 @@ that way.
 ## Getting started
 
 ```bash
-git clone https://github.com/ui-insight/AISPEG.git
+git clone --recurse-submodules https://github.com/ui-insight/AISPEG.git
 cd AISPEG
 cp .env.example .env.local   # then fill in DATABASE_URL and optional GITHUB_TOKEN
 npm install
 npm run dev
 ```
 
+The `--recurse-submodules` is not optional: `predev` regenerates the typed
+governance and strategic-plan catalogs from `vendor/`, and fails without
+them. If you already cloned without it, run
+`git submodule update --init --recursive`.
+
 The site runs at <http://localhost:3000>.
 
 > **Tip for agentic tools**: at the start of a session, point your agent at
-> [`CLAUDE.md`](./CLAUDE.md) and [`REFACTOR.md`](./REFACTOR.md). Together
-> they cover project structure, conventions, the five-surface IA, the
-> friction-ledger model, and the sprint sequencing.
+> [`CLAUDE.md`](./CLAUDE.md) — it carries the normative Agent Rules, the
+> IA, and the project structure. [`docs/adr/`](./docs/adr/) is where the
+> durable decisions live. [`REFACTOR.md`](./REFACTOR.md) is the May 2026
+> plan document, useful for *why* things were cut but superseded by the
+> ADRs on anything decided since.
 
 ---
 
 ## How the site works
 
-### Four primary surfaces
+### Five primary surfaces
 
 | Surface | Route | Source of truth |
 |---|---|---|
-| Projects | `/portfolio` | Postgres `applications` (read via `lib/work.ts`); `lib/portfolio.ts` is the typed seed source. Two-tier filter (public stage → operational status) per [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md). The category filter (`lib/work-categories.ts`) is the by-problem entry point. |
+| Projects | `/portfolio` | Postgres `applications` (read via `lib/work.ts`); `lib/portfolio.ts` is the typed seed source. Two-tier filter (public stage → operational status) per [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md). The category filter (`lib/work-categories.ts`) is the by-problem entry point. `/portfolio/pipeline` is the unified all-origin request queue (`lib/requests.ts` + ClickUp enrichment) per [ADR 0005](./docs/adr/0005-unified-technology-request-registry.md). |
 | Submit a Project | `/builder-guide` | `lib/builder-guide-data.ts` (quiz) + Postgres `submissions` (responses); status page at `/intake/[token]`. |
+| Coordination | `/coordination` | **Process** — how a request becomes tracked work. Sub-nav: Intake Crosswalk (`lib/governance-profile.ts`), OIT Pathway (`lib/oit-pathway.ts`), OIT Portfolio (`lib/oit-ea-portfolio.ts`), Op Excellence Survey (`lib/surveys/*`). |
+| Standards | `/standards` | **Reference** — `lib/standards-watch.ts`; sub-nav surfaces `/standards/data-model`, `/standards/strategic-plan`, and `/standards/strategic-plan/map` (per [ADR 0003](./docs/adr/0003-strategic-plan-map-home.md)). |
 | Reports | `/reports` | `lib/artifacts.ts` (unified timeline) + per-report routes |
-| Standards | `/standards` | `lib/standards-watch.ts`; sub-nav surfaces `/standards/data-model`, `/standards/strategic-plan`, and `/standards/strategic-plan/map` (per [ADR 0003](./docs/adr/0003-strategic-plan-map-home.md)). |
+
+The Coordination / Standards line is load-bearing: **Coordination holds
+process**, **Standards holds reference**. A new sub-page goes on the side
+of that line it answers to — see
+[ADR 0006](./docs/adr/0006-coordination-surface-split.md).
 
 Plus `/ai4ra-ecosystem`, `/about`, `/internal` (auth-gated),
 `/docs/*`, `/admin/*`. See [`CLAUDE.md`](./CLAUDE.md) for the full
 route inventory and what's been archived.
+
+### The site assistant
+
+A conversational assistant (`components/ChatWidget.tsx` → `POST /api/ask`)
+is mounted in the root layout and reachable from every page. It answers
+questions about the portfolio, standards, reports, and coordination
+surfaces by calling read-only tools in `lib/agent/tools/` against site
+data. If you add a surface that a stakeholder would ask about, add a tool
+for it — otherwise the assistant will not know it exists.
 
 ### Typed data modules over JSON blobs
 
@@ -82,23 +106,32 @@ shared across surfaces.
 - Don't reach for `"use client"` reflexively — server components keep
   bundles small and let Next render on the server.
 
-### Data architecture intent (Sprint 2+)
+### Data architecture
 
-The post-refactor data model:
+Source-of-truth boundaries:
 
 - **Postgres `applications` table** is canonical for project identity,
-  classification, and provenance.
-- **ClickUp** is canonical for project status, blockers, and daily
-  workflow. Each ClickUp task references an `applications.id`; each
-  `applications` row has a `clickup_task_id`. Sync runs on a cron.
+  classification, and provenance. `lib/portfolio.ts` is the typed shadow
+  and the seed source; `lib/work.ts` is the runtime read path.
+- **ClickUp** is canonical for project status narrative, ROI estimates,
+  and the scored request backlog. Ingestion is **read-only and pull-only**
+  into `clickup_*` projection tables, per
+  [ADR 0004](./docs/adr/0004-clickup-ingestion-boundary.md). There is no
+  write-back. Synced tables carry no foreign keys to `applications` —
+  they join to portfolio slugs at read time via `lib/clickup-map.ts`, so
+  a re-seed can't wipe them.
+- **This site's Postgres** owns the request registry (`tech_requests` and
+  friends) — request identity across origins, the request↔project graph,
+  and ROI claims, per
+  [ADR 0005](./docs/adr/0005-unified-technology-request-registry.md).
 - **GitHub issues** drive technical work and are surfaced via
   `lib/github.ts`.
-- **Markdown / typed TS** drives narrative content (decks, About copy,
-  standards ledger).
+- **Markdown / typed TS** drives narrative content (About copy, standards
+  ledger, vocabularies).
 
-Sprint 1 has not yet wired ClickUp; Sprint 2's Migration 005 adds the
-friction-ledger fields and a `blockers` table. Until then, status data is
-hand-maintained in `lib/portfolio.ts`.
+A note on why so much is typed TS rather than DB rows: each change to a
+governance vocabulary is a commit-worthy decision, and the git log is the
+audit trail. That's Agent Rule 9 in `CLAUDE.md`.
 
 ---
 
@@ -170,14 +203,20 @@ The status taxonomy is defined and enforced by
 [ADR 0001 — Product Lifecycle Taxonomy](./docs/adr/0001-product-lifecycle-taxonomy.md).
 The lifecycle has two layers:
 
-- **Operational ladder** (9 states + `tracked` meta): `idea`,
-  `approved`, `building`, `prototype`, `piloting`, `production`,
-  `maintained`, `sunsetting`, `archived`, plus `tracked` for
-  partner-unit-led work IIDS coordinates around.
-- **Public stage rollup** (5 buckets) — `exploring`, `building`,
-  `live`, `retired`, `tracked` — derived automatically from the
-  operational state. Stakeholders see the public stage; IIDS sees the
-  operational state as a secondary chip.
+- **Operational ladder** (11 states + `tracked` meta): `idea`,
+  `scoping`, `approved`, `building`, `prototype`, `piloting`,
+  `production`, `maintained`, `paused`, `sunsetting`, `archived`, plus
+  `tracked` for partner-unit-led work IIDS coordinates around.
+  `scoping` and `paused` were added by July 2026 amendments to ADR 0001
+  — `scoping` for named humans engaged before a formal go decision,
+  `paused` for a deliberate hold that is not abandonment.
+- **Public stage rollup** (6 buckets) — `exploring`, `building`,
+  `live`, `paused`, `retired`, `tracked` — derived automatically from
+  the operational state by `computePublicStage()`. Stakeholders see the
+  public stage; IIDS sees the operational state as a secondary chip.
+
+All values are **lowercase**; the union in `lib/portfolio.ts` is the
+source of truth and tsc will reject anything else.
 
 Each operational state has a **measurable verification rule** (e.g.
 `production` requires either a public `liveUrl` reachable beyond the
@@ -206,7 +245,7 @@ owns it, IIDS may have advised but did not build. Always pair with
   work, may not include IIDS at all.
 - **Example:** UCM Daily Register — `homeUnits:
   ["University Communications and Marketing"]`, `buildParticipants:
-  ["UCM"]`, `status: "Tracked"`. IIDS coordinates; UCM owns and builds.
+  ["UCM"]`, `status: "tracked"`. IIDS coordinates; UCM owns and builds.
 
 #### AI4RA relationship
 
@@ -289,9 +328,14 @@ artifact:
 
 ### Adding a new top-level route
 
-The IA is intentionally narrow (5 primary surfaces). Adding a new
-top-level route should be a deliberate choice — discuss in
-`REFACTOR.md` or open an issue first.
+The IA is intentionally narrow (5 primary surfaces plus Home and a
+footer About). Adding a new top-level route should be a deliberate
+choice — open an issue first, and if the decision is durable, write an
+ADR. [ADR 0006](./docs/adr/0006-coordination-surface-split.md) is the
+worked example of adding one.
+
+Most things that feel like they need a new route actually need a
+sub-section under Coordination or Standards. Try that first.
 
 If approved:
 
@@ -299,9 +343,15 @@ If approved:
 2. Add the entry to `primaryItems` (or `footerItems`) in
    `components/Sidebar.tsx`. Existing icons (each used by exactly one
    entry): `house` (Home), `grid` (Projects), `compass` (Submit a
-   Project), `shield` (Standards), `document` (Reports), `book` (About).
-   **Each sidebar entry uses a distinct icon** — adding a new entry
-   means adding a new glyph to `NavIcon`, not reusing an existing one.
+   Project), `funnel` (Coordination), `shield` (Standards), `document`
+   (Reports), `book` (About). **Each sidebar entry uses a distinct
+   icon** — adding a new entry means adding a new glyph to `NavIcon`,
+   not reusing an existing one.
+
+   Note the difference between a **primary surface** and a
+   **sub-section**: sub-sections never get a sidebar row. They go in
+   `subNavItems` in the parent surface's `layout.tsx`, rendered through
+   `components/SectionSubNav.tsx`. That's Agent Rule 11.
 3. Apply the page-heading-and-eyebrow rule documented in
    `.impeccable.md` — the H1 must thread the sidebar label (Form A: H1
    matches verbatim; Form B: declarative H1 with the sidebar label as
@@ -319,23 +369,17 @@ index.
 
 ## Workflow
 
-### For solo work (direct to main)
-
-```
-1. Pull latest:    git pull origin main
-2. Make changes:   (edit with your agentic tool)
-3. Verify:         npm run build && npm run lint
-4. Commit & push:  git add <files>
-                   git commit -m "imperative-mood subject"
-                   git push
-```
-
-### For collaborative or substantive work (branch + PR)
+**All work lands via PR. Never commit directly to `main`** — this is
+Agent Rule 1 in [`CLAUDE.md`](./CLAUDE.md), and it applies to solo work
+and human contributors too, not just agents. The value isn't review
+gating (often there's only one reviewer); it's that the PR body is where
+the *why* gets written down, and CI runs before the branch is live.
 
 ```
 1. Create branch:  git checkout -b feature/your-feature
 2. Make changes
 3. Verify:         npm run build && npm run lint
+                   npm run verify:portfolio   # if you touched lib/portfolio.ts
 4. Commit & push:  git push -u origin feature/your-feature
 5. Open PR:        gh pr create --title "..." --body "..."
 ```
@@ -343,10 +387,16 @@ index.
 **Always run `npm run build` before committing.** It's the primary
 TypeScript check and catches drift between data shapes and components.
 
-For the May 2026 refactor itself, work is happening in **per-sprint PRs**
-off `main` (see `REFACTOR.md`). If you're contributing during the
-refactor window, sync with whoever's running the active sprint before
-opening a parallel PR.
+**Run `npm run verify:portfolio` if you touched `lib/portfolio.ts`.** CI
+enforces it. It fails any project whose claimed lifecycle status isn't
+backed by the evidence [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md)
+requires — a `production` claim with no `supportContact`, a `piloting`
+claim with no cohort, and so on. Catching it locally is faster than
+catching it in CI.
+
+CI additionally runs ESLint, `tsc --noEmit`, and a production build, plus
+governance and strategic-plan drift checks on PRs touching the vendored
+catalogs.
 
 ---
 
@@ -356,12 +406,12 @@ opening a parallel PR.
 
 Give your agent the strategic context first. A good opening:
 
-> Read `REFACTOR.md` and `CLAUDE.md` to understand the project. This is a
-> Next.js 16 site that's the coordination nexus for the University of
-> Idaho's institutional AI initiative, operated by IIDS. We're mid-refactor
-> from a legacy AISPEG-collaboration framing. The IA is five surfaces:
-> Projects, Explore, Submit a Project, Reports, Standards. Run
-> `npm run build` to verify changes.
+> Read `CLAUDE.md` and skim `docs/adr/` to understand the project. This
+> is a Next.js 16 site that's the coordination nexus for the University
+> of Idaho's institutional AI initiative, operated by IIDS. The IA is
+> five primary surfaces: Projects, Submit a Project, Coordination,
+> Standards, Reports. Work on a feature branch — never commit to main.
+> Run `npm run build` to verify changes.
 
 ### Effective prompt patterns
 
@@ -374,24 +424,35 @@ Give your agent the strategic context first. A good opening:
 > alphabetical. Don't change the data."
 
 **New feature:**
-> "Add a `/standards/[id]` permalink that opens directly to the relevant
-> entry on the standards page. Read `lib/standards-watch.ts` first."
+> "Add a sub-page under `/coordination` summarizing X. Read
+> `app/coordination/layout.tsx` for the sub-nav pattern and
+> `docs/adr/0006-coordination-surface-split.md` for why it belongs on
+> Coordination rather than Standards."
 
 **Verification:**
-> "Run `npm run build` and `npm run lint`, fix any errors."
+> "Run `npm run build`, `npm run lint`, and `npm run verify:portfolio`;
+> fix any errors."
 
 ### What your agent needs to know
 
-- `REFACTOR.md` and `CLAUDE.md` are the primary orientation docs.
+- `CLAUDE.md` is the primary orientation doc, and its **Agent Rules**
+  section is normative — it wins over anything else, including this
+  file, if they ever conflict.
+- `docs/adr/` holds the durable decisions. Read the relevant ADR before
+  changing a taxonomy, a schema, or the IA.
 - Typed `lib/*.ts` modules are the source of truth for cross-surface
   content. Per-page data lives next to the page (e.g.
   `app/reports/<slug>/data.ts`).
+- Several `lib/` modules are **auto-generated** and must never be edited
+  by hand: `lib/governance/{catalog,vocabularies}.ts`,
+  `lib/strategic-plan/catalog.ts`, `lib/portfolio-meta.ts`. Edit the
+  vendored source and regenerate.
 - Tailwind tokens: `ui-charcoal`, `ui-gold`, `ui-gold-dark`,
   `brand-huckleberry`, `brand-lupine`. No raw hex in components.
-- `npm run build` must pass before committing.
-- The site is mid-refactor; legacy routes were cut for cause in the May
-  2026 refactor and should not be reintroduced without checking
-  `REFACTOR.md`.
+- `npm run build` must pass before committing; so must
+  `npm run verify:portfolio` if `lib/portfolio.ts` changed.
+- Legacy routes were cut for cause in the May 2026 refactor and should
+  not be reintroduced without checking `REFACTOR.md`.
 
 ### Common pitfalls
 
@@ -401,8 +462,17 @@ Give your agent the strategic context first. A good opening:
 - **Don't reach for `"use client"`** unless a component genuinely needs
   client-side state or events.
 - **Don't reintroduce cut routes** (`/knowledge`, `/cautionary-tales`,
-  `/roadmap`, `/outreach`, `/action-plan`, `/approach`) — they were cut
-  for cause; check `REFACTOR.md` before touching them.
+  `/roadmap`, `/outreach`, `/action-plan`, `/approach`,
+  `/standards/[id]`, `/explore`) — they were cut for cause. `/explore`
+  was retired per [ADR 0003](./docs/adr/0003-strategic-plan-map-home.md);
+  the coverage map lives at `/standards/strategic-plan/map` and the
+  by-problem browse is `/portfolio`'s category chips. Check
+  `REFACTOR.md` before touching the rest.
+- **Don't build a second view of anything the public site already
+  shows.** The standing directive (2026-07-24, recorded in the
+  [ADR 0005](./docs/adr/0005-unified-technology-request-registry.md)
+  amendment) is that the site tells one story with no public/internal
+  split. `/portfolio/pipeline` is the one request queue.
 - **Don't editorialize on user-facing surfaces** — the design principle is
   evidence-forward (status fields, day counters, owner names) over
   forcing-function rhetoric.
@@ -479,6 +549,7 @@ No display serif pairing. The brand is sans-only.
 ## Where to ask for help
 
 For project context (why a thing is the way it is): start with
-`REFACTOR.md` and `CLAUDE.md`. For technical specifics: see
+`docs/adr/` and `CLAUDE.md`, then `REFACTOR.md` for the May 2026
+cuts. For technical specifics: see
 [`/docs`](http://localhost:3000/docs) on the running site. For anything
 else: ping the IIDS team through the usual UI channels.

--- a/README.md
+++ b/README.md
@@ -12,18 +12,26 @@ The site shows what's being built, what's stalled, and where to engage.
 
 ## What's on the site
 
+Five primary surfaces in the sidebar, plus an About link in the footer.
+
 | Surface | Route | Job |
 |---|---|---|
-| **Projects** | `/portfolio` | Portfolio of AI projects across UI units. Each entry names a home unit and operational owner. The category filter chips serve the by-problem browse. |
-| **Submit a Project** | `/builder-guide` | A 9-step assessment that scopes an AI idea, classifies it into one of four tiers, and connects the submitter to a named owner at IIDS. |
+| **Projects** | `/portfolio` | Inventory of AI projects across UI units. Each entry names a home unit and operational owner. The category filter chips serve the by-problem browse. `/portfolio/pipeline` is the unified request queue — every requested project from every origin. |
+| **Submit a Project** | `/builder-guide` | A 9-step assessment that scopes an AI idea, classifies it into one of four tiers, and connects the submitter to a named owner at IIDS. Status page at `/intake/[token]`. |
+| **Coordination** | `/coordination` | **Process** — how a request becomes tracked institutional work. Sub-sections: Intake Crosswalk, OIT Pathway, OIT Portfolio, Op Excellence Survey. |
+| **Standards** | `/standards` | **Reference** — what the work is measured against. The public ledger of software-development and user-experience standards IIDS has formally requested from OIT, plus `/standards/data-model` (Data Governance Explorer for the AI4RA Unified Data Model), `/standards/strategic-plan` (Strategic Plan Alignment Explorer), and `/standards/strategic-plan/map` (the coverage map). |
 | **Reports** | `/reports` | Activity reports, briefs, and time-stamped public artifacts. |
-| **Standards** | `/standards` | Public ledger of the institutional software-development and user-experience standards IIDS has formally requested from OIT. Sub-sections: `/standards/data-model` (Data Governance Explorer for the AI4RA Unified Data Model), `/standards/strategic-plan` (Strategic Plan Alignment Explorer — pillars, priorities, and the projects advancing each one), and `/standards/strategic-plan/map` (the strategic-plan coverage map). |
 
-Plus `/docs` (technical and user documentation) and `/admin/*` (registry +
-submissions admin during the ClickUp transition). Several legacy routes
-(`/knowledge`, `/cautionary-tales`, `/roadmap`, `/outreach`,
-`/action-plan`, `/approach`, `/explore`) were cut in the May 2026
-refactor; recover from git history if needed.
+The Coordination / Standards split is load-bearing — process vs. reference.
+See [ADR 0006](./docs/adr/0006-coordination-surface-split.md).
+
+Plus `/about`, `/ai4ra-ecosystem` (AI4RA partnership deep-dive), `/docs`
+(technical and user documentation), `/admin/*` (registry + submissions
+admin during the ClickUp transition), and `/internal/*` (auth-gated ops
+surfaces). Several legacy routes (`/knowledge`, `/cautionary-tales`,
+`/roadmap`, `/outreach`, `/action-plan`, `/approach`, `/standards/[id]`,
+`/explore`) were cut in the May 2026 refactor; recover from git history if
+needed.
 
 ## Quick start
 
@@ -68,66 +76,90 @@ For full local-database setup, see [`/docs/deployment`](./app/docs/deployment/pa
 ```
 app/                         # Next.js App Router
   page.tsx                   # Landing — steering page
-  layout.tsx                 # Root layout + metadata
+  layout.tsx                 # Root layout + metadata + site assistant widget
   portfolio/                 # Projects — AI projects inventory
+    pipeline/                # Unified request queue (all origins)
   builder-guide/             # Submit a Project — 9-step assessment
+  intake/[token]/            # Submitter-visible status page
+  coordination/              # Coordination — process surfaces
+  standards/                 # Standards — reference surfaces
+    data-model/              # Data Governance Explorer
+    strategic-plan/          # Strategic Plan Alignment Explorer + map
   reports/                   # Reports surface
-  standards/                 # Standards ledger
+  presentations/             # Legacy redirect → /reports
+  about/                     # About
   ai4ra-ecosystem/           # AI4RA partnership reference page
+  internal/                  # Auth-gated ops surfaces (sync, agent log)
   admin/                     # Registry + submissions admin
-    registry/
-    submissions/
   api/                       # Next.js API routes
-    submissions/, registry/, ai/
+    submissions/, registry/, ai/, ask/, similarity/
   docs/                      # User + technical documentation
 
 components/                  # Reusable React components
-  Sidebar.tsx, PortfolioCard.tsx, IssueCard.tsx, DocPage.tsx, ...
+  Sidebar.tsx, SectionSubNav.tsx, PortfolioCard.tsx, PortfolioFilters.tsx,
+  ProjectDetail.tsx, ChatWidget.tsx, IssueCard.tsx, DocPage.tsx, ...
 
 lib/                         # Domain logic and data
-  portfolio.ts               # Inventory of AI projects (typed)
+  portfolio.ts               # Inventory of AI projects (typed) + lifecycle
+  work.ts                    # Postgres-backed read module for /portfolio
   standards-watch.ts         # Standards ledger entries
+  artifacts.ts               # Unified Reports timeline
   builder-guide-data.ts      # Assessment quiz, scoring, tiers
   similarity.ts              # Submission ↔ registry overlap engine
+  utr.ts, requests.ts        # Unified Technology Request registry (ADR 0005)
+  clickup*.ts                # ClickUp read-only ingestion (ADR 0004)
+  oit-*.ts, governance-profile.ts  # Coordination surfaces
+  agent/                     # Site assistant — tools, loop, logging
+  governance/                # Data Governance Explorer modules
+  strategic-plan/            # Strategic Plan Explorer modules
+  surveys/                   # Operational Excellence survey data
   github.ts                  # Issue fetching for home/about surfaces
   mindrouter.ts              # MindRouter LLM client
   db.ts                      # Postgres connection pool
 
-db/migrations/               # SQL migrations (001 → 008)
+db/migrations/               # SQL migrations (001 → 019)
+docs/adr/                    # Architecture Decision Records
+evals/agent/                 # Site-assistant eval harness
+vendor/                      # Git submodules (data-governance, strategic-plan)
 ```
 
-## Refactor in progress
+## Project history
 
-This codebase is mid-refactor. The May 2026 refactor pivots the site from
-its original AISPEG-collaboration framing to an IIDS-coordinated
-institutional AI initiative site. See [`REFACTOR.md`](./REFACTOR.md) for
-the full plan, sprint sequencing, and decisions:
+The May 2026 refactor pivoted the site from its original
+AISPEG-collaboration framing to an IIDS-coordinated institutional AI
+initiative site. Sprints 1–5 are complete; the user-facing surfaces no
+longer read as mid-refactor. [`REFACTOR.md`](./REFACTOR.md) is the
+May 2026 plan document and is preserved as a historical record — for
+decisions made since, read the ADRs.
 
-- **Sprint 1** — *complete*. IA reshape, Standards page, AISPEG branding
-  removed from user-facing surfaces.
-- **Sprint 2** — The Work rebuild: Migration 005 adds friction-ledger
-  fields and a `blockers` table; portfolio data migrates from
-  `lib/portfolio.ts` into the `applications` table; new `/work` rendering
-  with friction first-class; auth-gated `/internal` view.
-- **Sprint 3** — ClickUp wiring + Submit-a-Project improvements: named-SLA
-  acknowledgment, submitter-visible status page (`/intake/[token]`),
-  similarity matching surfaced during assessment.
-- **Sprint 4** — *complete (May 2026)*. Reports unification (PR #90),
-  `_archive/` deletion (PR #91), Lovable cautionary tale salvaged into
-  Reports (PR #92), `lib/data.ts` retired with per-page colocation
-  (PR #93). The About page predated the sprint and is live at `/about`.
-  Remaining `app/docs/*` drift is tracked as
-  [#94](https://github.com/ui-insight/AISPEG/issues/94)–[#98](https://github.com/ui-insight/AISPEG/issues/98).
-- **Sprint 5** — *complete (May 2026)*. Data governance integration:
-  `vendor/data-governance/` submodule + drift CI + `iids-portfolio`
-  domain registration (PR #172).
-- **Post-Sprint-5 / May 2026** — Lifecycle taxonomy shipped end-to-end
-  ([ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md)) with
-  Migration 007, the `verify:portfolio` CI gate, and two-tier filter
-  UI. Strategic Plan Alignment Explorer shipped
-  ([ADR 0002](./docs/adr/0002-strategic-plan-alignment-explorer.md))
-  with Migration 008, bidirectional alignment, and drift CI. See
-  [`REFACTOR.md`](./REFACTOR.md) for the full timeline.
+- **Sprints 1–5** — *complete (May 2026)*. IA reshape, The Work rebuild
+  (Migration 005 friction ledger + `blockers`), Submit-a-Project
+  delivery (named SLA, `/intake/[token]`, live similarity), Reports
+  unification, and data-governance integration (`vendor/data-governance`
+  submodule, drift CI, `iids-portfolio` domain).
+- **Lifecycle taxonomy** — [ADR 0001](./docs/adr/0001-product-lifecycle-taxonomy.md),
+  Migration 007, the `verify:portfolio` CI gate, two-tier filter UI.
+  Amended in July 2026 to add the `paused` and `scoping` states.
+- **Strategic Plan Alignment Explorer** —
+  [ADR 0002](./docs/adr/0002-strategic-plan-alignment-explorer.md),
+  Migration 008, bidirectional alignment, drift CI.
+- **ClickUp ingestion** *(July 2026)* —
+  [ADR 0004](./docs/adr/0004-clickup-ingestion-boundary.md). Read-only
+  pull of project status, ROI, and the scored request backlog into
+  `clickup_*` tables (Migrations 010–011). Write-side is still future work.
+- **Unified Technology Request registry** *(July 2026)* —
+  [ADR 0005](./docs/adr/0005-unified-technology-request-registry.md).
+  Phase 1 shipped: the `tech_requests` registry (Migration 018) and
+  `/portfolio/pipeline` as the single all-origin request queue.
+- **Coordination surface** *(July 2026)* —
+  [ADR 0006](./docs/adr/0006-coordination-surface-split.md). The four
+  process sub-pages moved out of `/standards` into a new `/coordination`
+  surface; permanent redirects live in `next.config.mjs`.
+
+Known open documentation drift: `app/docs/*`
+([#94](https://github.com/ui-insight/AISPEG/issues/94),
+[#96](https://github.com/ui-insight/AISPEG/issues/96),
+[#97](https://github.com/ui-insight/AISPEG/issues/97)).
 
 ## Working on the codebase
 
@@ -145,10 +177,18 @@ Design direction is captured in [`.impeccable.md`](./.impeccable.md).
 ## Commands
 
 ```bash
-npm run dev      # Dev server on :3000
-npm run build    # Production build (also a TypeScript check)
-npm run lint     # ESLint
+npm run dev                  # Dev server on :3000
+npm run build                # Production build (also a TypeScript check)
+npm run lint                 # ESLint
+npm run verify:portfolio     # ADR 0001 status-rule enforcer (CI runs this)
+npm run migrate              # Apply pending SQL migrations
+npm run seed:portfolio       # lib/portfolio.ts → applications table
+npm run sync:clickup         # ClickUp read-only ingestion (ADR 0004)
 ```
+
+`npm run build` and `npm run verify:portfolio` both run in CI. Run them
+before pushing — the verifier fails any project whose claimed lifecycle
+status isn't backed by the evidence ADR 0001 requires.
 
 ## Deployment
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1,5 +1,34 @@
 # AISPEG Refactor Plan — May 2026
 
+> **Status: historical plan document. Last substantive update 2026-07-10.**
+>
+> Sprints 1–5 are complete and the user-facing surfaces no longer read as
+> mid-refactor. Read this for the *why* behind what was cut and how the
+> data architecture was originally framed — that reasoning is still
+> load-bearing and Agent Rule 5 still points here before structural work.
+>
+> Do **not** read it as a description of the current site. Several things
+> below were overtaken:
+>
+> - The primary nav is **five surfaces**, not four —
+>   `/coordination` was added in July 2026
+>   ([ADR 0006](./docs/adr/0006-coordination-surface-split.md)).
+> - `The Work` never became `/work`; the route stayed `/portfolio` and
+>   the label is now "Projects".
+> - The public/internal split described here was reversed on 2026-07-24:
+>   the site tells one story, and `/portfolio/pipeline` is the single
+>   all-origin request queue
+>   ([ADR 0005](./docs/adr/0005-unified-technology-request-registry.md)
+>   amendment).
+> - The co-branded *"Sponsored by AISPEG"* header language was dropped.
+>   Agent Rule 10 now forbids AISPEG in user-facing copy.
+> - ClickUp ingestion shipped read-only in July 2026
+>   ([ADR 0004](./docs/adr/0004-clickup-ingestion-boundary.md)); the
+>   bidirectional sync sketched below was not built.
+>
+> For anything decided after May 2026, [`docs/adr/`](./docs/adr/) is
+> authoritative and this file is not.
+
 ## Why
 
 The site was conceived in early 2026 as a collaborative nexus for the AI Strategic


### PR DESCRIPTION
`README.md` and `CONTRIBUTING.md` were last substantively updated **2026-05-05**. They predate the Coordination surface, ClickUp ingestion, and the UTR registry. `.impeccable.md` predates the `paused` lifecycle state. The result: orientation docs that disagreed with the code, with each other, and in two places with the normative Agent Rules they tell contributors to follow.

## The two that were actively harmful

**`CONTRIBUTING.md` documented a "solo work (direct to main)" workflow** with a `git push` recipe — in direct contradiction of Agent Rule 1 (*all work lands via PR*), in the file that tells you to read `CLAUDE.md` first.

**Its worked example for a new feature was "Add a `/standards/[id]` permalink"** — a route Rule 12 explicitly forbids recreating. The doc handed an agent a banned task as its model prompt.

Both are gone. The `verify:portfolio` gate that CI enforces is now documented alongside build and lint, and the clone recipe recurses submodules so `npm run dev` works from a fresh checkout (`predev` builds the vendored catalogs and fails without them).

## Factual corrections

| Claim | Was | Is |
|---|---|---|
| Primary surfaces | four | **five** — `/coordination` shipped July 2026 (ADR 0006) |
| Operational ladder | 9 states + `tracked` | **11 + `tracked`** — `scoping`, `paused` added by ADR 0001 amendments |
| Public stage rollup | 5 buckets | **6** — `Paused` (amber) |
| Migrations | `001 → 008` (README), `001 → 010` (CLAUDE.md) | **`001 → 019`** |
| Portfolio size | 14 / 15 | **29 across 13 home units** |
| `status:` example | `"Tracked"` | `"tracked"` — the capitalized form wouldn't typecheck |

`CLAUDE.md`'s structure map still listed `app/explore/` — a directory that doesn't exist and that Rule 12 forbids recreating — and omitted thirteen `lib/` modules, including the entire site-assistant subsystem. Its refactor status recorded nothing after May 2026 even though the IA table below it describes July work; that section now covers ADRs 0004–0006.

`.impeccable.md`'s chip palette was missing `Paused` and its filter description said "5 chips". Since Rule 4 makes that file mandatory reading before any visual change, an agent following it would have built the wrong chip set. Its stat-strip example was 15 projects out of date; it now shows the real numbers with a note that counts are computed at build time, never hardcoded.

## `REFACTOR.md`

Left as the historical plan document it is, with a header saying so and listing the five specific things below it that were later overtaken — the four-surface nav, `/work`, the public/internal split reversed on 2026-07-24, the *"Sponsored by AISPEG"* header language Rule 10 now forbids, and the bidirectional ClickUp sync that was never built. Rule 5 still points agents at this file, so it needs to be honest about what it is rather than quietly wrong.

## Also

`CLAUDE.md` now documents `/internal/portfolio` as a second inventory view that contradicts the one-story directive and is **under review** — so nobody builds on it while that decision is open. That route still exists and still renders; deciding its fate is a separate call.

## Verification

`npm run build` and `npm run lint` pass. All relative links in the five edited files resolve. No code or schema changes.

## Scope note

Branch (b) of a three-branch audit response was scoped to README / CONTRIBUTING / `.impeccable.md`. I pulled in `CLAUDE.md`'s factual drift and the `REFACTOR.md` header because they are the same class of error and it made no sense to fix `app/explore/` in three files and leave it in the fourth. Happy to split them back out if you'd rather review separately.

Follows #314. Next: an ADR for the site assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)