### PR TITLE
Make iids-portfolio vocabulary parity a CI error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,11 @@ npm run migrate                # Apply pending SQL migrations against $DATABASE_
                                # (sole authority — never pipe a .sql into psql;
                                #  hand-applied files desync schema_migrations)
 npm run seed:portfolio         # lib/portfolio.ts → applications table (dev DB)
-npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this)
+npm run verify:portfolio       # ADR 0001 status-rule enforcer (CI runs this).
+                               # Also polices strategic-plan codes, the OIT
+                               # crosswalk, and ProjectStatus/PublicStage parity
+                               # with the vendored iids-portfolio vocabulary —
+                               # adding a status is a two-repo change.
 npm run refresh:commit-dates   # Hit GitHub API → regenerate lib/portfolio-meta.ts
 
 # ClickUp ingestion (ADR 0004; needs CLICKUP_API_TOKEN)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Design direction is captured in [`.impeccable.md`](./.impeccable.md).
 npm run dev                  # Dev server on :3000
 npm run build                # Production build (also a TypeScript check)
 npm run lint                 # ESLint
-npm run verify:portfolio     # ADR 0001 status-rule enforcer (CI runs this)
+npm run verify:portfolio     # ADR 0001 status-rule enforcer + governance parity (CI)
 npm run migrate              # Apply pending SQL migrations
 npm run seed:portfolio       # lib/portfolio.ts → applications table
 npm run sync:clickup         # ClickUp read-only ingestion (ADR 0004)

--- a/docs/adr/0001-product-lifecycle-taxonomy.md
+++ b/docs/adr/0001-product-lifecycle-taxonomy.md
@@ -260,3 +260,49 @@ production accessibility rule despite being in daily use by Payroll.
 **Decision.** Recorded as sub-decision #5 above: an `oit-*`
 `proposedDeploymentEnvironment` satisfies `production`/`maintained`
 accessibility; the OIT-operated platform is the artifact.
+
+### 2026-07-27 — Vocabulary follow-ups closed, and enforced from now on
+
+**Context.** The `paused` and `scoping` amendments above each ended with
+a **Follow-up** to register the new code in the vendored
+`iids-portfolio` ProjectStatus vocabulary. `paused` was done
+([data-governance#15](https://github.com/ui-insight/data-governance/pull/15)).
+`scoping` was not — and stayed undone while a project shipped claiming
+the status, with every check green the whole time.
+
+Each amendment noted in passing that this "does not block the build or
+the drift CI." That was accurate and, in hindsight, the actual problem:
+a follow-up whose only enforcement is someone remembering it is not
+enforced. The `iids-portfolio` registration exists precisely so this
+taxonomy has drift detection and an audit trail
+(see "Governance registration shape" above); it had neither for its own
+vocabulary.
+
+**Decision.**
+
+- `scoping` is registered upstream
+  ([data-governance#17](https://github.com/ui-insight/data-governance/pull/17)),
+  which also corrected the `Exploring` rollup rule to include it and
+  sharpened `idea` — whose rule read "no owner **OR** no sponsor" and
+  would otherwise have overlapped `scoping`. The verifier's meaning
+  (neither → `idea`, either → `scoping`) is now what the vocabulary says.
+- **Parity is now a CI error, in both directions.**
+  `verifyGovernanceVocabularyParity()` in `scripts/verify-portfolio.ts`
+  asserts that the `ProjectStatus` and `PublicStage` unions in
+  `lib/portfolio.ts` and the registered `iids-portfolio` vocabulary
+  contain exactly the same codes. It reads the unions from the exhaustive
+  `OPERATIONAL_LABEL` / `PUBLIC_STAGE_LABEL` records, so tsc guarantees
+  there is no third list to keep in sync.
+
+  This runs in the existing `verify:portfolio` job, which fires on every
+  PR. The Governance Drift workflow was the wrong home: it validates the
+  vendored registry's internal consistency and its remote repo canaries,
+  it has no knowledge of this repo's TypeScript unions, and it does not
+  run on `lib/portfolio.ts` changes.
+
+**Consequence for future amendments.** Adding an operational status is
+now a two-repo change, and CI will say so. The correct order is: land the
+vocabulary upstream, bump the submodule, run `npm run build:governance`,
+then add the code to the union. A "Follow-up" line is no longer a
+sufficient mechanism — if an amendment defers something, say what will
+fail if it is forgotten.

--- a/scripts/verify-portfolio.ts
+++ b/scripts/verify-portfolio.ts
@@ -14,10 +14,15 @@
 // CI:
 //   wired into .github/workflows/ci.yml as a separate job.
 
-import { projects } from "../lib/portfolio.js";
+import {
+  projects,
+  OPERATIONAL_LABEL,
+  PUBLIC_STAGE_LABEL,
+} from "../lib/portfolio.js";
 import { verifyAll, type VerificationProblem } from "../lib/portfolio-verification.js";
 import { priorities } from "../lib/strategic-plan/catalog.js";
 import { OIT_EA_PROJECTS } from "../lib/oit-ea-portfolio.js";
+import { vocabularyGroups } from "../lib/governance/vocabularies.js";
 
 function format(p: VerificationProblem): string {
   const tag = p.severity === "error" ? "ERROR " : "WARN  ";
@@ -74,20 +79,101 @@ function verifyOitCrosswalk(): VerificationProblem[] {
   return problems;
 }
 
+// The `iids-portfolio` domain in vendor/data-governance registers this
+// site's own taxonomies (ADR 0001, "Governance registration shape"). That
+// registration is only worth anything if it matches the union it claims to
+// describe — and nothing else checks it: the Governance Drift workflow
+// validates the vendored registry's internal consistency and its remote
+// repo canaries, and it doesn't run on lib/portfolio.ts at all.
+//
+// That gap was not hypothetical. ADR 0001's 2026-07-24 amendment added
+// `scoping` and named "add it upstream" as a follow-up; the follow-up was
+// missed, a project shipped claiming `scoping`, and the vocabulary went
+// three days without the code while every check stayed green. A July 2026
+// documentation audit found it by hand. This function is what should have
+// found it.
+//
+// Both directions are errors. A value in the union but not the vocabulary
+// means the registry is lying about what statuses exist; a value in the
+// vocabulary but not the union means a code was retired without being
+// deregistered, and a stakeholder reading the Data Model explorer sees a
+// state the site can no longer produce.
+function verifyGovernanceVocabularyParity(): VerificationProblem[] {
+  const problems: VerificationProblem[] = [];
+
+  const pairs: {
+    group: string;
+    // Keys of an exhaustive Record<Union, string>, so tsc guarantees this
+    // is the whole union — no second list to keep in sync here.
+    union: string[];
+  }[] = [
+    { group: "ProjectStatus", union: Object.keys(OPERATIONAL_LABEL) },
+    { group: "PublicStage", union: Object.keys(PUBLIC_STAGE_LABEL) },
+  ];
+
+  for (const { group, union } of pairs) {
+    const registered = vocabularyGroups.find(
+      (g) => g.domain === "iids-portfolio" && g.group === group
+    );
+
+    if (!registered) {
+      problems.push({
+        slug: `iids-portfolio/${group}`,
+        claimedStatus: "tracked",
+        problem: `no "${group}" vocabulary group registered under the iids-portfolio domain — expected one per ADR 0001. Did the submodule bump drop it, or was build:governance not re-run?`,
+        rule: "governance-vocab-parity",
+        severity: "error",
+      });
+      continue;
+    }
+
+    const codes = new Set(registered.values.map((v) => v.code));
+    const unionSet = new Set(union);
+
+    for (const value of union) {
+      if (!codes.has(value)) {
+        problems.push({
+          slug: `iids-portfolio/${group}`,
+          claimedStatus: "tracked",
+          problem: `"${value}" is in the ${group} union in lib/portfolio.ts but not registered in the vendored vocabulary. Add it upstream in ui-insight/data-governance (vocabularies/iids-portfolio/allowed_values.json), bump the submodule, then re-run npm run build:governance.`,
+          rule: "governance-vocab-parity",
+          severity: "error",
+        });
+      }
+    }
+
+    for (const code of codes) {
+      if (!unionSet.has(code)) {
+        problems.push({
+          slug: `iids-portfolio/${group}`,
+          claimedStatus: "tracked",
+          problem: `"${code}" is registered in the vendored ${group} vocabulary but is not a member of the union in lib/portfolio.ts. Either the code was retired without deregistering it upstream, or the submodule is ahead of this repo.`,
+          rule: "governance-vocab-parity",
+          severity: "error",
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
 function main(): void {
   const lifecycleProblems = verifyAll(projects);
   const stratPlanProblems = verifyStrategicPlanAlignment();
   const oitCrosswalkProblems = verifyOitCrosswalk();
+  const vocabParityProblems = verifyGovernanceVocabularyParity();
   const all = [
     ...lifecycleProblems,
     ...stratPlanProblems,
     ...oitCrosswalkProblems,
+    ...vocabParityProblems,
   ];
   const errors = all.filter((p) => p.severity === "error");
   const warnings = all.filter((p) => p.severity === "warning");
 
   console.log(
-    `Verifying ${projects.length} projects against ADR 0001 rules, strategic-plan alignment, and the OIT FY2027 crosswalk ...\n`
+    `Verifying ${projects.length} projects against ADR 0001 rules, strategic-plan alignment, the OIT FY2027 crosswalk, and iids-portfolio vocabulary parity ...\n`
   );
 
   if (warnings.length > 0) {


### PR DESCRIPTION
The `scoping` drift closed in #318 should never have been findable only by hand. ADR 0001's amendment named the upstream registration as a follow-up, the follow-up was missed, a project shipped claiming the status, and **every check stayed green for three days**.

## My first suggestion was wrong

I proposed adding `lib/portfolio.ts` to the Governance Drift workflow's path filter. Checking before building showed that wouldn't work: `check_governance_drift.py` validates the vendored registry's internal consistency and its remote repo canaries. It has no knowledge of this repo's TypeScript unions. Running it on a portfolio change would have been a no-op that *looked* like a fix — arguably worse than nothing, since it would have closed the item.

## What actually closes it

`verifyGovernanceVocabularyParity()` in `scripts/verify-portfolio.ts` — the `verify:portfolio` job already runs on every PR and can see both sides.

It asserts that the `ProjectStatus` and `PublicStage` unions in `lib/portfolio.ts` and the registered `iids-portfolio` vocabulary contain **exactly** the same codes. The unions are read from the exhaustive `OPERATIONAL_LABEL` / `PUBLIC_STAGE_LABEL` records, so tsc guarantees there's no third list to maintain. A missing vocabulary group is itself an error rather than a silently-skipped check.

**Both directions fail:**

| Drift | Why it matters |
|---|---|
| Code in the union, not in the vocabulary | The registry misdescribes what statuses exist — the `scoping` case |
| Code in the vocabulary, not in the union | A code was retired without deregistering it; the Data Model explorer shows stakeholders a state the site can no longer produce |

Each message names the fix, including the two-repo order.

## Verified against real drift, not just "it passes"

Reproduced the original failure by removing `scoping` from the generated vocabulary:

```
[ERROR ] iids-portfolio/ProjectStatus (tracked)
         "scoping" is in the ProjectStatus union in lib/portfolio.ts but not
         registered in the vendored vocabulary. Add it upstream in
         ui-insight/data-governance (vocabularies/iids-portfolio/allowed_values.json),
         bump the submodule, then re-run npm run build:governance.
```

And the reverse, by adding a code the union lacks:

```
[ERROR ] iids-portfolio/ProjectStatus (tracked)
         "mothballed" is registered in the vendored ProjectStatus vocabulary but is
         not a member of the union in lib/portfolio.ts. Either the code was retired
         without deregistering it upstream, or the submodule is ahead of this repo.
```

Baseline unchanged: 29 projects, 0 errors, 2 pre-existing stale-commit-date warnings. `npm run build` and `npm run lint` pass.

## Docs

ADR 0001 gains an amendment closing both vocabulary follow-ups (`paused` was done in data-governance#15; `scoping` in #17) and recording the consequence: **adding an operational status is now a two-repo change in a fixed order** — vocabulary upstream, submodule bump, `build:governance`, then the union. It also notes that a "Follow-up" line whose only enforcement is someone remembering it isn't enforcement, which is the lesson the `scoping` gap actually taught.

Follows #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)