### PR TITLE
Fix the last stale surname in REFACTOR.md

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -296,7 +296,7 @@ ClickUp-independent. Reads from Postgres directly; ClickUp later replaces
 *who* updates status, not the surfaces.
 
 - ✅ `lib/intake-config.ts` — single source of truth for the named human
-  (Colin Armitage), the SLA wording, and the status-state labels.
+  (Colin Addington), the SLA wording, and the status-state labels.
 - ✅ `POST /api/similarity/preview` — stateless similarity endpoint that
   takes a partial assessment profile and returns matches against the
   registry. Threshold lower than the post-submit endpoint (0.2 vs 0.3) —


### PR DESCRIPTION
#314 corrected `Colin Armitage` → **Colin Addington** in `lib/intake-config.ts` and at `REFACTOR.md:179`, but missed a second occurrence at `REFACTOR.md:299` in the Sprint 3a section. The grep that found the first one was truncated before reaching it. Caught by a full-repo sweep after merge.

## Where the error came from

**Kali Armitage is a real person** — an OIT technical program manager. She appears correctly in `lib/oit-ea-portfolio.ts` (4 rows), `lib/portfolio.ts`, and on `/standards`. The intake config had crossed her surname with Colin Addington's first name, producing a person who doesn't exist plus a non-resolving email.

Every other `Armitage` reference in the repo is correct and untouched. Verified by full sweep:

```
REFACTOR.md:299            Colin Armitage   ← fixed here
app/standards/page.tsx:151 Kali Armitage    ← correct
lib/oit-ea-portfolio.ts    Kali Armitage ×4 ← correct
lib/portfolio.ts:1052      Kali Armitage    ← correct
```

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)