### PR TITLE
Close the scoping vocabulary gap; scope ADR 0005's status to what was decided

### DIFF
--- a/docs/adr/0005-unified-technology-request-registry.md
+++ b/docs/adr/0005-unified-technology-request-registry.md
@@ -1,8 +1,8 @@
 # ADR 0005 — Unified Technology Request: request registry & governance tracking
 
-**Status:** Proposed — for discussion with the UTR working group (Hunter, Victoravich, Bartlett, Ewart, Robison)
+**Status:** Accepted for the registry layer and Phase 1 (shipped 2026-07-24). The cross-institutional pieces — the TDX boundary, the prioritization model, and approved-tools ownership — remain **proposed**, pending the UTR working group (Hunter, Victoravich, Bartlett, Ewart, Robison). See the 2026-07-27 amendment.
 **Date:** 2026-07-23
-**Deciders:** Pending — Barrie Robison (IIDS) + UTR working group
+**Deciders:** Barrie Robison (IIDS), for the registry design and Phase 1 as built. Working-group ratification outstanding for the pieces that bind other offices.
 **Related:** [ADR 0001](./0001-product-lifecycle-taxonomy.md) (lifecycle), [ADR 0004](./0004-clickup-ingestion-boundary.md) (ingestion pattern this extends), Migration 012 (enterprise-replacement facts), `UnifiedTechRequest/Unified Technology Request Process.pptx` (July 2026 draft), UTR meeting notes + email thread of 2026-07-20 → 2026-07-23
 
 ## Context
@@ -373,3 +373,53 @@ story with no public vs. internal distinction**.
 - This supersedes the "internal first" posture above **for the request
   queue**. Prioritization rounds (Phase 4) will make their own
   visibility call when they land.
+
+### 2026-07-27 — Status: Proposed → Accepted for Phase 1
+
+**Context.** This ADR was written as a proposal to the UTR working group
+and its header still said `Proposed` / `Deciders: Pending` three days
+after Phase 1 shipped. A documentation audit flagged the mismatch: the
+index in [`docs/adr/README.md`](./README.md) was telling readers that a
+decision embodied in live tables, live code, and a public surface had not
+been made yet.
+
+The confusion is real rather than clerical. This ADR does two different
+things. It designs a registry **this repo owns and can build alone**, and
+it proposes a division of labour that **binds other offices** — TDX as
+the workflow system of record, a shared prioritization model, OIT's
+ownership of the approved-tools list. The first was decided and built.
+The second is still a proposal, and nothing here can accept it on the
+working group's behalf.
+
+**Decision.** Split the status rather than flatten it.
+
+- **Accepted** — the registry layer and Phase 1 as built: `tech_requests`,
+  `tech_request_events`, `tech_request_links`,
+  `tech_request_project_links`, and `roi_claims` (Migration 018);
+  `lib/utr.ts` and `lib/requests.ts`; the backfill of ClickUp requests,
+  site submissions, and the GEO/Scrunch records; the survey candidates
+  registered by Migration 019; and `/portfolio/pipeline` as the single
+  all-origin queue (the Phase 2 line item pulled forward per the
+  2026-07-24 amendment). Decided by the portfolio owner; these needed no
+  external dependency, which is exactly why Phase 1 was scoped that way.
+- **Still proposed** — §1's assignment of workflow to TDX, §5's
+  `sync-tdx.ts` boundary, the prioritization model (open question 1), and
+  approved-tools ownership (open question 2). These describe how other
+  offices would work and are for the working group to ratify, amend, or
+  reject.
+- **Not yet built** — Phases 2, 3, and 4. No `project_interest_pool`,
+  `governance_flags`, `project_gates`, or `prioritization_*` tables
+  exist; `lib/approved-tools.ts`, `/standards/approved-tools`,
+  `/internal/prioritization`, and `scripts/sync-tdx.ts` are all
+  unwritten. Phase 4's TDX sync remains blocked on API access.
+
+**Why not simply mark the whole thing Accepted.** It would assert that a
+group which has not met on it signed off on a division of institutional
+labour. The site's own standard is that every claim names a human and
+holds up; an ADR header overclaiming ratification fails that standard in
+the audit trail itself.
+
+**Follow-up.** When the working group does take this up, record the
+outcome as a further amendment — including a rejection, if that is the
+outcome. The header should stop hedging once there is something real to
+point at.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,10 @@ By convention, follow the shape of [`0001-product-lifecycle-taxonomy.md`](./0001
 # ADR NNNN — Short title
 
 **Status:** Proposed | Accepted | Superseded by [ADR NNNN](./NNNN-...)
+           (an ADR that decides some things this repo owns and proposes
+            others that bind another office may scope its status — see
+            ADR 0005 — but say which part is which, and never let a
+            header imply a ratification that hasn't happened)
 **Date:** YYYY-MM-DD
 **Deciders:** Names of the people who actually made the call
 **Supersedes:** (optional) Pointer to the ADR or pattern this replaces
@@ -82,6 +86,6 @@ ADRs are **append-only**. To change a decision:
 | [0002](./0002-strategic-plan-alignment-explorer.md) | Strategic Plan Alignment Explorer | Accepted | 2026-05-03 |
 | [0003](./0003-strategic-plan-map-home.md) | Strategic-Plan Map Home + `/explore` Retirement | Accepted | 2026-05-05 |
 | [0004](./0004-clickup-ingestion-boundary.md) | ClickUp Ingestion Boundary | Accepted | 2026-07-10 |
-| [0005](./0005-unified-technology-request-registry.md) | Unified Technology Request: Request Registry & Governance Tracking | Proposed | 2026-07-23 |
+| [0005](./0005-unified-technology-request-registry.md) | Unified Technology Request: Request Registry & Governance Tracking | Accepted (Phase 1); cross-institutional pieces proposed | 2026-07-23 |
 | [0006](./0006-coordination-surface-split.md) | Split `/coordination` out of `/standards` | Accepted | 2026-07-25 |
 | [0007](./0007-site-assistant-tool-grounded-qa.md) | Site Assistant: Tool-Grounded Q&A with Strict Citation | Accepted | 2026-07-27 |

--- a/lib/governance/vocabularies.ts
+++ b/lib/governance/vocabularies.ts
@@ -572,76 +572,83 @@ export const vocabularyGroups: VocabularyGroup[] = [
         "code": "idea",
         "label": "Idea",
         "displayOrder": 1,
-        "description": "Named with a unit-of-interest; not yet committed to build.",
-        "verificationRule": "No committed operationalOwner OR no committed iidsSponsor; repoUrl empty or repo has zero commits."
+        "description": "Named with a unit-of-interest; no owner or sponsor engaged yet.",
+        "verificationRule": "No committed operationalOwner AND no committed iidsSponsor (either one engaged makes it scoping); repoUrl empty or repo has zero commits."
+      },
+      {
+        "code": "scoping",
+        "label": "Scoping",
+        "displayOrder": 2,
+        "description": "Named humans engaged; feasibility and shape being worked out before a formal go decision.",
+        "verificationRule": "A named operationalOwners[0] OR iidsSponsor is engaged (neither means it is still idea); no liveUrl; pilotCohort empty. No repo-cadence requirement — scoping produces framing and feasibility work, not necessarily commits."
       },
       {
         "code": "approved",
         "label": "Approved",
-        "displayOrder": 2,
+        "displayOrder": 3,
         "description": "Committed to build with named owner and sponsor; not yet under active development.",
         "verificationRule": "operationalOwners[0] set AND iidsSponsor set AND non-empty description; no liveUrl; repo (if present) has <10 commits OR no commits in last 14 days."
       },
       {
         "code": "building",
         "label": "Building",
-        "displayOrder": 3,
+        "displayOrder": 4,
         "description": "Active development. Code exists but not yet for real users.",
         "verificationRule": "repoUrl set; lastCommitDate within last 60 days; no liveUrl (or liveUrl flagged liveUrlIsStaging:true); pilotCohort empty."
       },
       {
         "code": "prototype",
         "label": "Prototype",
-        "displayOrder": 4,
+        "displayOrder": 5,
         "description": "Demo-able but quiet — feature-complete or dormant.",
         "verificationRule": "pilotCohort empty; either lastCommitDate older than 30 days OR featureComplete:true."
       },
       {
         "code": "piloting",
         "label": "Piloting",
-        "displayOrder": 5,
+        "displayOrder": 6,
         "description": "In use by a bounded, named cohort.",
         "verificationRule": "liveUrl set; pilotCohort populated with size > 0 and a bounded scope."
       },
       {
         "code": "production",
         "label": "Production",
-        "displayOrder": 6,
+        "displayOrder": 7,
         "description": "In real institutional use beyond the pilot cohort.",
         "verificationRule": "Publicly-accessible artifact: liveUrl OR a public repoUrl (isPrivateRepo:false) for repo-as-artifact deliverables (infrastructure, scaffolds, appliances). productionScope and supportContact populated."
       },
       {
         "code": "maintained",
         "label": "Maintained",
-        "displayOrder": 7,
+        "displayOrder": 8,
         "description": "In production but in maintenance-only mode.",
         "verificationRule": "Inherits production accessibility (liveUrl or public repo); no commits to main in last 90 days; no open feature issues — only bug-, security-, or chore-labeled."
       },
       {
         "code": "paused",
         "label": "Paused",
-        "displayOrder": 8,
+        "displayOrder": 9,
         "description": "Deliberately on hold — not abandoned; expected to resume.",
         "verificationRule": "Deliberate hold, so no commit-cadence requirement; pilotCohort empty."
       },
       {
         "code": "sunsetting",
         "label": "Sunsetting",
-        "displayOrder": 9,
+        "displayOrder": 10,
         "description": "Being wound down with a planned successor.",
         "verificationRule": "sunsetDate (ISO) set; replacedBy populated — successor project slug or the literal 'manual-process'."
       },
       {
         "code": "archived",
         "label": "Archived",
-        "displayOrder": 10,
+        "displayOrder": 11,
         "description": "Stopped. Record kept for institutional memory.",
         "verificationRule": "liveUrl returns 404 / is null / domain dead, or (for repo-as-artifact) repoUrl is archived/deleted; service stopped."
       },
       {
         "code": "tracked",
         "label": "Tracked",
-        "displayOrder": 11,
+        "displayOrder": 12,
         "description": "Externally-owned project IIDS observes but does not build.",
         "verificationRule": "trackingOnly:true; bypasses the operational ladder."
       }
@@ -658,7 +665,7 @@ export const vocabularyGroups: VocabularyGroup[] = [
         "label": "Exploring",
         "displayOrder": 1,
         "description": "Thinking about it / committed to build.",
-        "verificationRule": "Rolls up from ProjectStatus values: idea, approved."
+        "verificationRule": "Rolls up from ProjectStatus values: idea, scoping, approved."
       },
       {
         "code": "building",


### PR DESCRIPTION
The two remaining governance items from the documentation audit.

## 1. `scoping` reaches the vendored vocabulary

ADR 0001's **2026-07-24 amendment named this follow-up itself** — *"add `scoping` to the vendored `iids-portfolio` ProjectStatus vocabulary upstream"* — and it was never done. `lib/portfolio.ts` has used `scoping` since July and one project currently claims it, against a registry that didn't list the code.

**Nothing would have caught it.** The governance drift workflow doesn't run on `lib/portfolio.ts` changes, so the typed union and the vendored registry can diverge in silence — which is the exact failure the catalog exists to prevent.

Upstream: [ui-insight/data-governance#17](https://github.com/ui-insight/data-governance/pull/17), merged. It adds `scoping` at Display_Order 2 between `idea` and `approved`, corrects the `Exploring` rollup to `idea, scoping, approved`, and **sharpens `idea`** — its rule read *"no committed operationalOwner **OR** no committed iidsSponsor"*, which with `scoping` in place would let a project with exactly one of the two satisfy both codes. The verifier treats *neither* as `idea` and *either* as `scoping`; the vocabulary now says the same. Rules were transcribed from `lib/portfolio-verification.ts` rather than paraphrased.

This PR bumps the submodule pointer and regenerates `lib/governance/vocabularies.ts` via `npm run build:governance` — regenerated, not hand-edited, per Agent Rule 13.

## 2. ADR 0005's status

The header read `Proposed` / `Deciders: Pending` three days after Phase 1 shipped, so the index was telling readers a decision embodied in live tables, live code, and a public surface hadn't been made.

**A flat flip to Accepted would have been wrong.** This ADR does two things:

| | Status |
|---|---|
| The registry this repo owns and built alone — `tech_requests` + 4 tables (Migration 018), `lib/utr.ts`, `lib/requests.ts`, Migration 019's survey candidates, `/portfolio/pipeline` | **Accepted** — decided by the portfolio owner; needed no external dependency, which is why Phase 1 was scoped that way |
| A division of institutional labour binding other offices — TDX as workflow system of record, the shared prioritization model, OIT's approved-tools ownership | **Still proposed** — for the UTR working group to ratify, amend, or reject |
| Phases 2–4 | **Unbuilt** — verified: no `project_interest_pool`, `governance_flags`, `project_gates`, or `prioritization_*` tables; no `lib/approved-tools.ts`, `/standards/approved-tools`, `/internal/prioritization`, or `scripts/sync-tdx.ts` |

Marking the whole thing Accepted would assert that a group which hasn't met on it signed off. The site's standard is that every claim names a human and holds up; an ADR header overclaiming ratification fails that standard in the audit trail itself.

Recorded as a dated amendment rather than a silent header rewrite, per this directory's append-only rule. `docs/adr/README.md`'s format section gains a line permitting a scoped status, since 0005 is now the precedent — constrained so a header can never imply a ratification that hasn't happened.

## One thing to confirm

**`Deciders` now reads "Barrie Robison (IIDS), for the registry design and Phase 1 as built."** That's inferred from the 2026-07-24 amendment ("the portfolio owner's call") and from Phase 1 having shipped. Correct it if the attribution is wrong.

## Verification

`npm run build`, `npm run lint`, and `npm run verify:portfolio` all pass — 29 projects, 0 errors, 2 pre-existing stale-commit-date warnings. `scoping` and the corrected `Exploring` rollup confirmed present in the regenerated catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)