### PR TITLE
Refresh the technical docs against the current codebase

### DIFF
--- a/app/docs/admin-guide/page.tsx
+++ b/app/docs/admin-guide/page.tsx
@@ -4,7 +4,7 @@ export default function AdminGuideDocsPage() {
   return (
     <DocPage
       title="Admin Guide"
-      subtitle="Managing submissions, the application registry, notes, and the review workflow."
+      subtitle="Managing submissions, the application registry, notes, and the review workflow during the ClickUp transition."
       breadcrumbs={[
         { label: "Docs", href: "/docs" },
         { label: "Admin Guide" },
@@ -95,15 +95,58 @@ export default function AdminGuideDocsPage() {
       </ul>
 
       <h3>Application Lifecycle</h3>
-      <p>Applications progress through these states:</p>
+      <p>
+        The canonical lifecycle is the two-layer taxonomy in{" "}
+        <a href="https://github.com/ui-insight/AISPEG/blob/main/docs/adr/0001-product-lifecycle-taxonomy.md">
+          ADR 0001
+        </a>
+        : an operational ladder of eleven states plus the <code>tracked</code>{" "}
+        meta-state, rolling up into six public stages. Each state has a
+        measurable verification rule enforced by{" "}
+        <code>npm run verify:portfolio</code> in CI.
+      </p>
       <ul>
-        <li><strong>idea</strong> — Concept stage, not yet approved</li>
-        <li><strong>approved</strong> — Approved to proceed (auto-set when promoted)</li>
-        <li><strong>in-development</strong> — Actively being built</li>
-        <li><strong>staging</strong> — Deployed to a test environment</li>
-        <li><strong>production</strong> — Live and serving users</li>
-        <li><strong>retired</strong> — Decommissioned (excluded from similarity checks)</li>
+        <li><strong>idea</strong> — named, no owner or sponsor engaged yet</li>
+        <li><strong>scoping</strong> — named humans engaged, feasibility underway, no formal go decision</li>
+        <li><strong>approved</strong> — committed to build with named owner and sponsor</li>
+        <li><strong>building</strong> — under active development</li>
+        <li><strong>prototype</strong> — demo-able but quiet; feature-complete or dormant</li>
+        <li><strong>piloting</strong> — in use by a bounded, named cohort</li>
+        <li><strong>production</strong> — in real institutional use beyond the pilot</li>
+        <li><strong>maintained</strong> — production, maintenance-only mode</li>
+        <li><strong>paused</strong> — deliberately on hold; not abandoned</li>
+        <li><strong>sunsetting</strong> — winding down with a planned successor</li>
+        <li><strong>archived</strong> — stopped; record kept for institutional memory</li>
+        <li><strong>tracked</strong> — externally owned; IIDS observes but did not build</li>
       </ul>
+
+      <InfoBox type="warning" title="The registry form's status list is stale">
+        <p>
+          <code>STATUS_OPTIONS</code> in{" "}
+          <code>app/admin/registry/[id]/page.tsx</code> still offers the legacy
+          submission states (<code>in-development</code>, <code>staging</code>,{" "}
+          <code>retired</code>) and the pre-ADR-0001 capitalised union
+          (<code>Planned</code>, <code>Prototype</code>, <code>Piloting</code>,{" "}
+          <code>Production</code>, <code>Tracked</code>, <code>Archived</code>).
+          None of those are members of the current taxonomy.
+        </p>
+        <p className="mt-2">
+          <code>applications.status</code> is plain <code>TEXT</code> with no
+          CHECK constraint, so such a value writes successfully, and{" "}
+          <code>publicStageFromStatus()</code> buckets anything unrecognised as{" "}
+          <em>Exploring</em> so the UI never crashes. The practical effect:
+          setting a status here can silently misfile a project on{" "}
+          <code>/portfolio</code>.{" "}
+          <code>npm run verify:portfolio</code> will not catch it — the verifier
+          reads <code>lib/portfolio.ts</code>, not the database.
+        </p>
+        <p className="mt-2">
+          <strong>Until that list is fixed, prefer editing{" "}
+          <code>lib/portfolio.ts</code> and re-seeding</strong> over changing a
+          status here. Tracked as a follow-up to the July 2026 documentation
+          audit.
+        </p>
+      </InfoBox>
 
       <h3>Registry Detail Page</h3>
       <p>
@@ -126,6 +169,37 @@ export default function AdminGuideDocsPage() {
         To register an application that didn&apos;t come through the Submit-a-Project
         assessment, click <strong> &ldquo;Register App&rdquo;</strong> on the registry page.
         This is useful for existing applications that predate the platform.
+      </p>
+
+      <h2>Where the admin surfaces sit now</h2>
+      <p>
+        <code>/admin/*</code> is <strong>transitional</strong>. The source-of-truth
+        boundary has moved since these pages were built:
+      </p>
+      <ul>
+        <li>
+          <strong>Project identity and lifecycle</strong> — authored in{" "}
+          <code>lib/portfolio.ts</code> and seeded into <code>applications</code>{" "}
+          by <code>npm run seed:portfolio</code>. The seed{" "}
+          <code>TRUNCATE</code>s, so registry edits made here are{" "}
+          <strong>overwritten by the next re-seed</strong>.
+        </li>
+        <li>
+          <strong>Project status narrative and ROI</strong> — ClickUp, pulled
+          read-only into <code>clickup_*</code> tables (ADR 0004). Trigger a
+          pull with the &ldquo;Sync now&rdquo; button on <code>/internal</code>.
+        </li>
+        <li>
+          <strong>Requests</strong> — the <code>tech_requests</code> registry
+          (ADR 0005), surfaced publicly at <code>/portfolio/pipeline</code>.
+          That is the one all-origin queue; there is no internal copy.
+        </li>
+      </ul>
+      <p>
+        Submissions review — the dashboard, notes, similarity, and promote —
+        remains the live workflow here, and is what this page is for. ClickUp
+        write-side (new submissions creating ClickUp tasks) is still future
+        work; when it lands, <code>/admin/submissions</code> retires.
       </p>
 
       <h2>Notes System</h2>

--- a/app/docs/api-reference/page.tsx
+++ b/app/docs/api-reference/page.tsx
@@ -59,7 +59,7 @@ export default function ApiReferenceDocsPage() {
   return (
     <DocPage
       title="API Reference"
-      subtitle="REST API endpoints for submissions, the application registry, notes, similarity detection, and AI features."
+      subtitle="REST API endpoints for submissions, the application registry, notes, similarity detection, AI features, the site assistant, and the ClickUp sync trigger."
       breadcrumbs={[
         { label: "Docs", href: "/docs" },
         { label: "API Reference" },
@@ -176,7 +176,78 @@ export default function ApiReferenceDocsPage() {
           ]} />
           <p className="text-xs text-gray-500 mt-2">Returns 503 if MINDROUTER_API_KEY is not configured.</p>
         </Endpoint>
+
+        <Endpoint method="POST" path="/api/ask" description="The site assistant. Runs the tool-using agent loop over read-only site data and returns a cited answer. Backs the floating chat widget on every page. See ADR 0007.">
+          <ParamTable params={[
+            { name: "message", type: "string", desc: "User question. Required; 2000 chars max." },
+            { name: "history", type: "array", desc: "Optional prior turns as {role: 'user'|'assistant', content}. Last 20 kept; other roles are dropped." },
+          ]} />
+          <p className="text-xs text-gray-500 mt-2">
+            Returns <code>{`{ response, citations[], toolCalls[], iterations, truncated, salvagedToolCalls }`}</code>.
+            Citations are assembled from the tools&apos; own canonical URLs, never authored by the model.
+          </p>
+          <p className="text-xs text-gray-500 mt-1">
+            Rate limited per IP hash: 60/hour public, 600/hour internal. Over the
+            limit returns <strong>429</strong> with <code>Retry-After</code>,
+            <code>X-RateLimit-Limit</code>, and <code>X-RateLimit-Remaining</code>.
+            Returns 503 with <code>unconfigured: true</code> when
+            MINDROUTER_API_KEY is unset.
+          </p>
+          <p className="text-xs text-gray-500 mt-1">
+            A MindRouter outage returns <strong>200</strong>, not 500 — the body
+            carries a friendly fallback message and <code>fallback: true</code> so
+            the chat widget degrades instead of erroring. Every call is logged to{" "}
+            <code>agent_queries</code>.
+          </p>
+        </Endpoint>
       </div>
+
+      <h2>Similarity</h2>
+      <div className="not-prose space-y-4">
+        <Endpoint method="POST" path="/api/similarity/preview" description="Stateless similarity check against the registry. Takes a partial assessment profile and returns matches without persisting anything — used mid-assessment so a submitter can coordinate before duplicating effort.">
+          <ParamTable params={[
+            { name: "sensitivity", type: "string[]", desc: "Partial wizard answers — all fields optional" },
+            { name: "complexity", type: "string", desc: "Static | CRUD | Multi-source | Real-time" },
+            { name: "userbase", type: "string", desc: "Team | Department | College | University | External" },
+            { name: "auth", type: "string", desc: "None | Password | SSO | RBAC | Multi-tenant" },
+            { name: "integrations", type: "string[]", desc: "" },
+            { name: "dataSources", type: "string[]", desc: "" },
+            { name: "universitySystems", type: "string[]", desc: "" },
+            { name: "outputTypes", type: "string[]", desc: "" },
+          ]} />
+          <p className="text-xs text-gray-500 mt-2">
+            Distinct from <code>/api/submissions/[id]/similarity</code>, which
+            persists matches after a real submission. This runs at threshold
+            <strong> 0.2</strong> rather than 0.3 — deliberately over-notifying and
+            letting the submitter judge.
+          </p>
+        </Endpoint>
+      </div>
+
+      <h2>Operations</h2>
+      <div className="not-prose space-y-4">
+        <Endpoint method="POST" path="/internal/sync" description="Trigger a ClickUp ingestion run (ADR 0004). Pulls project status updates, ROI fields, and the scored request backlog into the clickup_* tables.">
+          <p className="text-xs text-gray-500 mt-2">
+            Lives under <code>/internal</code> so the Basic-auth proxy covers it.
+            Used by the &ldquo;Sync now&rdquo; button and by the host cron:
+          </p>
+          <pre className="mt-2 rounded-lg bg-gray-900 p-3 text-xs text-green-400 overflow-x-auto">{`curl -s -u "$BASIC_AUTH_USER:$BASIC_AUTH_PASS" -X POST \\
+  https://aispeg.insight.uidaho.edu/internal/sync`}</pre>
+          <p className="text-xs text-gray-500 mt-2">
+            Returns the run summary on success. <strong>503</strong> if
+            CLICKUP_API_TOKEN is unset; <strong>409</strong> if a sync is already
+            in flight — a run takes 30–60s of sequential ClickUp calls and
+            overlapping runs would double-write.
+          </p>
+        </Endpoint>
+      </div>
+
+      <InfoBox type="tip" title="Keeping this page honest">
+        This page drifted badly once already (issue #94): it documented the
+        registry and submissions endpoints while missing the site assistant, the
+        similarity preview, and the sync trigger entirely. If you add a route
+        under <code>app/api/</code>, add it here in the same PR.
+      </InfoBox>
     </DocPage>
   );
 }

--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -19,34 +19,49 @@ export default function ArchitectureDocsPage() {
 
       <h3>Component Diagram</h3>
       <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
-┌─────────────────────────────────────────────────────────────┐
-│                        Browser                              │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │
-│  │ Builder Guide │  │ Admin Pages  │  │ AI Chat Panel    │  │
-│  │ (Wizard)      │  │ (Dashboard)  │  │ (MindRouter)     │  │
-│  └──────┬───────┘  └──────┬───────┘  └────────┬─────────┘  │
-└─────────┼──────────────────┼──────────────────┼─────────────┘
-          │                  │                  │
-          ▼                  ▼                  ▼
-┌─────────────────────────────────────────────────────────────┐
-│                   Next.js API Routes                        │
-│  /api/submissions  /api/registry  /api/ai/analyze-idea      │
-│  /api/.../notes    /api/.../similarity  /api/ai/refine      │
-│  /api/.../promote                                           │
-└────────────┬───────────────────────────────┬────────────────┘
-             │                               │
-             ▼                               ▼
-┌────────────────────────┐    ┌──────────────────────────────┐
-│     PostgreSQL 16      │    │   MindRouter (On-Prem LLM)   │
-│  ┌──────────────────┐  │    │  OpenAI-compatible API        │
-│  │ submissions      │  │    │  qwen3.6-27b model            │
-│  │ submission_details│  │    │  https://mindrouter.uidaho.edu│
-│  │ submission_notes  │  │    └──────────────────────────────┘
-│  │ applications     │  │
-│  │ similarity_matches│  │
-│  └──────────────────┘  │
-└────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│                            Browser                               │
+│ ┌───────────┐ ┌──────────┐ ┌───────────┐ ┌──────┐ ┌───────────┐ │
+│ │ Portfolio │ │ Builder  │ │ Site      │ │Admin │ │ Internal  │ │
+│ │ + Pipeline│ │ Guide    │ │ Assistant │ │Pages │ │ (ops only)│ │
+│ └─────┬─────┘ └────┬─────┘ └─────┬─────┘ └──┬───┘ └─────┬─────┘ │
+└───────┼────────────┼─────────────┼──────────┼───────────┼────────┘
+        │            │             │          │           │
+        ▼            ▼             ▼          ▼           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                       Next.js (App Router)                       │
+│  Server components read lib/* directly — most pages make no API  │
+│  call at all. Route handlers exist for mutations and the agent:  │
+│                                                                  │
+│  /api/submissions  /api/registry   /api/ai/analyze-idea          │
+│  /api/.../notes    /api/.../promote  /api/ai/refine              │
+│  /api/.../similarity  /api/similarity/preview                    │
+│  /api/ask (agent loop)         /internal/sync (ClickUp trigger)  │
+└───┬────────────────────┬───────────────────┬─────────────────────┘
+    │                    │                   │
+    ▼                    ▼                   ▼
+┌─────────────────┐ ┌──────────────────┐ ┌──────────────────────┐
+│  PostgreSQL 16  │ │ MindRouter (LLM) │ │  External / vendored │
+│ submissions     │ │ OpenAI-compatible│ │ ClickUp  (pull-only) │
+│ submission_*    │ │ qwen3.6-27b      │ │ GitHub Issues        │
+│ applications    │ │ mindrouter       │ │ vendor/data-         │
+│ blockers        │ │   .uidaho.edu    │ │   governance (submod)│
+│ similarity_*    │ └──────────────────┘ │ vendor/strategic-plan│
+│ clickup_*       │                      └──────────────────────┘
+│ tech_request*   │      Typed TS modules (lib/*) are the source
+│ roi_claims      │      of truth for taxonomies and narrative —
+│ agent_queries   │      generated catalogs come from the
+│ schema_migrations│     submodules at build time.
+└─────────────────┘
       `}</pre>
+
+      <InfoBox type="info" title="Server components, not a REST client">
+        Most of this site never touches its own API. Pages are server
+        components that import <code>lib/*</code> and query Postgres directly.
+        The route handlers above exist for mutations (the wizard, the admin
+        surfaces), for the agent loop, and for the sync trigger — not as a
+        data-access layer for the UI.
+      </InfoBox>
 
       <h2>Database Schema</h2>
 
@@ -113,7 +128,51 @@ output_types      TEXT[]
 submission_id     UUID FK → submissions  -- Provenance link
 created_at        TIMESTAMPTZ
 updated_at        TIMESTAMPTZ    -- Auto-updated via trigger
+
+-- Portfolio identity (Migration 005). lib/portfolio.ts is the typed
+-- shadow and seed source; lib/work.ts is the runtime read path.
+slug              TEXT           -- Stable public identifier
+tagline           TEXT
+home_units        TEXT[]         -- Whose work depends on this
+operational_owners JSONB         -- [{name, title}] — rendered publicly
+build_participants TEXT[]        -- Who actually built it
+visibility_tier   TEXT           -- public | embargoed | internal
+clickup_task_id   TEXT           -- Reverse pointer (ADR 0004)
+
+-- Lifecycle taxonomy (Migration 007, ADR 0001). No CHECK constraint —
+-- the typed union in lib/portfolio.ts is the source of truth, and
+-- npm run verify:portfolio enforces the per-status evidence rules.
+status            TEXT           -- 12 values: idea | scoping | approved |
+                                 -- building | prototype | piloting |
+                                 -- production | maintained | paused |
+                                 -- sunsetting | archived | tracked
+iids_sponsor      TEXT
+feature_complete  BOOLEAN
+live_url_is_staging BOOLEAN
+pilot_cohort      JSONB          -- {size, scope, namedUsers[]}
+production_scope  TEXT           -- home-unit | institution-wide | external
+support_contact   TEXT
+sunset_date       DATE
+replaced_by       TEXT
+tracking_only     BOOLEAN
+
+-- Strategic-plan alignment (Migration 008, ADR 0002)
+strategic_plan_alignment TEXT[]  -- Priority codes, e.g. {A.1, D.3}
+
+-- ClickUp-synced narrative (Migration 011, ADR 0004)
+status_summary        TEXT
+status_summary_at     TIMESTAMPTZ
+status_summary_source TEXT
       `}</pre>
+
+      <InfoBox type="tip" title="Why no CHECK constraints on the enums">
+        <code>status</code>, <code>visibility_tier</code>, and the alignment
+        codes are all validated by typed TypeScript modules and by{" "}
+        <code>npm run verify:portfolio</code> in CI, not by the database. That
+        is deliberate — adding a lifecycle state should be a code change with a
+        governance record (an ADR amendment plus a vocabulary registration),
+        not a migration. See ADR 0001.
+      </InfoBox>
 
       <h3>similarity_matches</h3>
       <p>Pre-computed overlap scores between submissions and registry applications.</p>
@@ -136,6 +195,93 @@ author           TEXT
 content          TEXT
 created_at       TIMESTAMPTZ
       `}</pre>
+
+      <h3>blockers</h3>
+      <p>
+        The friction ledger — what is stalling a project, and who is named. One
+        row per active blocker, categorised against the 14-category taxonomy in{" "}
+        <code>lib/work.ts</code>.
+      </p>
+      <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
+id               UUID PRIMARY KEY
+application_id   UUID FK → applications ON DELETE CASCADE
+category         TEXT           -- oit-review | unit-engagement |
+                                -- legal-embargo | funding | ...14 total
+named_party      TEXT           -- e.g. 'OIT', 'Unit X'
+since            DATE           -- Drives the public day counter
+public_text      TEXT           -- Safe for /portfolio
+internal_text    TEXT           -- No surface reads this as of 2026-07-27
+severity         TEXT           -- low | medium | high
+resolved_at      DATE
+      `}</pre>
+
+      <h3>clickup_projects · clickup_status_updates · clickup_requests · clickup_sync_runs</h3>
+      <p>
+        Projection tables for the read-only ClickUp ingestion (ADR 0004,
+        Migrations 010–011). These carry <strong>no foreign keys</strong> to{" "}
+        <code>applications</code> — the seed script truncates that table with
+        CASCADE, which would silently wipe synced data. Synced rows key on
+        ClickUp ids and join to portfolio slugs at read time via{" "}
+        <code>lib/clickup-map.ts</code>, so seed and sync are order-independent
+        and each is individually idempotent.
+      </p>
+      <p>
+        <code>clickup_sync_runs</code> records freshness so a surface can say
+        how stale it is rather than implying it is live.
+      </p>
+
+      <h3>tech_requests + tech_request_events, tech_request_links, tech_request_project_links, roi_claims</h3>
+      <p>
+        The Unified Technology Request registry (ADR 0005 Phase 1, Migration
+        018). One <code>tech_requests</code> row per request regardless of
+        origin (<code>tdx</code> | <code>clickup</code> |{" "}
+        <code>site-submission</code> | <code>direct</code>), with an append-only
+        event trail, a request↔request and request↔project link graph, and an
+        ROI claims ledger. Backs <code>/portfolio/pipeline</code>, the single
+        all-origin request queue.
+      </p>
+      <p>
+        Project links use <code>application_slug</code> as a soft key rather
+        than a foreign key, for the same re-seed reason as the ClickUp tables.
+      </p>
+
+      <h3>agent_queries</h3>
+      <p>
+        Observability for the site assistant (ADR 0007, Migration 009). Every{" "}
+        <code>POST /api/ask</code> is recorded — message, response, tools
+        called, citation count, iterations, truncation, latency, outcome, HTTP
+        status, model. Reviewable at <code>/internal/agent-log</code>.
+      </p>
+      <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
+id               BIGSERIAL PRIMARY KEY
+created_at       TIMESTAMPTZ
+ip_hash          TEXT           -- SHA-256 of '<ip>:<AGENT_LOG_SALT>'.
+                                -- Never the raw IP — no PII at rest.
+audience         TEXT           -- CHECK (public | internal)
+message          TEXT
+response         TEXT           -- Null if the request errored early
+tool_calls       TEXT[]         -- Names, in call order
+citation_count   INTEGER
+iterations       INTEGER
+truncated        BOOLEAN
+latency_ms       INTEGER
+outcome          TEXT           -- ok | mindrouter_error | tool_error |
+                                -- rate_limited | bad_request |
+                                -- unconfigured | internal_error
+http_status      INTEGER
+model            TEXT
+error_message    TEXT
+      `}</pre>
+
+      <h3>schema_migrations</h3>
+      <p>
+        Applied-migration ledger written by <code>scripts/migrate.ts</code>,
+        which is the only thing that applies migrations. Piping a{" "}
+        <code>.sql</code> file straight into <code>psql</code> changes the
+        schema without recording it here, and the runner will later try to
+        apply it again and fail — individual migration files are not reliably
+        idempotent. Idempotency lives in the runner.
+      </p>
 
       <h2>Indexes</h2>
       <p>
@@ -199,31 +345,66 @@ auth_level             5%     Exact match
         <li>Admin redirected to the new registry entry</li>
       </ol>
 
+      <h3>Assistant Flow</h3>
+      <ol>
+        <li>User asks a question in the floating chat widget</li>
+        <li>Client POSTs to <code>/api/ask</code>; rate limit checked per IP hash</li>
+        <li>
+          The agent loop (<code>lib/agent/loop.ts</code>) calls MindRouter with
+          the message plus 25 read-only tool definitions
+        </li>
+        <li>
+          Tools execute against site data and return a payload plus a{" "}
+          <code>canonicalUrl</code>; the loop accumulates those as citations
+        </li>
+        <li>
+          The model composes an answer, or refuses if no tool returned relevant
+          data — see ADR 0007&apos;s strict-citation policy
+        </li>
+        <li>The turn is logged to <code>agent_queries</code></li>
+      </ol>
+
       <h2>Project Structure</h2>
+      <p>
+        Abbreviated — see <code>CLAUDE.md</code> for the annotated tree, which
+        is kept current as the normative reference.
+      </p>
       <pre className="not-prose rounded-lg bg-gray-900 p-4 text-sm text-green-400 overflow-x-auto">{`
 app/
-  layout.tsx              # Root layout with Sidebar
-  page.tsx                # Landing — four-card steering page
+  layout.tsx              # Root layout: Sidebar + site-assistant widget
+  page.tsx                # Landing — three-lane steering page
   portfolio/              # Projects inventory
+    pipeline/             # Unified all-origin request queue (ADR 0005)
   builder-guide/          # Submit-a-Project assessment
+  intake/[token]/         # Submitter-visible status page
+  coordination/           # PROCESS surfaces (ADR 0006)
+  standards/              # REFERENCE surfaces
+    data-model/           # Data Governance Explorer
+    strategic-plan/       # Strategic Plan Alignment Explorer + map
   reports/                # Reports surface
-  standards/              # Standards ledger
-  ai4ra-ecosystem/        # AI4RA partnership reference
-  admin/
-    submissions/          # Submission list + detail
-    registry/             # App registry list + detail + new
-  api/
-    submissions/          # CRUD + notes + similarity + promote
-    registry/             # CRUD
-    ai/                   # analyze-idea + refine (MindRouter)
+  about/, ai4ra-ecosystem/
+  internal/               # Ops only — sync trigger, agent log
+  admin/                  # Submissions + registry admin
+  api/                    # See the API Reference page
   docs/                   # Documentation pages (you are here)
 components/
   Sidebar.tsx             # Navigation sidebar
+  SectionSubNav.tsx       # Shared sub-nav for Standards + Coordination
   PortfolioCard.tsx       # Project card
+  PortfolioFilters.tsx    # Two-tier stage / status filter
+  ProjectDetail.tsx       # Project detail composition
+  ChatWidget.tsx          # Site assistant (ADR 0007)
   IssueCard.tsx           # GitHub issue card
   DocPage.tsx             # Documentation layout components
 lib/
-  portfolio.ts            # Projects inventory (typed)
+  portfolio.ts            # Projects inventory + lifecycle (typed)
+  work.ts                 # Postgres read path for /portfolio
+  utr.ts, requests.ts     # Request registry (ADR 0005)
+  clickup*.ts             # ClickUp ingestion (ADR 0004)
+  agent/                  # Site assistant — tools, loop, logging
+  governance/             # UDM catalog modules (generated + curated)
+  strategic-plan/         # Pillars + priorities (generated + curated)
+  surveys/                # Operational Excellence survey
   standards-watch.ts      # Standards ledger entries
   builder-guide-data.ts   # Quiz steps, scoring, tiers
   similarity.ts           # Similarity detection engine


### PR DESCRIPTION
Closes the `/docs` drift tracked since May: #94, #96, #97.

## API Reference (#94)

Documented the submissions and registry endpoints; **missed three others entirely**. Now covered with their real contracts, read off the route handlers:

- **`POST /api/ask`** — the site assistant. Rate limits (60/hr public, 600/hr internal) with the `Retry-After` / `X-RateLimit-*` headers, and the deliberate **200-with-`fallback: true`** behaviour on a MindRouter outage — it doesn't 500, so the chat widget degrades instead of erroring.
- **`POST /api/similarity/preview`** — and *why* it's separate from `/api/submissions/[id]/similarity`: threshold **0.2 vs 0.3**, stateless vs persisting. Over-notify and let the submitter judge.
- **`POST /internal/sync`** — the ClickUp trigger, including 409-when-in-flight (a run is 30–60s of sequential calls; overlapping runs would double-write).

Verified: all **12** routes under `app/api/` and `app/internal/` now appear on the page.

## Architecture (#96)

Described the **migration-003 schema** — five tables, no lifecycle columns, no friction ledger, no ClickUp projections, no request registry, no agent log.

- All **17 tables** now documented (verified by diffing `CREATE TABLE` across `db/migrations/*` against the page).
- The ~40 columns added to `applications` since, grouped by the migration and ADR that introduced them.
- **Why the enums carry no CHECK constraints** — the typed modules plus `verify:portfolio` are the enforcement, deliberately, so adding a lifecycle state stays a governance change rather than a migration.
- The component diagram showed a browser-calls-API architecture **that was never true of most of this site**. It now says plainly that pages are server components reading `lib/*` directly, and the route handlers exist for mutations, the agent, and the sync trigger.
- Added the assistant data flow alongside the submission/analysis/promote flows.

## Admin Guide (#97)

Listed a six-state lifecycle superseded by ADR 0001. Now carries the real twelve-state ladder, plus a section on where the admin surfaces actually sit: **registry edits are overwritten by the next `seed:portfolio` TRUNCATE**, status narrative comes from ClickUp, requests live in `tech_requests`. Submissions review is the part that's still the live workflow.

## ⚠️ A defect found while checking that page

`STATUS_OPTIONS` in `app/admin/registry/[id]/page.tsx` still offers the legacy submission states (`in-development`, `staging`, `retired`) **and** the pre-ADR-0001 capitalised union (`Planned`, `Prototype`, `Piloting`, …) — ADR 0001 explicitly supersedes the latter. None are members of the current taxonomy.

`applications.status` is plain `TEXT` with no CHECK, so those values write successfully, and `publicStageFromStatus()` buckets anything unrecognised as **Exploring** so the UI never crashes. Net effect: **an admin can silently misfile a project on `/portfolio`**, and `verify:portfolio` won't catch it — the verifier reads `lib/portfolio.ts`, not the database.

I documented it rather than fixing it, because the fix is a product decision (restrict the list? add a CHECK? extend the verifier to the DB? retire the surface, since REFACTOR.md has it retiring when ClickUp write-side lands). Flagged as a follow-up.

## Verification

`npm run build` and `npm run lint` pass. All three pages rendered in the browser and checked for content, not just compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)