### PR TITLE
Audit applications.status against the union, not just the typed module

### DIFF
--- a/app/docs/admin-guide/page.tsx
+++ b/app/docs/admin-guide/page.tsx
@@ -144,6 +144,13 @@ export default function AdminGuideDocsPage() {
           select shows it as a marked option so the record isn&apos;t silently
           rewritten on load — pick a replacement and save.
         </p>
+        <p className="mt-2">
+          To find such rows without opening them one at a time, run{" "}
+          <code>npm run verify:portfolio</code> with <code>DATABASE_URL</code>{" "}
+          set: it reads <code>applications.status</code> and errors on any
+          value outside the union. CI has no database, so there it checks the
+          typed module only.
+        </p>
       </InfoBox>
 
       <h3>Registry Detail Page</h3>

--- a/app/docs/api-reference/page.tsx
+++ b/app/docs/api-reference/page.tsx
@@ -134,7 +134,7 @@ export default function ApiReferenceDocsPage() {
             { name: "github_repo", type: "string?", desc: "GitHub repo (org/repo format)" },
             { name: "url", type: "string?", desc: "Production URL" },
             { name: "tier", type: "number?", desc: "1-4, defaults to 1" },
-            { name: "status", type: "string?", desc: "Lifecycle status, defaults to 'idea'" },
+            { name: "status", type: "string?", desc: "An ADR 0001 operational status, defaults to 'idea'. Anything outside the ladder returns 400." },
             { name: "proposed_deployment_environment", type: "string?", desc: "Proposed hosting target; defaults to 'to-be-determined'" },
             { name: "enterprise_replacement_status", type: "string?", desc: "yes | no | to-be-determined" },
             { name: "existing_enterprise_system_name", type: "string?", desc: "Required when replacement status is yes" },
@@ -151,7 +151,7 @@ export default function ApiReferenceDocsPage() {
         <Endpoint method="PATCH" path="/api/registry/[id]" description="Update any application fields. Only provided fields are modified.">
           <ParamTable params={[
             { name: "name", type: "string?", desc: "Application name" },
-            { name: "status", type: "string?", desc: "An ADR 0001 operational status — idea | scoping | approved | building | prototype | piloting | production | maintained | paused | sunsetting | archived | tracked. The column is plain TEXT with no CHECK, so anything else writes successfully and renders as Exploring. Send one of these." },
+            { name: "status", type: "string?", desc: "An ADR 0001 operational status — idea | scoping | approved | building | prototype | piloting | production | maintained | paused | sunsetting | archived | tracked. The column is plain TEXT with no CHECK, so this endpoint is the constraint: anything else returns 400." },
             { name: "github_repo", type: "string?", desc: "GitHub repository" },
             { name: "url", type: "string?", desc: "Production URL" },
             { name: "...", type: "...", desc: "Any other application field" },

--- a/lib/portfolio-verification.ts
+++ b/lib/portfolio-verification.ts
@@ -26,6 +26,10 @@ export interface VerificationProblem {
   problem: string;
   rule: string;
   severity: "error" | "warning";
+  // What the checked source actually carried, when that isn't a member of the
+  // union — a database row's raw `applications.status`, say. Reported in place
+  // of `claimedStatus`, which the type system pins to the union.
+  observedStatus?: string;
 }
 
 type Verifier = (i: Project) => VerificationProblem[];

--- a/scripts/verify-portfolio.ts
+++ b/scripts/verify-portfolio.ts
@@ -8,16 +8,24 @@
 // NOT fail the build — they're surfaced for awareness so a stale
 // portfolio-meta doesn't gate CI.
 //
+// The verifier reads the typed module, which is the authoring source. When
+// DATABASE_URL is set it additionally audits `applications.status` in that
+// database — the column /portfolio actually renders from, and the one place
+// a value outside the union can appear without the typed module changing.
+//
 // Usage:
 //   npm run verify:portfolio
 //
 // CI:
-//   wired into .github/workflows/ci.yml as a separate job.
+//   wired into .github/workflows/ci.yml as a separate job. CI has no
+//   DATABASE_URL, so the database audit is skipped there; it's for the
+//   dev/prod databases, run locally or on the host.
 
 import {
   projects,
   OPERATIONAL_LABEL,
   PUBLIC_STAGE_LABEL,
+  isProjectStatus,
 } from "../lib/portfolio.js";
 import { verifyAll, type VerificationProblem } from "../lib/portfolio-verification.js";
 import { priorities } from "../lib/strategic-plan/catalog.js";
@@ -26,7 +34,7 @@ import { vocabularyGroups } from "../lib/governance/vocabularies.js";
 
 function format(p: VerificationProblem): string {
   const tag = p.severity === "error" ? "ERROR " : "WARN  ";
-  return `  [${tag}] ${p.slug.padEnd(28)} (${p.claimedStatus})\n           ${p.problem}\n           rule: ${p.rule}`;
+  return `  [${tag}] ${p.slug.padEnd(28)} (${p.observedStatus ?? p.claimedStatus})\n           ${p.problem}\n           rule: ${p.rule}`;
 }
 
 function verifyStrategicPlanAlignment(): VerificationProblem[] {
@@ -158,23 +166,88 @@ function verifyGovernanceVocabularyParity(): VerificationProblem[] {
   return problems;
 }
 
-function main(): void {
+// Everything above reads lib/portfolio.ts. But /portfolio renders from the
+// `applications` table, and `applications.status` is plain TEXT with no CHECK
+// constraint — ADR 0001 chose that deliberately so a new state needs a re-seed
+// rather than a migration. The cost of that choice is that a value outside the
+// union can land in the column (a legacy row, a hand-run UPDATE) and never be
+// caught: publicStageFromStatus() files anything unrecognised under
+// "exploring", so the site keeps rendering and simply misplaces the project.
+//
+// This audit is the check for that. It needs a live database, so it only runs
+// when DATABASE_URL is set — CI has none and skips it; run it against dev or
+// prod (or the host cron) to police the rows themselves.
+async function verifyDatabaseStatuses(): Promise<VerificationProblem[]> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.log(
+      "Skipping the applications.status audit — DATABASE_URL is not set.\n"
+    );
+    return [];
+  }
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: databaseUrl });
+  const problems: VerificationProblem[] = [];
+
+  try {
+    const { rows } = await pool.query<{
+      slug: string | null;
+      name: string;
+      status: string;
+    }>("SELECT slug, name, status FROM applications ORDER BY name");
+
+    console.log(
+      `Auditing applications.status across ${rows.length} row(s) in ${databaseUrl.replace(/\/\/[^@]+@/, "//***@")} ...\n`
+    );
+
+    for (const row of rows) {
+      if (isProjectStatus(row.status)) continue;
+      problems.push({
+        slug: row.slug ?? row.name,
+        claimedStatus: "tracked",
+        observedStatus: row.status,
+        problem: `applications.status is "${row.status}", which is not a member of the ProjectStatus union. /portfolio renders this project as "Exploring". Fix it in lib/portfolio.ts and re-seed, or correct the row at /admin/registry.`,
+        rule: "db-status-in-union",
+        severity: "error",
+      });
+    }
+  } catch (err) {
+    // A database that's simply unreachable isn't portfolio drift — warn so a
+    // down dev box doesn't read as a data problem.
+    problems.push({
+      slug: "applications",
+      claimedStatus: "tracked",
+      problem: `could not audit applications.status — ${err instanceof Error ? err.message : String(err)}`,
+      rule: "db-status-in-union",
+      severity: "warning",
+    });
+  } finally {
+    await pool.end();
+  }
+
+  return problems;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Verifying ${projects.length} projects against ADR 0001 rules, strategic-plan alignment, the OIT FY2027 crosswalk, and iids-portfolio vocabulary parity ...\n`
+  );
+
   const lifecycleProblems = verifyAll(projects);
   const stratPlanProblems = verifyStrategicPlanAlignment();
   const oitCrosswalkProblems = verifyOitCrosswalk();
   const vocabParityProblems = verifyGovernanceVocabularyParity();
+  const dbStatusProblems = await verifyDatabaseStatuses();
   const all = [
     ...lifecycleProblems,
     ...stratPlanProblems,
     ...oitCrosswalkProblems,
     ...vocabParityProblems,
+    ...dbStatusProblems,
   ];
   const errors = all.filter((p) => p.severity === "error");
   const warnings = all.filter((p) => p.severity === "warning");
-
-  console.log(
-    `Verifying ${projects.length} projects against ADR 0001 rules, strategic-plan alignment, the OIT FY2027 crosswalk, and iids-portfolio vocabulary parity ...\n`
-  );
 
   if (warnings.length > 0) {
     console.log(`Warnings (${warnings.length}):`);
@@ -194,4 +267,7 @@ function main(): void {
   );
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Rescoped. This PR originally fixed the stale `STATUS_OPTIONS` list — [#323](https://github.com/ui-insight/AISPEG/pull/323) landed that fix first, so everything duplicated has been dropped. What's left is the one part #323 doesn't cover.

## The remaining gap

#323 closed the **write path**: the admin form is a `select` over `PROJECT_STATUSES`, and both registry endpoints `400` on anything outside the union. It did not close the **read path** — the rows already in the table.

`npm run verify:portfolio` reads `lib/portfolio.ts`, the typed seed source. `applications.status` is what `/portfolio` actually renders from, it's plain `TEXT` with no CHECK (deliberately — ADR 0001 makes a new state a re-seed rather than a migration), and `publicStageFromStatus()` buckets anything unrecognised as `exploring`. So a status that predates the constraint, or arrives via a hand-run `UPDATE`, renders as **Exploring** and no check sees it. #323 verified remote dev and prod by hand and found them clean; this is the check that means nobody has to do that again.

## What changed

- `verify:portfolio` reads `applications.status` and errors on any value outside the union. It needs a live database, so it runs only when `DATABASE_URL` is set — CI has none and prints that it skipped, rather than implying it passed. Run it against dev or prod.
- `VerificationProblem` gains an optional `observedStatus`, so the report names the offending value. `claimedStatus` is pinned to `ProjectStatus` — which is precisely what a bad row doesn't have.
- Two `/docs/api-reference` param descriptions that #323's `400` outdated (the PATCH one still said out-of-union values "write successfully"; the POST one didn't mention the constraint at all).
- The admin guide's status InfoBox now points at the audit as the way to find pre-taxonomy rows in bulk, instead of only describing the per-record select behaviour.

## Verification

Against a local database: clean at 29 rows. A seeded `Planned` row is reported as `[ERROR] stratplan (Planned)` naming the value and the fix, and clears when the row goes. `npm run build`, `npm run lint`, and `npm run verify:portfolio` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)