### PR TITLE
Add evidence-backed standards foundation

### DIFF
--- a/app/standards/foundation/page.tsx
+++ b/app/standards/foundation/page.tsx
@@ -1,0 +1,379 @@
+import type { Metadata } from "next";
+import {
+  ASSURANCE_DIMENSIONS,
+  ASSURANCE_LEVELS,
+  CONFIDENCE_LABELS,
+  EVIDENCE_ARTIFACTS,
+  EVIDENCE_HIERARCHY,
+  FOUNDATION_DEFINITIONS,
+  FOUNDATION_TEMPLATE_LINKS,
+  PROVISIONAL_DEFAULT_PROCESS,
+  THREAT_MODEL_SECTIONS,
+  foundationSummary,
+} from "@/lib/standards-foundation";
+import {
+  SOURCE_AUTHORITY_LABELS,
+  standardsSourceById,
+} from "@/lib/standards-drafts";
+
+export const metadata: Metadata = {
+  title: "Standards Foundation",
+  description:
+    "Definitions, assurance profiles, evidence instruments, and provisional-default rules supporting the proposed University technology standards.",
+};
+
+const sectionLinks = [
+  { href: "#evidence", label: "Evidence" },
+  { href: "#assurance", label: "Assurance" },
+  { href: "#definitions", label: "Definitions" },
+  { href: "#threat-model", label: "Threat model" },
+  { href: "#artifacts", label: "Artifacts" },
+  { href: "#defaults", label: "Defaults" },
+] as const;
+
+function SourceLinks({ sourceIds }: { sourceIds: readonly string[] }) {
+  return (
+    <span className="inline-flex flex-wrap gap-x-3 gap-y-1">
+      {sourceIds.map((sourceId) => {
+        const source = standardsSourceById.get(sourceId);
+        if (!source) throw new Error(`Unknown foundation source: ${sourceId}`);
+        return (
+          <a
+            key={source.id}
+            href={source.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-medium text-brand-black"
+          >
+            {source.shortLabel}
+          </a>
+        );
+      })}
+    </span>
+  );
+}
+
+export default function StandardsFoundationPage() {
+  const summary = foundationSummary();
+  const usedSourceIds = new Set([
+    ...EVIDENCE_HIERARCHY.flatMap((tier) => tier.sourceIds ?? []),
+    ...FOUNDATION_DEFINITIONS.flatMap((definition) => definition.sourceIds),
+  ]);
+  const sources = [...usedSourceIds]
+    .map((sourceId) => standardsSourceById.get(sourceId))
+    .filter((source) => source !== undefined);
+
+  return (
+    <div className="space-y-16 pb-12">
+      <header>
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Working reference — not yet University policy
+        </p>
+        <h1 className="mt-3 max-w-4xl text-3xl font-black tracking-tight text-brand-black sm:text-4xl">
+          The definitions and instruments behind the standards
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+          This foundation supplies the terms, risk profiles, templates, and
+          evidence rules needed to assess the twenty proposed standards without
+          relying on undocumented institutional knowledge. Where stronger
+          authority does not determine an answer, it publishes a measurable
+          provisional default and the reasoning behind it.
+        </p>
+      </header>
+
+      <section className="bg-brand-black px-5 py-6 text-white sm:px-8 sm:py-8">
+        <p className="text-xs font-bold uppercase tracking-wider text-brand-gold">
+          Usable now; designed to be superseded cleanly
+        </p>
+        <div className="mt-3 grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(18rem,0.6fr)] lg:gap-12">
+          <div>
+            <h2 className="text-xl font-black tracking-tight text-white sm:text-2xl">
+              A complete starting position, not a claim of final authority
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-200">
+              {summary.definitions} controlled definitions, {summary.assuranceDimensions}{" "}
+              assurance dimensions, {summary.threatModelSections} threat-model
+              sections, and {summary.evidenceArtifacts} evidence artifacts turn
+              broad best practice into reviewable work. Each may be refined when
+              institutional evidence or an authorized decision becomes available.
+            </p>
+          </div>
+          <div className="border-t border-gray-700 pt-4 lg:border-t-0 lg:border-l lg:pl-8 lg:pt-0">
+            <p className="text-sm font-semibold text-white">Escalation rule</p>
+            <p className="mt-2 text-sm leading-relaxed text-gray-300">
+              Stronger authority always wins: law and policy outrank consensus,
+              sector practice, implementation guidance, and first-principles
+              defaults.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <nav
+        aria-label="Foundation sections"
+        className="overflow-x-auto border-y border-hairline py-3"
+      >
+        <ul className="flex min-w-max gap-6">
+          {sectionLinks.map((link) => (
+            <li key={link.href}>
+              <a href={link.href} className="text-sm font-semibold text-brand-black">
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <section id="evidence" className="scroll-mt-28" aria-labelledby="evidence-heading">
+        <div className="grid gap-8 lg:grid-cols-[minmax(15rem,0.55fr)_minmax(0,1.45fr)] lg:gap-12">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+              Evidence hierarchy
+            </p>
+            <h2 id="evidence-heading" className="mt-2 text-2xl font-black tracking-tight text-brand-black">
+              Every claim shows what kind of authority supports it
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-ink-muted">
+              A useful standard can combine several kinds of evidence, but it
+              must not make implementation guidance look like law or a local
+              judgment look like external consensus.
+            </p>
+          </div>
+          <ol className="divide-y divide-hairline border-y border-hairline">
+            {EVIDENCE_HIERARCHY.map((tier) => (
+              <li key={tier.rank} className="grid gap-3 py-5 sm:grid-cols-[3rem_minmax(0,1fr)]">
+                <span className="font-mono text-sm font-bold text-brand-huckleberry">
+                  {tier.rank.toString().padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="text-base font-black text-brand-black">{tier.label}</h3>
+                  <p className="mt-1 text-sm leading-relaxed text-ink-muted">{tier.use}</p>
+                  <p className="mt-2 text-sm font-semibold leading-relaxed text-brand-black">
+                    {tier.treatment}
+                  </p>
+                  {tier.sourceIds && (
+                    <p className="mt-2">
+                      <SourceLinks sourceIds={tier.sourceIds} />
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section id="assurance" className="scroll-mt-28" aria-labelledby="assurance-heading">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          Application Assurance Profile
+        </p>
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h2 id="assurance-heading" className="text-2xl font-black tracking-tight text-brand-black">
+              The highest trigger determines the minimum level
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-muted">
+              Levels are not averaged. A single Level 3 trigger makes Level 3
+              the minimum until an assessor documents why the trigger does not
+              apply or an authorized exception changes the decision.
+            </p>
+          </div>
+          <a
+            href="/templates/application-assurance-profile.md"
+            download
+            className="rounded bg-brand-gold px-4 py-2 text-sm font-bold text-brand-black no-underline hover:bg-brand-gold-light"
+          >
+            Download profile template
+          </a>
+        </div>
+
+        <div className="mt-8 grid gap-px border border-hairline bg-hairline lg:grid-cols-3">
+          {ASSURANCE_LEVELS.map((level) => (
+            <article key={level.level} className="bg-white p-5 sm:p-6">
+              <p className="font-mono text-xs font-bold text-brand-huckleberry">
+                LEVEL {level.level}
+              </p>
+              <h3 className="mt-2 text-lg font-black text-brand-black">{level.label}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-ink-muted">{level.defaultUse}</p>
+              <p className="mt-5 text-xs font-bold uppercase tracking-wider text-brand-silver">
+                Minimum evidence
+              </p>
+              <ul className="mt-2 list-disc space-y-1.5 pl-5 text-sm leading-relaxed text-ink-muted marker:text-brand-gold-dark">
+                {level.minimumEvidence.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <p className="mt-4 text-xs leading-relaxed text-brand-black">
+                <strong>Verification:</strong> {level.verification}
+              </p>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-8 overflow-x-auto">
+          <table className="w-full min-w-[52rem] border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-y border-hairline bg-surface-alt">
+                <th className="px-3 py-3 font-bold text-brand-black">Dimension</th>
+                <th className="px-3 py-3 font-bold text-brand-black">Question</th>
+                <th className="px-3 py-3 font-bold text-brand-black">Level 2 trigger</th>
+                <th className="px-3 py-3 font-bold text-brand-black">Level 3 trigger</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-hairline">
+              {ASSURANCE_DIMENSIONS.map((dimension) => (
+                <tr key={dimension.id} className="align-top">
+                  <th className="px-3 py-4 font-semibold text-brand-black">{dimension.label}</th>
+                  <td className="px-3 py-4 leading-relaxed text-ink-muted">{dimension.question}</td>
+                  <td className="px-3 py-4 leading-relaxed text-ink-muted">{dimension.level2Trigger}</td>
+                  <td className="px-3 py-4 leading-relaxed text-ink-muted">{dimension.level3Trigger}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="definitions" className="scroll-mt-28" aria-labelledby="definitions-heading">
+        <div className="grid gap-8 lg:grid-cols-[minmax(15rem,0.55fr)_minmax(0,1.45fr)] lg:gap-12">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+              Controlled glossary
+            </p>
+            <h2 id="definitions-heading" className="mt-2 text-2xl font-black tracking-tight text-brand-black">
+              Terms that change an assessment result
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-ink-muted">
+              These are operational definitions. Each includes a decision rule,
+              examples, evidence basis, and confidence so assessors do not have
+              to invent meaning independently.
+            </p>
+          </div>
+          <div className="divide-y divide-hairline border-y border-hairline">
+            {FOUNDATION_DEFINITIONS.map((definition) => (
+              <details key={definition.id} id={definition.id} className="group scroll-mt-28 py-1">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 [&::-webkit-details-marker]:hidden">
+                  <span>
+                    <span className="block text-base font-black text-brand-black">{definition.term}</span>
+                    <span className="mt-1 block text-xs text-ink-muted">
+                      {CONFIDENCE_LABELS[definition.confidence]} · used by {definition.relatedStandards.join(", ").toUpperCase()}
+                    </span>
+                  </span>
+                  <span aria-hidden="true" className="text-xl font-light text-brand-silver transition-transform group-open:rotate-45 motion-reduce:transition-none">+</span>
+                </summary>
+                <div className="pb-5 pr-8">
+                  <p className="max-w-3xl text-sm leading-relaxed text-brand-black">{definition.definition}</p>
+                  <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                    <strong className="text-brand-black">Decision rule:</strong> {definition.decisionRule}
+                  </p>
+                  <p className="mt-3 text-xs font-bold uppercase tracking-wider text-brand-silver">Examples</p>
+                  <ul className="mt-2 flex flex-wrap gap-2">
+                    {definition.examples.map((example) => (
+                      <li key={example} className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-700">{example}</li>
+                    ))}
+                  </ul>
+                  <p className="mt-4"><SourceLinks sourceIds={definition.sourceIds} /></p>
+                </div>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="threat-model" className="scroll-mt-28" aria-labelledby="threat-model-heading">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">Reusable instrument</p>
+            <h2 id="threat-model-heading" className="mt-2 text-2xl font-black tracking-tight text-brand-black">Threat model: the minimum complete record</h2>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-muted">
+              Level 1 uses this as a short attack-surface review. Levels 2 and 3
+              complete every section, with depth proportional to plausible harm.
+            </p>
+          </div>
+          <a href="/templates/threat-model.md" download className="rounded bg-brand-gold px-4 py-2 text-sm font-bold text-brand-black no-underline hover:bg-brand-gold-light">Download threat-model template</a>
+        </div>
+        <ol className="mt-8 grid gap-px border border-hairline bg-hairline md:grid-cols-2">
+          {THREAT_MODEL_SECTIONS.map((section, index) => (
+            <li key={section.id} className="bg-white p-5">
+              <p className="font-mono text-xs font-bold text-brand-huckleberry">{String(index + 1).padStart(2, "0")}</p>
+              <h3 className="mt-2 text-base font-black text-brand-black">{section.label}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-ink-muted">{section.prompt}</p>
+              <p className="mt-3 text-xs leading-relaxed text-brand-black"><strong>Acceptable evidence:</strong> {section.acceptableEvidence}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section id="artifacts" className="scroll-mt-28" aria-labelledby="artifacts-heading">
+        <div className="grid gap-8 lg:grid-cols-[minmax(15rem,0.55fr)_minmax(0,1.45fr)] lg:gap-12">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">Evidence catalog</p>
+            <h2 id="artifacts-heading" className="mt-2 text-2xl font-black tracking-tight text-brand-black">What acceptable evidence must contain</h2>
+            <p className="mt-3 text-sm leading-relaxed text-ink-muted">A filename is not evidence by itself. Each artifact has minimum contents and a freshness rule tied to the assessed version and environment.</p>
+          </div>
+          <div className="divide-y divide-hairline border-y border-hairline">
+            {EVIDENCE_ARTIFACTS.map((artifact) => (
+              <details key={artifact.id} id={artifact.id} className="group scroll-mt-28 py-1">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 [&::-webkit-details-marker]:hidden">
+                  <span>
+                    <span className="block text-base font-black text-brand-black">{artifact.name}</span>
+                    <span className="mt-1 block text-xs text-ink-muted">Freshness: {artifact.freshness}</span>
+                  </span>
+                  <span aria-hidden="true" className="text-xl font-light text-brand-silver transition-transform group-open:rotate-45 motion-reduce:transition-none">+</span>
+                </summary>
+                <div className="pb-5 pr-8">
+                  <p className="max-w-3xl text-sm leading-relaxed text-ink-muted">{artifact.purpose}</p>
+                  <p className="mt-3 text-xs font-bold uppercase tracking-wider text-brand-silver">Minimum contents</p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-ink-muted marker:text-brand-gold-dark">
+                    {artifact.minimumContents.map((item) => <li key={item}>{item}</li>)}
+                  </ul>
+                </div>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="defaults" className="scroll-mt-28" aria-labelledby="defaults-heading">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">Provisional-default method</p>
+        <h2 id="defaults-heading" className="mt-2 text-2xl font-black tracking-tight text-brand-black">How to decide when no authoritative definition exists</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-ink-muted">The absence of institutional documentation becomes an explicit standards-design task—not an indefinite dependency.</p>
+        <ol className="mt-8 grid gap-px border border-hairline bg-hairline sm:grid-cols-2 lg:grid-cols-3">
+          {PROVISIONAL_DEFAULT_PROCESS.map((item) => (
+            <li key={item.step} className="bg-white p-5">
+              <p className="font-mono text-xs font-bold text-brand-huckleberry">STEP {item.step}</p>
+              <h3 className="mt-2 text-base font-black text-brand-black">{item.label}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-ink-muted">{item.requirement}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section aria-labelledby="templates-heading" className="border-y border-hairline py-8">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">Working files</p>
+        <h2 id="templates-heading" className="mt-2 text-xl font-black tracking-tight text-brand-black">Start with an instrument, not a blank page</h2>
+        <div className="mt-5 flex flex-wrap gap-x-6 gap-y-3">
+          {FOUNDATION_TEMPLATE_LINKS.map((template) => (
+            <a key={template.href} href={template.href} download className="text-sm font-semibold text-brand-black">{template.label} ↓</a>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="foundation-sources-heading">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">Provenance</p>
+        <h2 id="foundation-sources-heading" className="mt-2 text-xl font-black tracking-tight text-brand-black">Sources used by this foundation</h2>
+        <ul className="mt-5 divide-y divide-hairline border-y border-hairline">
+          {sources.map((source) => (
+            <li key={source.id} className="grid gap-2 py-4 sm:grid-cols-[minmax(12rem,0.55fr)_minmax(0,1.45fr)] sm:gap-6">
+              <div>
+                <a href={source.href} target="_blank" rel="noopener noreferrer" className="text-sm font-semibold text-brand-black">{source.title}</a>
+                <p className="mt-1 text-xs text-ink-subtle">{source.publisher} · {SOURCE_AUTHORITY_LABELS[source.authority]}</p>
+              </div>
+              <p className="text-sm leading-relaxed text-ink-muted">{source.note}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/standards/layout.tsx
+++ b/app/standards/layout.tsx
@@ -5,6 +5,7 @@ import SectionSubNav, { type SubNavItem } from "@/components/SectionSubNav";
 // /coordination.
 const subNavItems: SubNavItem[] = [
   { href: "/standards", label: "Standards" },
+  { href: "/standards/foundation", label: "Foundation" },
   { href: "/standards/data-model", label: "Data Model" },
   { href: "/standards/strategic-plan", label: "Strategic Plan" },
   { href: "/standards/strategic-plan/map", label: "Map" },

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -1,4 +1,10 @@
 import Link from "next/link";
+import StandardDraftPanel from "@/components/StandardDraftPanel";
+import {
+  MATURITY_LEVELS,
+  draftSummary,
+  standardDraftById,
+} from "@/lib/standards-drafts";
 import {
   standardsWatch,
   summary,
@@ -31,14 +37,18 @@ function StatusChip({ status }: { status: StandardsWatchStatus }) {
 }
 
 function StandardRow({ item }: { item: StandardsWatchItem }) {
+  const draft = standardDraftById.get(item.id);
+
   return (
-    <article className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex-1">
+    <article id={item.id} className="scroll-mt-28 border-t border-hairline py-6">
+      <div className="grid gap-4 sm:grid-cols-[3.5rem_minmax(0,1fr)] sm:gap-6">
+        <div>
+          <span className="inline-flex size-10 items-center justify-center rounded-full bg-brand-black font-mono text-xs font-bold text-white">
+            {item.agenda}.{item.id.split("-")[1]}
+          </span>
+        </div>
+        <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded bg-gray-100 px-2 py-0.5 font-mono text-xs font-medium text-gray-600">
-              {item.agenda}.{item.id.split("-")[1]}
-            </span>
             <h3 className="text-base font-semibold text-ui-charcoal">
               {item.title}
             </h3>
@@ -55,55 +65,63 @@ function StandardRow({ item }: { item: StandardsWatchItem }) {
                 Response artifact
               </a>
             )}
+            {draft && (
+              <span className="rounded-full bg-violet-100 px-2.5 py-0.5 text-xs font-medium text-brand-huckleberry">
+                Measurable draft attached
+              </span>
+            )}
           </div>
-        </div>
-      </div>
 
-      <details className="mt-4 group">
-        <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-brand-black">
-          Show requested detail ({item.details.length} sub-items)
-        </summary>
-        <ul className="mt-3 space-y-2 border-l-2 border-gray-100 pl-4">
-          {item.details.map((d, i) => (
-            <li key={i} className="text-sm leading-relaxed text-gray-700">
-              {d}
-            </li>
-          ))}
-        </ul>
-        {item.links && item.links.length > 0 && (
-          <div className="mt-4 border-l-2 border-gray-100 pl-4">
-            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-              References
-            </p>
-            <ul className="mt-2 space-y-1.5">
-              {item.links.map((l) => (
-                <li key={l.href} className="text-sm leading-relaxed">
-                  <a
-                    href={l.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2"
-                  >
-                    {l.label}
-                  </a>
+          <details className="group mt-4">
+            <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-brand-black">
+              Requested scope ({item.details.length} sub-items)
+            </summary>
+            <ul className="mt-3 list-disc space-y-2 pl-5 marker:text-brand-gold-dark">
+              {item.details.map((d, i) => (
+                <li key={i} className="text-sm leading-relaxed text-gray-700">
+                  {d}
                 </li>
               ))}
             </ul>
-          </div>
-        )}
-      </details>
+            {item.links && item.links.length > 0 && (
+              <div className="mt-4">
+                <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+                  Existing references
+                </p>
+                <ul className="mt-2 space-y-1.5">
+                  {item.links.map((l) => (
+                    <li key={l.href} className="text-sm leading-relaxed">
+                      <a
+                        href={l.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2"
+                      >
+                        {l.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </details>
 
-      {item.responseNote && (
-        <p className="mt-3 rounded bg-green-50 px-3 py-2 text-xs text-green-900">
-          <strong>Response note:</strong> {item.responseNote}
-        </p>
-      )}
+          {item.responseNote && (
+            <p className="mt-4 bg-green-50 px-3 py-2 text-xs leading-relaxed text-green-950">
+              <strong>OIT response to date:</strong> {item.responseNote}
+            </p>
+          )}
+
+          {draft && <StandardDraftPanel draft={draft} />}
+        </div>
+      </div>
     </article>
   );
 }
 
 export default function StandardsWatchPage() {
   const stats = summary();
+  const drafts = draftSummary();
   const agendaI = standardsWatch.filter((s) => s.agenda === "I");
   const agendaII = standardsWatch.filter((s) => s.agenda === "II");
 
@@ -128,6 +146,83 @@ export default function StandardsWatchPage() {
           approved.
         </p>
       </header>
+
+      <section
+        aria-labelledby="proposed-drafts-heading"
+        className="bg-brand-black px-5 py-6 text-white sm:px-7 sm:py-8"
+      >
+        <p className="text-xs font-bold uppercase tracking-wider text-brand-gold">
+          Working material — not yet University policy
+        </p>
+        <div className="mt-3 grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(17rem,0.65fr)] lg:gap-12">
+          <div>
+            <h2
+              id="proposed-drafts-heading"
+              className="text-xl font-black tracking-tight text-white sm:text-2xl"
+            >
+              Evidence-backed drafts now cover all twenty categories
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-gray-200">
+              {drafts.requirements} atomic requirements draw on {drafts.sources}{" "}
+              published sources. Each requirement states what evidence an
+              assessor examines and how it is tested. {drafts.criticalRequirements}{" "}
+              requirements are explicit gates that cannot disappear inside an
+              average score.
+            </p>
+          </div>
+          <div className="border-t border-gray-700 pt-4 lg:border-t-0 lg:border-l lg:pl-8 lg:pt-0">
+            <p className="text-sm font-semibold text-white">Publication rule</p>
+            <p className="mt-2 text-sm leading-relaxed text-gray-300">
+              External sources justify and shape a proposal. Only a named
+              University authority can resolve local thresholds and move an
+              entry from draft to approved.
+            </p>
+            <Link
+              href="/standards/foundation"
+              className="mt-3 inline-block text-sm font-semibold text-white"
+            >
+              Read the definitions and assessment instruments →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="assessment-heading">
+        <div className="grid gap-6 lg:grid-cols-[minmax(15rem,0.55fr)_minmax(0,1.45fr)] lg:gap-12">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+              Assessment method
+            </p>
+            <h2
+              id="assessment-heading"
+              className="mt-2 text-xl font-black tracking-tight text-brand-black"
+            >
+              Conformance and maturity answer different questions
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-ink-muted">
+              Every requirement is marked Met, Partially met, Not met, Not
+              applicable, or Not assessed. Maturity describes how reliably the
+              institution sustains that practice; it does not excuse a failed
+              legal, accessibility, privacy, or security gate.
+            </p>
+          </div>
+          <ol className="grid gap-px overflow-hidden border border-hairline bg-hairline sm:grid-cols-5">
+            {MATURITY_LEVELS.map((level) => (
+              <li key={level.score} className="bg-white p-4">
+                <span className="font-mono text-xs font-bold text-brand-huckleberry">
+                  {level.score}
+                </span>
+                <p className="mt-2 text-sm font-black text-brand-black">
+                  {level.label}
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-ink-muted">
+                  {level.definition}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
 
       {/* Active sources — resources OIT is currently drafting against
           that answer (in part or whole) the asks below. As OIT
@@ -214,7 +309,7 @@ export default function StandardsWatchPage() {
             deployed, and maintained at the University of Idaho.
           </p>
         </div>
-        <div className="space-y-3">
+        <div>
           {agendaI.map((item) => (
             <StandardRow key={item.id} item={item} />
           ))}
@@ -232,7 +327,7 @@ export default function StandardsWatchPage() {
             behave, and treat the people who use them.
           </p>
         </div>
-        <div className="space-y-3">
+        <div>
           {agendaII.map((item) => (
             <StandardRow key={item.id} item={item} />
           ))}

--- a/components/StandardDraftPanel.tsx
+++ b/components/StandardDraftPanel.tsx
@@ -1,0 +1,243 @@
+import {
+  SOURCE_AUTHORITY_LABELS,
+  standardsSourceById,
+  type StandardDraft,
+  type SourceAuthority,
+} from "@/lib/standards-drafts";
+import { FOUNDATION_DEFINITIONS } from "@/lib/standards-foundation";
+
+const AUTHORITY_STYLES: Record<SourceAuthority, string> = {
+  "binding-policy": "bg-brand-gold text-brand-black",
+  "consensus-standard": "bg-violet-100 text-brand-huckleberry",
+  "government-guidance": "bg-teal-50 text-teal-900",
+  "higher-ed-practice": "bg-amber-100 text-amber-950",
+  "implementation-guidance": "bg-gray-100 text-gray-700",
+};
+
+function SourceList({ draft }: { draft: StandardDraft }) {
+  const sources = draft.sourceIds.map((sourceId) => {
+    const source = standardsSourceById.get(sourceId);
+    if (!source) throw new Error(`Unknown standards source: ${sourceId}`);
+    return source;
+  });
+
+  return (
+    <div>
+      <h5 className="text-sm font-black tracking-tight text-brand-black">
+        Source basis
+      </h5>
+      <ul className="mt-3 divide-y divide-hairline border-y border-hairline">
+        {sources.map((source) => (
+          <li key={source.id} className="py-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <a
+                href={source.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm font-semibold text-brand-black"
+              >
+                {source.shortLabel}
+              </a>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[0.68rem] font-semibold ${AUTHORITY_STYLES[source.authority]}`}
+              >
+                {SOURCE_AUTHORITY_LABELS[source.authority]}
+              </span>
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-ink-muted">
+              {source.title}
+              {source.version ? ` · ${source.version}` : ""} · checked{" "}
+              {source.checkedOn}
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-ink-muted">
+              {source.note}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function StandardDraftPanel({ draft }: { draft: StandardDraft }) {
+  const criticalCount = draft.requirements.filter(
+    (requirement) => requirement.critical,
+  ).length;
+  const foundationTerms = FOUNDATION_DEFINITIONS.filter((definition) =>
+    definition.relatedStandards.includes(draft.standardId),
+  );
+
+  return (
+    <details className="group mt-4 border-y border-hairline bg-surface-alt">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-gold [&::-webkit-details-marker]:hidden">
+        <span>
+          <span className="block text-xs font-bold uppercase tracking-wider text-brand-huckleberry">
+            Proposed measurable draft
+          </span>
+          <span className="mt-0.5 block text-sm text-ink-muted">
+            {draft.requirements.length} requirements · {criticalCount} release{" "}
+            {criticalCount === 1 ? "gate" : "gates"}
+          </span>
+        </span>
+        <span
+          aria-hidden="true"
+          className="text-xl font-light text-brand-silver transition-transform duration-200 group-open:rotate-45 motion-reduce:transition-none"
+        >
+          +
+        </span>
+      </summary>
+
+      <div className="border-t border-hairline px-4 py-6 sm:px-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(16rem,0.75fr)] lg:gap-10">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+              Applies to
+            </p>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-brand-black">
+              {draft.scope}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+              Why this belongs in the standard
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+              {draft.rationale}
+            </p>
+          </div>
+        </div>
+
+        {foundationTerms.length > 0 && (
+          <div className="mt-6 border-y border-hairline py-3">
+            <p className="text-xs font-bold uppercase tracking-wider text-brand-silver">
+              Defined foundation terms
+            </p>
+            <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+              {foundationTerms.map((definition) => (
+                <a
+                  key={definition.id}
+                  href={`/standards/foundation#${definition.id}`}
+                  className="text-sm font-semibold text-brand-black"
+                >
+                  {definition.term}
+                </a>
+              ))}
+            </p>
+          </div>
+        )}
+
+        <section className="mt-8" aria-label="Draft requirements">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <h4 className="text-base font-black tracking-tight text-brand-black">
+              Testable requirements
+            </h4>
+            <p className="text-xs text-ink-subtle">
+              Critical gates cannot be averaged away
+            </p>
+          </div>
+          <ol className="mt-3 divide-y divide-hairline border-y border-hairline">
+            {draft.requirements.map((requirement) => (
+              <li
+                key={requirement.id}
+                className="grid gap-4 py-5 md:grid-cols-[7.5rem_minmax(0,1fr)]"
+              >
+                <div>
+                  <span className="font-mono text-xs font-bold text-brand-huckleberry">
+                    {requirement.id}
+                  </span>
+                  {requirement.critical && (
+                    <span className="mt-2 block w-fit rounded-full bg-amber-100 px-2 py-0.5 text-[0.68rem] font-semibold text-amber-900">
+                      Critical gate
+                    </span>
+                  )}
+                </div>
+                <div>
+                  <p className="max-w-3xl text-sm font-semibold leading-relaxed text-brand-black">
+                    {requirement.statement}
+                  </p>
+                  <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-2">
+                    <div>
+                      <dt className="font-bold uppercase tracking-wider text-brand-silver">
+                        Evidence
+                      </dt>
+                      <dd className="mt-1 leading-relaxed text-ink-muted">
+                        {requirement.evidence.join(" · ")}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="font-bold uppercase tracking-wider text-brand-silver">
+                        Assessment
+                      </dt>
+                      <dd className="mt-1 leading-relaxed text-ink-muted">
+                        {requirement.assessment}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <div className="mt-8 grid gap-8 lg:grid-cols-2 lg:gap-10">
+          <SourceList draft={draft} />
+
+          <div className="space-y-7">
+            <div>
+              <h5 className="text-sm font-black tracking-tight text-brand-black">
+                Open calibration items
+              </h5>
+              <p className="mt-2 text-xs leading-relaxed text-ink-muted">
+                These do not suspend the proposed requirements. Use the stated
+                default and record operational evidence until stronger
+                institutional authority or pilot results justify revision.
+              </p>
+              <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-relaxed text-ink-muted marker:text-brand-gold-dark">
+                {draft.localDecisions.map((decision) => (
+                  <li key={decision}>{decision}</li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h5 className="text-sm font-black tracking-tight text-brand-black">
+                Assessment governance
+              </h5>
+              <dl className="mt-3 space-y-3 text-sm">
+                <div>
+                  <dt className="font-semibold text-brand-black">Cadence</dt>
+                  <dd className="mt-0.5 leading-relaxed text-ink-muted">
+                    {draft.assessment.cadence}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-brand-black">Assessor</dt>
+                  <dd className="mt-0.5 leading-relaxed text-ink-muted">
+                    {draft.assessment.assessor}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-brand-black">
+                    Conformance rule
+                  </dt>
+                  <dd className="mt-0.5 leading-relaxed text-ink-muted">
+                    {draft.assessment.conformanceRule}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <div>
+              <h5 className="text-sm font-black tracking-tight text-brand-black">
+                Exception process
+              </h5>
+              <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+                {draft.exceptionProcess}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/lib/standards-drafts.ts
+++ b/lib/standards-drafts.ts
@@ -1,0 +1,796 @@
+// Proposed, evidence-backed standards attached to the twenty-item standards
+// ledger. These are working drafts, not ratified University policy. The
+// standards-watch status remains the authoritative approval state.
+
+export type SourceAuthority =
+  | "binding-policy"
+  | "consensus-standard"
+  | "government-guidance"
+  | "higher-ed-practice"
+  | "implementation-guidance";
+
+export interface StandardsSource {
+  id: string;
+  shortLabel: string;
+  title: string;
+  publisher: string;
+  version?: string;
+  href: string;
+  authority: SourceAuthority;
+  note: string;
+  checkedOn: string;
+}
+
+export interface DraftRequirement {
+  id: string;
+  statement: string;
+  evidence: string[];
+  assessment: string;
+  critical?: boolean;
+}
+
+export interface DraftAssessment {
+  cadence: string;
+  assessor: string;
+  conformanceRule: string;
+}
+
+export interface StandardDraft {
+  standardId: string;
+  scope: string;
+  rationale: string;
+  sourceIds: string[];
+  requirements: DraftRequirement[];
+  localDecisions: string[];
+  assessment: DraftAssessment;
+  exceptionProcess: string;
+}
+
+export interface MaturityLevel {
+  score: 0 | 1 | 2 | 3 | 4;
+  label: string;
+  definition: string;
+}
+
+export const SOURCE_AUTHORITY_LABELS: Record<SourceAuthority, string> = {
+  "binding-policy": "Binding policy or law",
+  "consensus-standard": "Consensus standard",
+  "government-guidance": "Government guidance",
+  "higher-ed-practice": "Higher-ed practice",
+  "implementation-guidance": "Implementation guidance",
+};
+
+export const MATURITY_LEVELS: readonly MaturityLevel[] = [
+  {
+    score: 0,
+    label: "Absent",
+    definition: "No defined practice and no reliable evidence.",
+  },
+  {
+    score: 1,
+    label: "Ad hoc",
+    definition: "Some teams perform the practice, but it is inconsistent or person-dependent.",
+  },
+  {
+    score: 2,
+    label: "Defined",
+    definition: "The practice is documented, assigned, and repeatable.",
+  },
+  {
+    score: 3,
+    label: "Evidenced",
+    definition: "The practice is implemented and supported by current, reviewable evidence.",
+  },
+  {
+    score: 4,
+    label: "Managed",
+    definition: "Results are monitored, exceptions are controlled, and findings drive improvement.",
+  },
+] as const;
+
+const CHECKED_ON = "2026-07-31";
+
+export const STANDARDS_SOURCES: readonly StandardsSource[] = [
+  {
+    id: "ui-apm-30-11",
+    shortLabel: "APM 30.11",
+    title: "University Data Classification and Standards",
+    publisher: "University of Idaho",
+    href: "https://www.uidaho.edu/policies/apm/30/11",
+    authority: "binding-policy",
+    note: "Defines Low, Moderate, and High risk classifications, accountable data roles, minimum protection, and annual exception review.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "ui-it-standards",
+    shortLabel: "U of I IT standards",
+    title: "Information Technology Standards",
+    publisher: "University of Idaho OIT",
+    href: "https://www.uidaho.edu/leadership/information-technology/standards",
+    authority: "binding-policy",
+    note: "Published institutional specifications and protocols supporting University technology policy.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "ui-brand",
+    shortLabel: "U of I brand",
+    title: "University of Idaho Brand",
+    publisher: "University of Idaho",
+    href: "https://www.uidaho.edu/brand",
+    authority: "binding-policy",
+    note: "Institutional source for approved identity, color, logo, typography, and voice decisions.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "ui-accessibility",
+    shortLabel: "U of I accessibility",
+    title: "Website Accessibility",
+    publisher: "University of Idaho",
+    href: "https://www.uidaho.edu/brand/ucm/web-and-digital/web-accessibility",
+    authority: "binding-policy",
+    note: "States the University's public-institution commitment to ADA Title II digital accessibility.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "ada-title-ii-web",
+    shortLabel: "ADA Title II web rule",
+    title: "Accessibility of Web Content and Mobile Apps Provided by State and Local Government Entities",
+    publisher: "U.S. Department of Justice",
+    href: "https://www.ada.gov/resources/2024-03-08-web-rule/",
+    authority: "binding-policy",
+    note: "Establishes WCAG 2.1 Level A and AA as the technical conformance standard for covered public entities.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-800-53",
+    shortLabel: "NIST SP 800-53",
+    title: "Security and Privacy Controls for Information Systems and Organizations",
+    publisher: "National Institute of Standards and Technology",
+    version: "Revision 5",
+    href: "https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final",
+    authority: "government-guidance",
+    note: "Control catalog covering architecture, access, audit, configuration, contingency, incident response, acquisition, and system integrity.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-800-53a",
+    shortLabel: "NIST SP 800-53A",
+    title: "Assessing Security and Privacy Controls in Information Systems and Organizations",
+    publisher: "National Institute of Standards and Technology",
+    version: "Revision 5",
+    href: "https://csrc.nist.gov/pubs/sp/800/53/a/r5/final",
+    authority: "government-guidance",
+    note: "Defines examine, interview, and test methods for evidence-based control assessment.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-ssdf",
+    shortLabel: "NIST SSDF",
+    title: "Secure Software Development Framework",
+    publisher: "National Institute of Standards and Technology",
+    version: "SP 800-218 v1.1",
+    href: "https://csrc.nist.gov/pubs/sp/800/218/final",
+    authority: "government-guidance",
+    note: "Common secure-development practices for preparing, protecting, producing, and responding to software vulnerabilities.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-csf",
+    shortLabel: "NIST CSF 2.0",
+    title: "Cybersecurity Framework",
+    publisher: "National Institute of Standards and Technology",
+    version: "2.0",
+    href: "https://www.nist.gov/cyberframework",
+    authority: "government-guidance",
+    note: "Risk-based governance outcomes organized around Govern, Identify, Protect, Detect, Respond, and Recover.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-privacy",
+    shortLabel: "NIST Privacy Framework",
+    title: "Privacy Framework: A Tool for Improving Privacy through Enterprise Risk Management",
+    publisher: "National Institute of Standards and Technology",
+    href: "https://www.nist.gov/privacy-framework/privacy-framework",
+    authority: "government-guidance",
+    note: "Supports data inventory, privacy-risk assessment, governance, controls, current/target profiles, and reassessment.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "nist-800-92",
+    shortLabel: "NIST SP 800-92",
+    title: "Guide to Computer Security Log Management",
+    publisher: "National Institute of Standards and Technology",
+    href: "https://csrc.nist.gov/pubs/sp/800/92/final",
+    authority: "government-guidance",
+    note: "Establishes log-management infrastructure, operational processes, and lifecycle considerations.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "owasp-asvs",
+    shortLabel: "OWASP ASVS",
+    title: "Application Security Verification Standard",
+    publisher: "OWASP Foundation",
+    version: "5.0.0",
+    href: "https://owasp.org/www-project-application-security-verification-standard/",
+    authority: "consensus-standard",
+    note: "Testable application-security requirements with risk-based verification levels.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "owasp-api",
+    shortLabel: "OWASP API Security",
+    title: "OWASP API Security Top 10",
+    publisher: "OWASP Foundation",
+    href: "https://owasp.org/API-Security/",
+    authority: "implementation-guidance",
+    note: "API-specific risks and mitigations for authorization, authentication, consumption, inventory, and unsafe integrations.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "rfc-9110",
+    shortLabel: "RFC 9110",
+    title: "HTTP Semantics",
+    publisher: "Internet Engineering Task Force",
+    version: "RFC 9110",
+    href: "https://www.rfc-editor.org/rfc/rfc9110",
+    authority: "consensus-standard",
+    note: "Normative HTTP method, status, representation, caching, and authentication semantics.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "rfc-9457",
+    shortLabel: "RFC 9457",
+    title: "Problem Details for HTTP APIs",
+    publisher: "Internet Engineering Task Force",
+    version: "RFC 9457",
+    href: "https://www.rfc-editor.org/rfc/rfc9457",
+    authority: "consensus-standard",
+    note: "Standard machine-readable format for actionable HTTP API error responses.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "openapi-311",
+    shortLabel: "OpenAPI 3.1.1",
+    title: "OpenAPI Specification",
+    publisher: "OpenAPI Initiative",
+    version: "3.1.1",
+    href: "https://spec.openapis.org/oas/v3.1.1.html",
+    authority: "consensus-standard",
+    note: "Machine-readable contract format for HTTP APIs, schemas, security, examples, and documentation.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "cisa-secure-by-design",
+    shortLabel: "CISA Secure by Design",
+    title: "Secure by Design",
+    publisher: "Cybersecurity and Infrastructure Security Agency",
+    href: "https://www.cisa.gov/securebydesign",
+    authority: "government-guidance",
+    note: "Makes customer security outcomes, secure defaults, and transparency core product requirements.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "slsa",
+    shortLabel: "SLSA",
+    title: "Supply-chain Levels for Software Artifacts",
+    publisher: "OpenSSF",
+    href: "https://slsa.dev/spec/",
+    authority: "consensus-standard",
+    note: "Incremental requirements for build provenance and protection against software supply-chain tampering.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "opentelemetry",
+    shortLabel: "OpenTelemetry",
+    title: "OpenTelemetry Semantic Conventions",
+    publisher: "Cloud Native Computing Foundation",
+    href: "https://opentelemetry.io/docs/specs/semconv/",
+    authority: "consensus-standard",
+    note: "Common names and meanings for service, request, error, trace, metric, log, and resource telemetry.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "wcag-21",
+    shortLabel: "WCAG 2.1",
+    title: "Web Content Accessibility Guidelines 2.1",
+    publisher: "World Wide Web Consortium",
+    version: "2.1",
+    href: "https://www.w3.org/TR/WCAG21/",
+    authority: "consensus-standard",
+    note: "Normative success criteria and conformance requirements incorporated by the ADA Title II web rule.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "wcag-em",
+    shortLabel: "WCAG-EM",
+    title: "Website Accessibility Conformance Evaluation Methodology",
+    publisher: "World Wide Web Consortium",
+    href: "https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/",
+    authority: "implementation-guidance",
+    note: "Repeatable scope, sampling, evaluation, and reporting method for WCAG conformance assessments.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "wai-apg",
+    shortLabel: "WAI-ARIA APG",
+    title: "ARIA Authoring Practices Guide",
+    publisher: "World Wide Web Consortium",
+    href: "https://www.w3.org/WAI/ARIA/apg/",
+    authority: "implementation-guidance",
+    note: "Keyboard, focus, role, state, and property patterns for accessible custom interface components.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "uswds",
+    shortLabel: "USWDS",
+    title: "U.S. Web Design System",
+    publisher: "U.S. General Services Administration",
+    href: "https://designsystem.digital.gov/",
+    authority: "government-guidance",
+    note: "Research-backed component, pattern, accessibility, token, and implementation guidance for public digital services.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "uswds-principles",
+    shortLabel: "USWDS principles",
+    title: "U.S. Web Design System Design Principles",
+    publisher: "U.S. General Services Administration",
+    href: "https://designsystem.digital.gov/design-principles/",
+    authority: "government-guidance",
+    note: "Evaluative guidance centered on real user needs, trust, continuity, access, and evidence.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "digital-playbook",
+    shortLabel: "Digital Services Playbook",
+    title: "U.S. Digital Services Playbook",
+    publisher: "U.S. Chief Information Officers Council",
+    href: "https://playbook.cio.gov/",
+    authority: "government-guidance",
+    note: "Thirteen practices for user-centered, iterative, measurable, secure digital-service delivery.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "plain-language",
+    shortLabel: "Federal plain language",
+    title: "Federal Plain Language Guidelines",
+    publisher: "PlainLanguage.gov",
+    href: "https://www.plainlanguage.gov/guidelines/",
+    authority: "government-guidance",
+    note: "Guidance for audience-centered organization, short direct language, informative headings, and usable content.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "core-web-vitals",
+    shortLabel: "Core Web Vitals",
+    title: "How the Core Web Vitals Metrics Thresholds Were Defined",
+    publisher: "Google web.dev",
+    href: "https://web.dev/articles/defining-core-web-vitals-thresholds",
+    authority: "implementation-guidance",
+    note: "Published field-performance thresholds for loading, interaction responsiveness, and visual stability at the 75th percentile.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "educause-hecvat",
+    shortLabel: "EDUCAUSE HECVAT",
+    title: "Higher Education Community Vendor Assessment Toolkit",
+    publisher: "EDUCAUSE, Internet2, and REN-ISAC",
+    href: "https://www.educause.edu/higher-education-community-vendor-assessment-toolkit",
+    authority: "higher-ed-practice",
+    note: "Community-developed higher-education assessment covering cybersecurity, privacy, accessibility, and compliance evidence.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "internet2-netplus",
+    shortLabel: "Internet2 NET+",
+    title: "NET+ Community-Vetted Cloud Services",
+    publisher: "Internet2",
+    href: "https://internet2.edu/cloud/internet2-net-plus-services/",
+    authority: "higher-ed-practice",
+    note: "Peer evaluation model spanning functionality, integration, security and compliance, pricing, contract terms, accessibility, and deployment.",
+    checkedOn: CHECKED_ON,
+  },
+  {
+    id: "berkeley-mssei",
+    shortLabel: "Berkeley MSSEI",
+    title: "Minimum Security Standards for Electronic Information",
+    publisher: "University of California, Berkeley",
+    href: "https://security.berkeley.edu/node/1154",
+    authority: "higher-ed-practice",
+    note: "Peer-university example of data-classification and use-category profiles that distinguish required, future, recommended, and not-applicable controls.",
+    checkedOn: CHECKED_ON,
+  },
+] as const;
+
+function req(
+  id: string,
+  statement: string,
+  evidence: string[],
+  assessment: string,
+  critical = false,
+): DraftRequirement {
+  return { id, statement, evidence, assessment, critical };
+}
+
+const SECURITY_EXCEPTION =
+  "Submit a written exception before deployment. Name the risk owner, business need, compensating controls, approval authority, and expiration date; reassess at least annually and after a material change.";
+
+const UX_EXCEPTION =
+  "Document the affected users and workflow, explain why the requirement cannot be met, provide an equivalent path where required, name the approving standard owner, and set a review date no later than one year.";
+
+export const STANDARD_DRAFTS: readonly StandardDraft[] = [
+  {
+    standardId: "i-1",
+    scope: "New systems, material integrations, and material architectural changes that store, process, or exchange University data.",
+    rationale: "Explicit boundaries, ownership, trust relationships, and data flows make security review, support, change analysis, and handoff possible. Architecture documentation is operational evidence, not presentation material.",
+    sourceIds: ["nist-800-53", "nist-800-53a", "ui-apm-30-11"],
+    requirements: [
+      req("I1-R1", "Before build approval, the team shall publish a version-controlled context diagram naming users, external systems, trust boundaries, data stores, and the accountable owner.", ["Current architecture diagram", "Diagram revision history", "Named system owner"], "Examine the diagram and compare its boundaries with deployed infrastructure and integration inventory.", true),
+      req("I1-R2", "Each integration shall use an approved pattern and document protocol, authentication, authorization, data classification, failure behavior, retry/idempotency behavior, and owning teams.", ["Integration inventory", "Interface contract", "Data-classification record"], "Sample every Moderate/High-risk integration and at least three Low-risk integrations; verify every required attribute."),
+      req("I1-R3", "Direct database access across application boundaries shall be prohibited unless OIT approves a time-bounded exception with read/write scope, audit controls, and an exit plan.", ["Database grants", "Approved exception or API contract", "Audit-log configuration"], "Compare active cross-system grants with the interface inventory and exception register.", true),
+      req("I1-R4", "A material architecture change shall update diagrams and receive impact review before production deployment.", ["Change record", "Updated diagram", "Reviewer approval"], "Trace a sample of material production changes to updated architecture evidence."),
+    ],
+    localDecisions: ["Approved integration-pattern catalog", "What constitutes a material architecture change", "Architecture approval authority and response time"],
+    assessment: { cadence: "At design approval, before production, and after material change", assessor: "Enterprise architecture with the system owner and information security", conformanceRule: "All critical requirements must be Met; at least 90% of remaining applicable requirements must be Met and none may be Not assessed." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-2",
+    scope: "HTTP APIs and externally consumed application interfaces operated for University business.",
+    rationale: "Consistent contracts reduce integration defects and security ambiguity while allowing clients and providers to evolve independently.",
+    sourceIds: ["rfc-9110", "rfc-9457", "openapi-311", "owasp-api"],
+    requirements: [
+      req("I2-R1", "Every production HTTP API shall publish a validated OpenAPI 3.1 contract covering operations, schemas, authentication, error responses, and representative examples.", ["Versioned OpenAPI document", "Contract validation result", "Published documentation URL"], "Validate the contract and compare all production routes and status codes with the document.", true),
+      req("I2-R2", "HTTP methods, status codes, caching, conditional requests, and content negotiation shall follow RFC 9110 semantics.", ["Contract", "Automated API tests"], "Run contract tests for success, client error, server error, and caching behavior."),
+      req("I2-R3", "API errors shall use RFC 9457 problem details, include a stable problem type and actionable message, and exclude secrets, stack traces, and unnecessary personal data.", ["Error schema", "Negative-path test output", "Log-redaction configuration"], "Exercise representative validation, authorization, missing-resource, rate-limit, and server failures.", true),
+      req("I2-R4", "Collection endpoints shall document pagination, filtering, sorting, maximum page size, rate limits, and deterministic ordering; breaking changes shall use an announced version and deprecation window.", ["API contract", "Version/deprecation policy", "Consumer notice"], "Inspect each collection operation and trace one breaking-change rehearsal or completed change."),
+    ],
+    localDecisions: ["Default and maximum page sizes", "Rate-limit tiers", "Minimum breaking-change notice and support window"],
+    assessment: { cadence: "In CI for every change and before production release", assessor: "API owner with architecture and security review for Moderate/High-risk APIs", conformanceRule: "All critical requirements must be Met. Other applicable requirements may be Partially met only with an approved remediation date." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-3",
+    scope: "Systems and integrations that create, collect, store, transform, disclose, retain, or dispose of University data.",
+    rationale: "Data cannot be protected, interpreted, retained, or responsibly reused unless its owner, meaning, sensitivity, lineage, and lifecycle are explicit.",
+    sourceIds: ["ui-apm-30-11", "nist-privacy", "nist-800-53"],
+    requirements: [
+      req("I3-R1", "The accountable Data Owner or Steward shall classify each system at the highest risk level of the data it stores, processes, or accesses and approve the classification before production use.", ["Signed classification record", "Data inventory", "Named Data Owner and Steward"], "Compare representative data elements and integrations with the approved classification.", true),
+      req("I3-R2", "Each authoritative domain shall identify its system of record, canonical identifiers, definitions, allowed values, steward, and approved exchange interfaces.", ["Data dictionary", "System-of-record register", "Controlled-vocabulary references"], "Trace a sample of shared fields from source through consuming systems and compare definitions."),
+      req("I3-R3", "The system shall document collection purpose, lineage, retention trigger and period, archival location, legal hold behavior, and verified disposal method for each data class.", ["Lifecycle schedule", "Lineage record", "Disposal evidence"], "Examine lifecycle rules and test one retention/disposal path in a non-production environment.", true),
+      req("I3-R4", "Backup and recovery controls shall have defined recovery objectives, protected copies, named ownership, and a recorded restore test.", ["Backup configuration", "RPO/RTO statement", "Restore-test report"], "Inspect backup coverage and observe or review the latest restore test."),
+    ],
+    localDecisions: ["Approved retention schedules by data domain", "Canonical system-of-record registry owner", "Minimum recovery objectives by service tier"],
+    assessment: { cadence: "Before production, annually, and when data use or classification changes", assessor: "Data Steward with OIT security and records/privacy stakeholders", conformanceRule: "All critical requirements must be Met. Not applicable determinations require the Data Steward's written approval." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-4",
+    scope: "University-developed, configured, acquired, or hosted applications and their supporting infrastructure.",
+    rationale: "Security and compliance are lifecycle properties. Risk-tiered, testable controls reduce preventable vulnerabilities and make residual risk visible to accountable owners.",
+    sourceIds: ["ui-apm-30-11", "ui-it-standards", "nist-ssdf", "owasp-asvs", "cisa-secure-by-design"],
+    requirements: [
+      req("I4-R1", "Every application shall complete the Application Assurance Profile. The highest applicable trigger across data classification, protected actions, exposure, privilege, blast radius, availability, and external obligations shall determine the minimum OWASP ASVS 5.0.0 level: Level 1 only for eligible low-risk applications, Level 2 for most production applications, and Level 3 for any high-assurance trigger.", ["Completed Application Assurance Profile", "Selected ASVS 5.0.0 control profile", "Threat model at the depth required for the selected level", "Applicability decisions"], "Reperform the seven-dimension profile from current evidence, confirm the highest trigger determines the selected level, and verify that required threat-model and ASVS evidence matches that level.", true),
+      req("I4-R2", "Secrets shall be stored only in an OIT-approved secrets service, encrypted in transit and at rest, excluded from source and logs, and rotated after suspected exposure.", ["Secrets inventory", "Repository scan", "Runtime configuration", "Rotation procedure"], "Scan source/history and inspect runtime injection, access control, encryption, and rotation evidence.", true),
+      req("I4-R3", "CI shall perform dependency, secret, static-analysis, and container/infrastructure scans where applicable; unresolved critical findings shall block release and high findings require an approved risk disposition.", ["CI configuration", "Scan reports", "Finding dispositions"], "Inspect the latest successful release and intentionally verify blocking behavior in a safe test.", true),
+      req("I4-R4", "Authentication shall use approved University identity services; authorization shall enforce least privilege server-side and shall be tested for horizontal and vertical access-control failures.", ["Identity configuration", "Role/permission matrix", "Authorization tests"], "Test representative roles against allowed and prohibited records and functions.", true),
+    ],
+    localDecisions: ["Calibrate assurance triggers after the first five completed profiles", "Approved scanning tools and severity timeframes", "Approved secrets and encryption services"],
+    assessment: { cadence: "Continuously in CI, before release, and annually", assessor: "Information security with the product owner and technical lead", conformanceRule: "Every critical requirement is a release gate. A critical Not met result means Nonconforming regardless of aggregate completion." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-5",
+    scope: "Build, test, package, deploy, host, and release processes for University applications.",
+    rationale: "Repeatable, reviewable delivery reduces configuration drift, supply-chain tampering, failed changes, and reliance on individual operator knowledge.",
+    sourceIds: ["nist-ssdf", "nist-800-53", "slsa"],
+    requirements: [
+      req("I5-R1", "Production artifacts shall be built by an approved CI service from version-controlled source with immutable provenance linking commit, dependencies, build process, and artifact digest.", ["CI build record", "Artifact digest", "Provenance attestation"], "Select a production artifact and trace it reproducibly to reviewed source and build inputs.", true),
+      req("I5-R2", "Development, test, and production shall be logically separated; production data shall not be used outside production unless explicitly approved and protected to the production classification.", ["Environment architecture", "Access configuration", "Data-use approval"], "Inspect network, identity, secret, and data boundaries across environments.", true),
+      req("I5-R3", "Infrastructure and deployment configuration shall be version controlled, peer reviewed, automatically validated, and reconciled through the approved deployment mechanism.", ["Infrastructure repository", "Review history", "Deployment/reconciliation logs"], "Trace a production configuration change from review through deployment and drift detection."),
+      req("I5-R4", "Every production release shall have automated health verification, a rollback or forward-recovery procedure, and a record of the deployed version and approver.", ["Release record", "Health-check result", "Recovery procedure", "Rollback rehearsal"], "Review the latest release and the latest recovery rehearsal."),
+    ],
+    localDecisions: ["Approved hosting and CI/CD services", "Required provenance level", "Environment topology and release approval tiers"],
+    assessment: { cadence: "For every release, with quarterly control sampling", assessor: "Platform operations with the application technical owner", conformanceRule: "Critical requirements must be Met for production. Other requirements require current evidence from the assessed release." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-6",
+    scope: "Applications seeking production approval, changing operational ownership, or approaching retirement.",
+    rationale: "A deployable application is not necessarily supportable. Named ownership, operating objectives, recovery procedures, and retirement planning prevent orphaned institutional services.",
+    sourceIds: ["nist-800-53", "nist-800-53a", "nist-ssdf"],
+    requirements: [
+      req("I6-R1", "Production approval shall require a named business owner, technical owner, support contact, data owner/steward where applicable, and funded maintenance commitment.", ["Ownership record", "Support assignment", "Funding or capacity statement"], "Confirm each named individual accepts the role and escalation path.", true),
+      req("I6-R2", "The handoff package shall include current architecture and data-flow diagrams, dependency inventory, deployment and recovery instructions, monitoring/alert ownership, access procedures, known risks, and vendor contacts.", ["Versioned runbook", "Architecture artifacts", "Dependency inventory"], "A person outside the build team shall execute a tabletop handoff using only the package.", true),
+      req("I6-R3", "The owner shall define measurable service objectives, support hours, incident severity/escalation, recovery objectives, and maintenance windows appropriate to the service tier.", ["Service-level objectives", "Escalation matrix", "RPO/RTO record"], "Compare monitoring and on-call/support behavior with the declared objectives."),
+      req("I6-R4", "Before go-live, the owner shall approve a decommission plan covering notification, export, retention, disposal, integration shutdown, access removal, and archival evidence.", ["Decommission plan", "Data lifecycle mapping", "Owner approval"], "Inspect completeness and rehearse decision ownership in a tabletop review."),
+    ],
+    localDecisions: ["Institutional service tiers and default objectives", "Minimum support commitment", "Required handoff approvers"],
+    assessment: { cadence: "Before go-live, at ownership transfer, and annually", assessor: "Service owner with OIT operations, security, and the Data Steward", conformanceRule: "All requirements are production gates; Partially met requires a dated transition plan accepted by the operational owner." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-7",
+    scope: "Source code and configuration maintained for University applications.",
+    rationale: "Automated quality controls, maintainable structure, and visible debt reduce regression risk and make software supportable by people beyond its original authors.",
+    sourceIds: ["nist-ssdf", "nist-800-53", "owasp-asvs"],
+    requirements: [
+      req("I7-R1", "Repositories shall enforce approved formatting, linting, type checking where supported, tests, dependency review, and secret scanning before merge.", ["Branch protection", "CI configuration", "Representative pull request"], "Inspect protected-branch rules and verify a failing check prevents merge."),
+      req("I7-R2", "Changed behavior shall include automated tests at the lowest effective level; critical authorization, data-integrity, and recovery paths shall have integration tests.", ["Test suite", "Change-to-test trace", "Coverage of critical paths"], "Sample material changes and trace each to a meaningful behavioral test.", true),
+      req("I7-R3", "Teams shall maintain a reviewed technical-debt register with impact, risk, owner, disposition, and target horizon; critical debt may not remain only in code comments.", ["Debt register", "Review record", "Linked remediation work"], "Sample debt items and compare declared risk and target dates with delivery planning."),
+      req("I7-R4", "Shared or approved components shall be used where they satisfy the need; intentional duplication or custom framework use shall record the reason and maintenance owner.", ["Dependency/component inventory", "Deviation rationale"], "Review custom components and frameworks against the approved catalog."),
+    ],
+    localDecisions: ["Approved toolchain by language", "Critical-path test inventory", "Debt review frequency and escalation thresholds"],
+    assessment: { cadence: "For every change, with quarterly repository review", assessor: "Technical owner with peer maintainers", conformanceRule: "The critical requirement must be Met; at least 90% of sampled changes must satisfy each remaining applicable requirement." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-8",
+    scope: "Technology, architecture, security, data, and vendor decisions for University applications.",
+    rationale: "Decision rights and a time-bounded exception path let teams move quickly on the paved road while making risk acceptance visible and accountable.",
+    sourceIds: ["nist-csf", "nist-800-53", "ui-apm-30-11"],
+    requirements: [
+      req("I8-R1", "The standards owner shall publish a decision-rights matrix naming who proposes, reviews, approves, owns, and may accept risk for each decision class.", ["Decision-rights matrix", "Named role holders", "Publication date"], "Interview representative participants and trace recent decisions to the matrix.", true),
+      req("I8-R2", "Material decisions and deviations shall record context, options, decision, rationale, approver, affected standards, and review trigger in a durable register.", ["Decision register", "Architecture/risk records"], "Sample recent material decisions and verify completeness and discoverability."),
+      req("I8-R3", "Each exception shall be scoped, risk-assessed, approved by an authorized owner, paired with compensating controls, assigned an expiration date, and reviewed at least annually.", ["Exception register", "Risk approval", "Review history"], "Identify expired or ownerless exceptions and verify they cannot remain silently active.", true),
+      req("I8-R4", "Each standard shall have an accountable owner, version, effective date, review date, change history, and stakeholder comment path.", ["Standards register", "Change history", "Review calendar"], "Inspect all published standards for complete governance metadata."),
+    ],
+    localDecisions: ["Decision classes and authorized approvers", "Materiality thresholds", "Appeal and escalation path"],
+    assessment: { cadence: "Quarterly, and when decision authority changes", assessor: "CIO-designated governance owner with affected business and risk owners", conformanceRule: "All critical requirements must be Met; expired exceptions count as Not met until closed or renewed." },
+    exceptionProcess: "Governance requirements may be changed only through the published standards-change process; an individual project exception may not waive accountable approval or expiration.",
+  },
+  {
+    standardId: "i-9",
+    scope: "Application, platform, API, dependency, schema, and infrastructure changes after initial production approval.",
+    rationale: "Predictable upgrade and deprecation practices reduce emergency work, consumer breakage, unsupported software, and hidden operational risk.",
+    sourceIds: ["nist-800-53", "nist-800-53a", "nist-ssdf"],
+    requirements: [
+      req("I9-R1", "Every production component shall have a named upgrade owner, supported-version policy, dependency inventory, and monitored end-of-support date.", ["Component inventory", "Owner", "Support lifecycle dashboard"], "Sample components and verify version, owner, and support date against authoritative vendor sources.", true),
+      req("I9-R2", "Security updates shall follow risk-based remediation timeframes; an overdue critical or actively exploited issue shall block unrelated releases unless risk is explicitly accepted.", ["Vulnerability record", "Patch timeline", "Risk acceptance"], "Compare detection and remediation dates with the approved severity policy.", true),
+      req("I9-R3", "Breaking API, schema, or user-workflow changes shall publish impact, migration instructions, owner, notice date, compatibility period, and removal date.", ["Change notice", "Migration guide", "Consumer inventory"], "Trace a breaking change to identified consumers, notification, compatibility testing, and removal approval."),
+      req("I9-R4", "Material upgrades shall pass automated regression, security, migration, rollback/forward-recovery, and observability checks before production.", ["Upgrade test report", "Recovery result", "Release approval"], "Review the latest material upgrade and verify each required test produced current evidence."),
+    ],
+    localDecisions: ["Severity-based remediation timeframes", "Default compatibility/deprecation period", "Approved sources for lifecycle alerts"],
+    assessment: { cadence: "Continuously for support status; per material change and quarterly review", assessor: "Technical owner with platform operations and security", conformanceRule: "Critical requirements must be Met. Overdue critical vulnerabilities or unsupported production components make the system Nonconforming." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "i-10",
+    scope: "Production applications, APIs, scheduled jobs, integrations, and infrastructure supporting University services.",
+    rationale: "Consistent telemetry and owned alerts turn failures into detectable, diagnosable, and actionable events while avoiding unnecessary collection of sensitive data.",
+    sourceIds: ["opentelemetry", "nist-800-92", "nist-800-53", "ui-apm-30-11"],
+    requirements: [
+      req("I10-R1", "Production services shall emit structured logs, metrics, and traces using approved OpenTelemetry semantic conventions for service identity, requests, dependencies, and errors where applicable.", ["Telemetry schema", "Collector configuration", "Sample correlated event"], "Trace a representative request across service, dependency, log, metric, and error views."),
+      req("I10-R2", "Telemetry shall exclude secrets and minimize personal or regulated data; access, retention, integrity, and disposal shall match the highest data classification represented.", ["Telemetry data inventory", "Redaction tests", "Access and retention configuration"], "Inject safe test markers and verify redaction, access control, retention, and disposal behavior.", true),
+      req("I10-R3", "Each production service shall define service indicators and objectives for availability, latency, errors, and critical business transactions, with dashboards showing current performance and measurement gaps.", ["SLI/SLO definitions", "Dashboard", "Measurement coverage"], "Compare telemetry queries and dashboard calculations with the published objective definitions."),
+      req("I10-R4", "Actionable alerts shall name an owner, severity, runbook, notification path, and response expectation; alert tests and post-incident findings shall be recorded.", ["Alert catalog", "Runbooks", "Alert test or incident record"], "Sample critical alerts and verify delivery, ownership, diagnostic context, and runbook action."),
+    ],
+    localDecisions: ["Institutional telemetry platform and retention tiers", "Default service indicators/objectives", "Alert severity and response expectations"],
+    assessment: { cadence: "Continuously, with quarterly control and alert review", assessor: "Service owner with operations and information security", conformanceRule: "The telemetry-data protection requirement is critical. All other requirements must be Met for tier-one services and at least 90% Met for other production services." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "ii-1",
+    scope: "Public-facing and internal University web applications, mobile interfaces, and reusable interface assets.",
+    rationale: "A governed visual language makes University services recognizable, coherent, accessible, and less expensive to build and maintain.",
+    sourceIds: ["ui-brand", "uswds", "ui-accessibility"],
+    requirements: [
+      req("II1-R1", "Interfaces representing the University shall use approved University identity assets, colors, typography, logo clear space, and voice without altering protected marks.", ["Design review", "Token or theme configuration", "Approved identity assets"], "Compare representative screens and assets with current University brand guidance.", true),
+      req("II1-R2", "The institutional application design system shall publish versioned design tokens for color, typography, spacing, elevation, borders, breakpoints, focus, and motion with accessible usage guidance.", ["Token package", "Documentation", "Release history"], "Inspect the distributed tokens and compare documented values with rendered reference components."),
+      req("II1-R3", "Applications shall consume shared tokens and components through an approved, versioned dependency or documented synchronization process rather than copying styles without provenance.", ["Dependency inventory", "Build configuration", "Update record"], "Trace representative visual styles and components to their governed source."),
+      req("II1-R4", "Themes, including any dark theme, shall preserve semantic meaning and meet the same accessibility and component-state requirements as the default theme.", ["Theme specification", "Contrast results", "Component state review"], "Test representative components and content across every supported theme and forced-colors mode."),
+    ],
+    localDecisions: ["Authoritative application design-system owner", "Approved component framework and distribution model", "Whether dark mode is supported or intentionally excluded"],
+    assessment: { cadence: "At design review, before launch, and after design-system major versions", assessor: "University Communications and Marketing with the UX and accessibility owners", conformanceRule: "Brand and accessibility-critical findings must be Met before public release; other findings require a dated remediation plan." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-2",
+    scope: "Interactive components and patterns used in University web and mobile applications.",
+    rationale: "Predictable interaction, accessible behavior, and reuse reduce user learning effort and eliminate repeated implementation defects.",
+    sourceIds: ["uswds", "wai-apg", "wcag-21"],
+    requirements: [
+      req("II2-R1", "Teams shall use approved shared components for common controls and patterns; custom components require a documented unmet need, owner, accessibility review, tests, and contribution decision.", ["Component inventory", "Deviation record", "Component tests"], "Inventory rendered component types and trace each custom interactive component to approval evidence."),
+      req("II2-R2", "Every interactive element shall expose the correct accessible name, role, value/state, keyboard operation, focus order, visible focus, and disabled/read-only behavior.", ["Automated accessibility results", "Keyboard test", "Screen-reader test"], "Test every unique interactive pattern with keyboard and at least one supported screen reader.", true),
+      req("II2-R3", "Forms shall use persistent labels, programmatic instructions, appropriate input purpose, inline validation, an error summary for failed submission, and preserved user-entered values.", ["Form-pattern review", "Validation tests", "Assistive-technology test"], "Complete representative valid and invalid paths using keyboard and screen reader.", true),
+      req("II2-R4", "Destructive, irreversible, legal, or financial actions shall require clear consequence language and confirmation, reversal, or review before final commitment.", ["Critical-action inventory", "Interaction design", "User test"], "Exercise each critical action and verify prevention and recovery behavior."),
+    ],
+    localDecisions: ["Approved component inventory", "Supported browser and assistive-technology matrix", "Criteria for contributing custom components upstream"],
+    assessment: { cadence: "Per component release and before application launch", assessor: "Design-system owner with accessibility reviewer and product team", conformanceRule: "All critical requirements must be Met for every unique pattern; sampling is permitted only for repeated instances of the same implementation." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-3",
+    scope: "University-provided or contractually delivered web content and mobile applications, subject to the applicability and exceptions of ADA Title II and University policy.",
+    rationale: "Accessible digital services provide equal participation and reduce barriers for people with visual, auditory, physical, speech, cognitive, and neurological disabilities.",
+    sourceIds: ["ada-title-ii-web", "ui-accessibility", "wcag-21", "wcag-em"],
+    requirements: [
+      req("II3-R1", "Covered web content and mobile applications shall conform to WCAG 2.1 Level A and Level AA, including complete-process and accessibility-supported-use requirements.", ["WCAG-EM conformance report", "Issue register", "Accessibility statement"], "Evaluate a representative sample and every critical process using WCAG-EM; every applicable A and AA success criterion must pass.", true),
+      req("II3-R2", "Automated accessibility checks shall run in CI and production monitoring where feasible, but automated results shall not substitute for keyboard, zoom/reflow, contrast, screen-reader, and cognitive/usability review.", ["CI accessibility results", "Manual test record", "Production scan"], "Verify both automated and manual evidence cover every unique template and interaction pattern."),
+      req("II3-R3", "Accessibility defects shall be triaged by user impact; blockers in a critical process shall prevent release or trigger an immediately available equivalent path and executive risk decision.", ["Defect severity policy", "Release record", "Equivalent-path evidence"], "Sample critical defects and trace detection, decision, communication, remediation, and retest.", true),
+      req("II3-R4", "Each service shall publish an accessible feedback channel, name the responsible owner, acknowledge reports, and track remediation through verification.", ["Accessibility statement", "Feedback workflow", "Remediation record"], "Submit a test report and verify receipt, ownership, escalation, and closure evidence."),
+    ],
+    localDecisions: ["Accessibility defect severity and remediation targets", "Supported assistive-technology test matrix", "Central accessibility review and reporting owner"],
+    assessment: { cadence: "During design and development, before launch, after material change, and at least annually", assessor: "Qualified accessibility evaluator with the product owner; people with disabilities included in usability validation where practical", conformanceRule: "WCAG conformance is not an averaged score: all applicable Level A and AA success criteria must pass. Maturity is reported separately." },
+    exceptionProcess: "Use only the exceptions and defenses permitted by applicable law and University policy. Any determination of undue burden, fundamental alteration, conforming alternate version, or equivalent facilitation requires documented legal and executive review; a project team may not self-approve it.",
+  },
+  {
+    standardId: "ii-4",
+    scope: "Task-oriented University digital services used by students, employees, faculty, partners, or the public.",
+    rationale: "Workflow standards should reduce task failure and burden for real users, not optimize arbitrary click counts. Evidence from representative users is the basis for acceptability.",
+    sourceIds: ["uswds-principles", "digital-playbook", "wcag-21"],
+    requirements: [
+      req("II4-R1", "Before solution approval, the team shall identify primary user groups, critical tasks, context of use, barriers, current baseline, and the user outcome the service must improve.", ["Research brief", "Task inventory", "Baseline evidence"], "Review research coverage and confirm requirements trace to observed user needs rather than stakeholder assumption.", true),
+      req("II4-R2", "Each critical task shall have a measurable success definition covering completion, errors, time or effort where meaningful, abandonment, accessibility, and user confidence.", ["Task success measures", "Analytics plan", "Test protocol"], "Inspect every critical task for an observable outcome and a defensible target or baseline-improvement commitment."),
+      req("II4-R3", "Navigation, action placement, terminology, and interaction behavior shall remain consistent across modules unless user evidence supports a documented exception.", ["Pattern inventory", "Content/design review", "Exception rationale"], "Compare repeated tasks and labels across modules and review any divergence with representative users."),
+      req("II4-R4", "Critical workflows shall work at supported mobile and desktop sizes, 200% zoom, and 320 CSS-pixel reflow without loss of content, context, or functionality.", ["Responsive test matrix", "Reflow evidence", "Device/browser results"], "Complete every critical workflow at the required viewport and zoom conditions.", true),
+    ],
+    localDecisions: ["Critical-task designation method", "Acceptable baseline improvement or success targets by service", "Supported device and browser matrix"],
+    assessment: { cadence: "Before build commitment, during prototype testing, before launch, and after material workflow change", assessor: "Product owner and UX researcher with representative users", conformanceRule: "All critical requirements must be Met. Outcome targets are assessed task-by-task; a strong average cannot offset a failed critical task." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-5",
+    scope: "User-facing web applications and the APIs required to complete their critical workflows.",
+    rationale: "Real-world loading speed, interaction responsiveness, visual stability, and network resilience directly affect whether people can complete University tasks.",
+    sourceIds: ["core-web-vitals", "wcag-21", "uswds"],
+    requirements: [
+      req("II5-R1", "At least 75% of production visits, measured separately for mobile and desktop over a rolling 28-day window, shall achieve LCP at or below 2.5 seconds, INP at or below 200 milliseconds, and CLS at or below 0.1.", ["Real-user monitoring dashboard", "28-day percentile report", "Page/template coverage"], "Verify p75 field data for all three metrics by device class and identify unmeasured critical pages."),
+      req("II5-R2", "Critical user transactions shall have documented end-to-end latency and availability objectives, with API budgets allocated to dependent services and measured in production.", ["Transaction SLOs", "Dependency budgets", "Production traces"], "Compare representative production traces and SLO calculations with the documented budget."),
+      req("II5-R3", "Critical workflows shall remain understandable and recoverable on a representative constrained network, including meaningful loading, timeout, retry, and reconnection behavior.", ["Network-condition test", "Loading/error states", "Recovery test"], "Complete critical workflows under the approved constrained-network profile and interrupted requests."),
+      req("II5-R4", "Large result sets shall use bounded queries and an appropriate pagination, incremental loading, or virtualization pattern without removing keyboard or assistive-technology access.", ["Query limits", "Performance trace", "Accessibility test"], "Test the documented maximum supported data volume for performance and full interaction access."),
+    ],
+    localDecisions: ["Critical transaction SLOs and service tiers", "Representative constrained-network profile", "Data-volume thresholds and performance budgets"],
+    assessment: { cadence: "Continuously in production, with release and monthly trend review", assessor: "Product and technical owners with UX and operations", conformanceRule: "Core Web Vitals are reported individually; all three must meet the target. A composite score may not hide a failed metric or unmeasured critical flow." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-6",
+    scope: "User-visible validation, errors, warnings, status changes, progress, success, and service interruptions.",
+    rationale: "Clear, timely, accessible feedback helps people recover without blame, protects entered work, and keeps diagnostic detail out of unsafe user-facing messages.",
+    sourceIds: ["wcag-21", "uswds", "rfc-9457"],
+    requirements: [
+      req("II6-R1", "User-facing errors shall state what happened in plain language, identify the affected item, explain how to recover, preserve valid work, and provide a support/reference identifier when escalation may be needed.", ["Error-message inventory", "Content review", "Recovery tests"], "Trigger representative errors and assess clarity, actionability, preservation, and escalation information with users."),
+      req("II6-R2", "Validation shall occur at a helpful time, associate each message programmatically with its field, and provide an accessible summary after an unsuccessful submission.", ["Validation pattern", "Accessibility test", "Invalid-submission test"], "Submit representative invalid inputs using keyboard and screen reader; verify focus and announced context.", true),
+      req("II6-R3", "Loading, success, warning, and failure states shall be programmatically announced without stealing focus; long operations shall show meaningful progress or status and support safe retry or cancellation where feasible.", ["Status-state inventory", "Live-region test", "Interruption/retry test"], "Exercise asynchronous operations with assistive technology and interrupted connectivity."),
+      req("II6-R4", "User messages shall not expose stack traces, internal identifiers without explanation, secrets, or unnecessary personal data; diagnostic detail shall go to protected logs correlated by a safe reference identifier.", ["Error samples", "Logging correlation", "Redaction tests"], "Trigger server and integration failures and compare the user response with protected diagnostic logs.", true),
+    ],
+    localDecisions: ["Approved notification pattern by persistence and severity", "Reference/support routing format", "Maximum silent wait before progress is required"],
+    assessment: { cadence: "Per workflow release and during usability/accessibility testing", assessor: "Content designer and UX/accessibility reviewer with the technical owner", conformanceRule: "Critical requirements must pass every tested error path. Other requirements require at least 90% of sampled states Met with no repeated systemic defect." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-7",
+    scope: "Labels, instructions, navigation, help, errors, notifications, and documentation within University digital services.",
+    rationale: "People complete tasks more reliably when content uses their language, leads with the needed information, and remains consistent across systems.",
+    sourceIds: ["plain-language", "ui-brand", "uswds-principles"],
+    requirements: [
+      req("II7-R1", "Content shall identify its primary audience and purpose, lead with the needed information, use active voice and familiar words, and explain unavoidable institutional or technical terms at first use.", ["Content brief", "Editorial review", "Terminology decisions"], "Review representative task content against the audience, purpose, organization, sentence, and vocabulary criteria."),
+      req("II7-R2", "Buttons and links shall describe the action or destination; field labels shall name the requested information; headings shall describe the following content and form a meaningful hierarchy.", ["Interface copy inventory", "Heading/link audit", "Usability test"], "Review all unique action labels and a representative content sample out of visual context."),
+      req("II7-R3", "A governed glossary shall define cross-system institutional terms, preferred labels, prohibited ambiguity, owner, and change process; products shall reuse those terms consistently.", ["Glossary", "Content-lint or review results", "Change history"], "Compare repeated domain concepts across services and record unexplained variation."),
+      req("II7-R4", "Help shall be available at the point of need without hiding information necessary to complete the task; critical instructions shall not depend only on tooltips, placeholders, icons, or hover.", ["Help-content inventory", "Keyboard/touch test", "User test"], "Complete critical tasks without hover and verify essential guidance remains visible and accessible."),
+    ],
+    localDecisions: ["Institutional product voice and reading-level guidance", "Glossary governance owner", "Content review triggers and approvers"],
+    assessment: { cadence: "During design, before release, and when policy or terminology changes", assessor: "Content owner with representative users and the product owner", conformanceRule: "Each critical workflow must meet every requirement. Broader content inventories may use a statistically defensible sample with remediation for systemic findings." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-8",
+    scope: "New services, material workflow changes, and existing services with significant user-impact or adoption concerns.",
+    rationale: "Testing with representative users turns assumptions into evidence and catches workflow, accessibility, terminology, and trust failures before they become institutional burden.",
+    sourceIds: ["uswds-principles", "digital-playbook", "wcag-em"],
+    requirements: [
+      req("II8-R1", "Every material release shall test its critical tasks with representative participants, including people likely to face the greatest barriers; recruitment and exclusions shall be documented.", ["Research plan", "Participant characteristics", "Consent/privacy record"], "Review participant coverage against the service's identified user groups and barriers.", true),
+      req("II8-R2", "The test plan shall define tasks, success measures, stopping rules, accessibility accommodations, observation method, and decision thresholds before sessions begin.", ["Approved test plan", "Task scripts", "Success thresholds"], "Compare the final report with the predeclared plan and explain deviations."),
+      req("II8-R3", "Critical task findings shall be prioritized by user impact, assigned to an owner, resolved or explicitly accepted before launch, and retested when the design changes materially.", ["Findings register", "Disposition approvals", "Retest evidence"], "Trace every critical/high-impact finding from observation to verified disposition.", true),
+      req("II8-R4", "After launch, the owner shall maintain a feedback channel and review task analytics, support themes, accessibility reports, and qualitative feedback on a declared cadence.", ["Feedback channels", "Review record", "Improvement decisions"], "Inspect the latest review and trace at least one decision to post-launch evidence."),
+    ],
+    localDecisions: ["Minimum participant strategy by service risk", "Material-release definition", "Critical task success thresholds and launch authority"],
+    assessment: { cadence: "Before material release, soon after launch, and at least annually for critical services", assessor: "Qualified UX researcher with the product owner and accessibility support", conformanceRule: "Critical research and finding-disposition requirements must be Met. Participant count alone never establishes acceptable UX; evidence quality and task coverage are assessed." },
+    exceptionProcess: UX_EXCEPTION,
+  },
+  {
+    standardId: "ii-9",
+    scope: "Analytics, session measurement, product telemetry, surveys, experiments, and feedback data describing people or their use of University services.",
+    rationale: "Measurement should answer declared service questions while minimizing surveillance, privacy risk, sensitive inference, and retention of data without continuing value.",
+    sourceIds: ["nist-privacy", "ui-apm-30-11", "uswds-principles"],
+    requirements: [
+      req("II9-R1", "Each tracked event or attribute shall have a documented decision purpose, owner, data classification, lawful/policy basis, retention period, access group, and prohibited uses.", ["Measurement plan", "Event dictionary", "Data classification"], "Sample collected events and compare every field with the approved plan and actual decision use.", true),
+      req("II9-R2", "Analytics shall collect the minimum data needed, avoid sensitive content and raw identifiers where aggregation or pseudonymous identifiers suffice, and prohibit credential, free-text, or regulated-data capture by default.", ["Collection configuration", "Payload inspection", "Redaction/block list"], "Inspect production payloads from representative workflows and test prohibited-field blocking.", true),
+      req("II9-R3", "Users shall receive clear notice and controls where required; analytics shall respect applicable consent, opt-out, access, and deletion obligations across first- and third-party tools.", ["Privacy notice", "Consent/control behavior", "Vendor configuration"], "Exercise each applicable privacy control and verify downstream propagation."),
+      req("II9-R4", "Access and retention shall be enforced technically, reviewed periodically, and include verified deletion from exports and downstream destinations when the approved period ends.", ["Access review", "Retention configuration", "Deletion evidence", "Destination inventory"], "Trace a test record or cohort through retention and deletion across all destinations."),
+    ],
+    localDecisions: ["Approved analytics tools and hosting", "Event-level retention tiers", "Privacy review and consent triggers"],
+    assessment: { cadence: "Before collection begins, after schema/tool changes, and at least annually", assessor: "Product owner with Data Steward, privacy/legal, and information security review", conformanceRule: "All requirements are critical for datasets containing Moderate/High-risk data. Unregistered collection is automatically Not met." },
+    exceptionProcess: SECURITY_EXCEPTION,
+  },
+  {
+    standardId: "ii-10",
+    scope: "Ownership, publication, change, enforcement, and exceptions for University UX standards and the institutional design system.",
+    rationale: "UX standards remain credible only when ownership, decision rights, review, evidence, and exceptions are visible and consistently applied.",
+    sourceIds: ["nist-csf", "uswds", "ui-brand", "ui-accessibility"],
+    requirements: [
+      req("II10-R1", "The University shall name accountable owners for brand, design system, content, accessibility, user research, and product analytics standards, plus a single escalation path for conflicts.", ["Published ownership matrix", "Named role holders", "Escalation path"], "Confirm role holders accept responsibility and recent questions reached the appropriate owner.", true),
+      req("II10-R2", "UX standards and shared components shall publish version, effective date, change history, evidence/rationale, migration guidance, deprecation window, and next review date.", ["Published standard/component metadata", "Release notes", "Review calendar"], "Inspect every active standard and current major component version for complete metadata."),
+      req("II10-R3", "Proposed changes shall collect evidence and affected-stakeholder input, document the decision and dissent, and receive approval from the authorized owner before becoming binding.", ["Change proposal", "Research or issue evidence", "Approval record"], "Trace a sample of adopted and rejected changes through the published process."),
+      req("II10-R4", "UX exceptions shall identify affected users, duration, owner, rationale, risk, accessible/equivalent path where required, compensating measures, approval, and expiration; expired exceptions shall not remain active.", ["Exception register", "Approvals", "Expiration review"], "Review all open exceptions for completeness, user impact, and timely closure.", true),
+    ],
+    localDecisions: ["Named UX governance roles and conflict authority", "Standards-review and component-support cadence", "Required stakeholder groups for material changes"],
+    assessment: { cadence: "Quarterly and before each material standards release", assessor: "CIO- and UCM-designated UX governance owners with accessibility and product representation", conformanceRule: "Critical requirements must be Met. Expired, ownerless, or unpublished exceptions are Not met and may not be treated as precedent." },
+    exceptionProcess: "Governance requirements may be revised through the standards-change process; individual projects may not waive accessibility law, accountable ownership, or exception expiration.",
+  },
+] as const;
+
+export const standardsSourceById = new Map(
+  STANDARDS_SOURCES.map((source) => [source.id, source]),
+);
+
+export const standardDraftById = new Map(
+  STANDARD_DRAFTS.map((draft) => [draft.standardId, draft]),
+);
+
+export function draftSummary(drafts: readonly StandardDraft[] = STANDARD_DRAFTS) {
+  return {
+    drafts: drafts.length,
+    requirements: drafts.reduce(
+      (total, draft) => total + draft.requirements.length,
+      0,
+    ),
+    criticalRequirements: drafts.reduce(
+      (total, draft) =>
+        total + draft.requirements.filter((requirement) => requirement.critical).length,
+      0,
+    ),
+    sources: new Set(drafts.flatMap((draft) => draft.sourceIds)).size,
+  };
+}
+
+export function validateStandardsDrafts(
+  standardIds: readonly string[],
+  drafts: readonly StandardDraft[] = STANDARD_DRAFTS,
+  sources: readonly StandardsSource[] = STANDARDS_SOURCES,
+): string[] {
+  const errors: string[] = [];
+  const expected = new Set(standardIds);
+  const draftIds = new Set<string>();
+  const sourceIds = new Set(sources.map((source) => source.id));
+  const requirementIds = new Set<string>();
+
+  for (const draft of drafts) {
+    if (draftIds.has(draft.standardId)) {
+      errors.push(`Duplicate draft for ${draft.standardId}`);
+    }
+    draftIds.add(draft.standardId);
+    if (!expected.has(draft.standardId)) {
+      errors.push(`Draft ${draft.standardId} has no standards-ledger entry`);
+    }
+    if (draft.requirements.length === 0) {
+      errors.push(`Draft ${draft.standardId} has no requirements`);
+    }
+    if (draft.sourceIds.length === 0) {
+      errors.push(`Draft ${draft.standardId} has no sources`);
+    }
+    for (const sourceId of draft.sourceIds) {
+      if (!sourceIds.has(sourceId)) {
+        errors.push(`Draft ${draft.standardId} references unknown source ${sourceId}`);
+      }
+    }
+    for (const requirement of draft.requirements) {
+      if (requirementIds.has(requirement.id)) {
+        errors.push(`Duplicate requirement id ${requirement.id}`);
+      }
+      requirementIds.add(requirement.id);
+      if (requirement.evidence.length === 0) {
+        errors.push(`Requirement ${requirement.id} has no evidence`);
+      }
+    }
+  }
+
+  for (const standardId of expected) {
+    if (!draftIds.has(standardId)) {
+      errors.push(`Standards-ledger entry ${standardId} has no draft`);
+    }
+  }
+
+  return errors;
+}

--- a/lib/standards-foundation.ts
+++ b/lib/standards-foundation.ts
@@ -1,0 +1,398 @@
+// Standards Foundation — the definitions, profiles, and reusable evidence
+// instruments that make the twenty proposed standards assessable without
+// relying on undocumented institutional knowledge.
+
+export type FoundationConfidence = "high" | "moderate" | "experimental";
+
+export interface EvidenceTier {
+  rank: number;
+  label: string;
+  use: string;
+  treatment: string;
+  sourceIds?: string[];
+}
+
+export interface FoundationDefinition {
+  id: string;
+  term: string;
+  definition: string;
+  decisionRule: string;
+  examples: string[];
+  relatedStandards: string[];
+  confidence: FoundationConfidence;
+  sourceIds: string[];
+}
+
+export interface AssuranceLevel {
+  level: 1 | 2 | 3;
+  label: string;
+  defaultUse: string;
+  minimumEvidence: string[];
+  verification: string;
+}
+
+export interface AssuranceDimension {
+  id: string;
+  label: string;
+  question: string;
+  level2Trigger: string;
+  level3Trigger: string;
+}
+
+export interface TemplateSection {
+  id: string;
+  label: string;
+  prompt: string;
+  acceptableEvidence: string;
+}
+
+export interface EvidenceArtifact {
+  id: string;
+  name: string;
+  purpose: string;
+  minimumContents: string[];
+  freshness: string;
+  relatedStandards: string[];
+}
+
+export interface ProvisionalDefaultStep {
+  step: number;
+  label: string;
+  requirement: string;
+}
+
+export const CONFIDENCE_LABELS: Record<FoundationConfidence, string> = {
+  high: "High confidence",
+  moderate: "Moderate confidence",
+  experimental: "Experimental",
+};
+
+export const EVIDENCE_HIERARCHY: readonly EvidenceTier[] = [
+  {
+    rank: 1,
+    label: "Binding obligation",
+    use: "Applicable law, regulation, contract, and current University policy.",
+    treatment: "Adopt as a gate; local drafts may clarify implementation but may not weaken it.",
+    sourceIds: ["ada-title-ii-web", "ui-apm-30-11", "ui-it-standards"],
+  },
+  {
+    rank: 2,
+    label: "Consensus standard",
+    use: "Stable specifications produced through an open or recognized standards process.",
+    treatment: "Adopt or profile explicitly; pin the version and identify any exclusions.",
+    sourceIds: ["wcag-21", "owasp-asvs", "openapi-311", "rfc-9110"],
+  },
+  {
+    rank: 3,
+    label: "Government guidance",
+    use: "Risk, security, privacy, and digital-service guidance from accountable public bodies.",
+    treatment: "Use as the primary rationale and assessment pattern when no binding rule controls.",
+    sourceIds: ["nist-800-53", "nist-ssdf", "nist-privacy", "uswds-principles"],
+  },
+  {
+    rank: 4,
+    label: "Higher-education practice",
+    use: "Community-developed instruments and published peer-institution control profiles.",
+    treatment: "Use to calibrate feasibility, evidence expectations, and sector-specific risk.",
+    sourceIds: ["educause-hecvat", "internet2-netplus", "berkeley-mssei"],
+  },
+  {
+    rank: 5,
+    label: "Documented implementation practice",
+    use: "Maintained technical guidance and measurement methods from responsible projects or vendors.",
+    treatment: "Use for implementation and measurement; do not mislabel it as law or consensus.",
+    sourceIds: ["opentelemetry", "core-web-vitals", "wai-apg"],
+  },
+  {
+    rank: 6,
+    label: "First-principles default",
+    use: "A necessary local decision not determined by stronger evidence.",
+    treatment: "Publish the reasoning, alternative, confidence, assessment, and calibration trigger.",
+  },
+] as const;
+
+export const FOUNDATION_DEFINITIONS: readonly FoundationDefinition[] = [
+  {
+    id: "protected-action",
+    term: "Protected action",
+    definition: "An action that creates, changes, deletes, releases, approves, or authorizes data, access, money, academic standing, employment status, compliance status, or another institutional decision.",
+    decisionRule: "Treat an action as protected when unauthorized or erroneous execution could create a meaningful adverse effect or require an accountable institutional correction.",
+    examples: ["Change a grade", "Approve payroll or financial aid", "Provision an administrator", "Release student records", "Delete research data"],
+    relatedStandards: ["i-4", "ii-2", "ii-4", "ii-8"],
+    confidence: "high",
+    sourceIds: ["ui-apm-30-11", "nist-800-53", "owasp-asvs"],
+  },
+  {
+    id: "high-consequence-action",
+    term: "High-consequence action",
+    definition: "A protected action whose misuse or error could materially affect rights, academic standing, employment, financial obligations, privacy, safety, system access, regulatory compliance, or a significant body of institutional records and is difficult to detect, reverse, or contain.",
+    decisionRule: "Classify as high consequence when any listed impact is severe, when reversal depends on multiple offices or external parties, or when one action can affect 500 or more people or records.",
+    examples: ["Bulk grade change", "Disbursement approval", "Identity or privileged-access provisioning", "Admissions decision", "Disclosure of High-risk data"],
+    relatedStandards: ["i-4", "ii-2", "ii-4", "ii-8"],
+    confidence: "moderate",
+    sourceIds: ["ui-apm-30-11", "owasp-asvs", "berkeley-mssei"],
+  },
+  {
+    id: "critical-workflow",
+    term: "Critical workflow",
+    definition: "A complete user task whose failure prevents or materially delays access to a University service, right, obligation, academic activity, employment function, payment, or safety-related outcome.",
+    decisionRule: "A workflow is critical when no timely equivalent path exists or when delay can cause missed eligibility, financial, academic, legal, or safety consequences.",
+    examples: ["Apply for admission", "Register for classes", "Submit grades", "Approve time or payroll", "Request an accommodation"],
+    relatedStandards: ["ii-3", "ii-4", "ii-5", "ii-6", "ii-8"],
+    confidence: "high",
+    sourceIds: ["ada-title-ii-web", "uswds-principles", "digital-playbook"],
+  },
+  {
+    id: "critical-service",
+    term: "Critical service",
+    definition: "A service supporting one or more critical workflows or an institutional capability whose prolonged loss creates material academic, financial, operational, compliance, research, or safety impact.",
+    decisionRule: "Classify as critical when the maximum tolerable outage is less than one business day or when outage timing can cause an irreversible missed deadline or institutional breach.",
+    examples: ["Identity and access", "Learning management", "Student registration", "Payroll", "Emergency communications"],
+    relatedStandards: ["i-6", "i-10", "ii-5"],
+    confidence: "moderate",
+    sourceIds: ["nist-800-53", "internet2-netplus"],
+  },
+  {
+    id: "material-change",
+    term: "Material change",
+    definition: "A change that can alter security, privacy, accessibility, architecture, data use, user decisions, service objectives, external integrations, or the evidence supporting an approval.",
+    decisionRule: "Treat a change as material when it adds a data category, role, integration, vendor, model, protected action, critical workflow, major dependency, public interface, or changes a trust boundary.",
+    examples: ["Add SSO or a privileged role", "Introduce an AI vendor", "Move hosting providers", "Collect a new personal-data field", "Redesign a critical form"],
+    relatedStandards: ["i-1", "i-6", "i-9", "ii-3", "ii-4", "ii-8"],
+    confidence: "high",
+    sourceIds: ["nist-800-53", "nist-ssdf", "nist-privacy"],
+  },
+  {
+    id: "material-release",
+    term: "Material release",
+    definition: "A release containing a material change or a set of changes whose combined user or operational impact warrants renewed evidence and approval.",
+    decisionRule: "If any included change is material, the release is material; product owners may also classify a cumulative release as material based on combined impact.",
+    examples: ["New protected action", "New public workflow", "Major framework upgrade", "Changed authorization model"],
+    relatedStandards: ["i-5", "i-9", "ii-8"],
+    confidence: "high",
+    sourceIds: ["nist-800-53", "nist-ssdf"],
+  },
+  {
+    id: "representative-user",
+    term: "Representative user",
+    definition: "A participant whose role, goals, experience, access needs, device or environment, and likely barriers reflect a user group affected by the service.",
+    decisionRule: "Research coverage is representative only when it includes each primary role and the people expected to encounter the greatest barriers; demographic similarity alone is insufficient.",
+    examples: ["Student using only a phone", "Faculty member using a screen reader", "Department administrator handling exceptions", "Rural user on constrained bandwidth"],
+    relatedStandards: ["ii-4", "ii-7", "ii-8"],
+    confidence: "high",
+    sourceIds: ["uswds-principles", "digital-playbook", "wcag-em"],
+  },
+  {
+    id: "current-evidence",
+    term: "Current evidence",
+    definition: "Evidence produced from the assessed version and environment within its defined freshness period, with enough provenance for an independent reviewer to reproduce or verify the conclusion.",
+    decisionRule: "Evidence is not current after a material change, after its stated freshness period, or when its source, scope, version, or assessor cannot be established.",
+    examples: ["CI result tied to a release commit", "28-day production measurement", "Annual access review", "Restore test for the current architecture"],
+    relatedStandards: ["i-4", "i-5", "i-6", "i-10", "ii-3", "ii-5"],
+    confidence: "high",
+    sourceIds: ["nist-800-53a", "wcag-em"],
+  },
+  {
+    id: "risk-owner",
+    term: "Risk owner",
+    definition: "The named individual with authority over the affected mission or business outcome and sufficient accountability to accept, fund treatment of, or stop the risk.",
+    decisionRule: "A development team, vendor, committee, or department name alone is not a risk owner; the record must name an individual and the authority under which they decide.",
+    examples: ["Data Owner", "Service executive", "CIO-authorized security authority", "College or division executive"],
+    relatedStandards: ["i-3", "i-6", "i-8", "i-9", "ii-9", "ii-10"],
+    confidence: "high",
+    sourceIds: ["ui-apm-30-11", "nist-csf"],
+  },
+  {
+    id: "compensating-control",
+    term: "Compensating control",
+    definition: "A documented safeguard that addresses the same risk objective as an unmet requirement with comparable, testable protection.",
+    decisionRule: "Additional effort, monitoring, or policy language is compensating only when it reduces the identified risk and produces evidence that can be independently assessed.",
+    examples: ["Independent approval plus enhanced monitoring", "Network isolation replacing unavailable endpoint control", "Manual reconciliation with recorded dual review"],
+    relatedStandards: ["i-4", "i-8", "ii-10"],
+    confidence: "high",
+    sourceIds: ["nist-800-53", "berkeley-mssei"],
+  },
+  {
+    id: "equivalent-path",
+    term: "Equivalent path",
+    definition: "An alternative way to complete the same task with comparable timeliness, privacy, independence, dignity, accuracy, and service availability.",
+    decisionRule: "A phone number or request-for-help is not equivalent when it imposes delay, disclosure, limited hours, dependency on another person, or materially greater effort.",
+    examples: ["Accessible version with the same data and completion time", "Staff-assisted process available on equal terms", "Alternative input method preserving all functions"],
+    relatedStandards: ["ii-3", "ii-4", "ii-6", "ii-10"],
+    confidence: "high",
+    sourceIds: ["ada-title-ii-web", "wcag-21"],
+  },
+  {
+    id: "supported-environment",
+    term: "Supported environment",
+    definition: "A documented combination of browser, device class, operating system, assistive technology, network condition, and viewport against which the service commits to functioning.",
+    decisionRule: "The matrix must cover observed or expected users and may exclude an environment only with usage evidence, impact analysis, and an equivalent path where required.",
+    examples: ["Current Chrome, Firefox, Safari, and Edge", "VoiceOver/Safari", "NVDA/Chrome or Firefox", "Mobile viewport on constrained broadband"],
+    relatedStandards: ["ii-1", "ii-2", "ii-3", "ii-4", "ii-5"],
+    confidence: "moderate",
+    sourceIds: ["wcag-em", "uswds"],
+  },
+  {
+    id: "critical-finding",
+    term: "Critical finding",
+    definition: "A verified defect that enables severe unauthorized impact, blocks a critical workflow, exposes High-risk data, creates a safety risk, or makes a covered service inaccessible without a timely equivalent path.",
+    decisionRule: "Classify by demonstrated or credible impact, not by tool severity alone; a finding remains critical until the affected path is prevented, remediated, or formally taken out of service.",
+    examples: ["Authorization bypass", "Credential exposure", "Inaccessible registration submission", "Unrecoverable data corruption"],
+    relatedStandards: ["i-4", "i-7", "ii-3", "ii-8"],
+    confidence: "moderate",
+    sourceIds: ["nist-ssdf", "owasp-asvs", "ada-title-ii-web"],
+  },
+] as const;
+
+export const ASSURANCE_LEVELS: readonly AssuranceLevel[] = [
+  {
+    level: 1,
+    label: "Essential",
+    defaultUse: "Public, low-risk, non-transactional applications with no sensitive University data, privileged roles, or high-consequence actions.",
+    minimumEvidence: ["Assurance profile", "Architecture/attack-surface sketch", "ASVS 5.0.0 Level 1 results", "Dependency and vulnerability results"],
+    verification: "Team verification with independent review of any failed or excluded requirement.",
+  },
+  {
+    level: 2,
+    label: "Standard production",
+    defaultUse: "Most production applications, including authenticated services, business workflows, external integrations, and systems processing Moderate-risk data.",
+    minimumEvidence: ["Assurance profile", "Lightweight threat model", "ASVS 5.0.0 Level 2 results", "Authorization and integration tests", "Finding dispositions"],
+    verification: "Independent technical review; security participation for Moderate-risk data or consequential actions.",
+  },
+  {
+    level: 3,
+    label: "High assurance",
+    defaultUse: "Systems with High-risk data, high-consequence actions, safety or regulatory impact, institution-wide blast radius, or unusually demanding availability or adversary assumptions.",
+    minimumEvidence: ["Approved assurance profile", "Detailed threat model", "ASVS 5.0.0 Level 3 results", "Independent security assessment", "Residual-risk acceptance", "Recovery exercise"],
+    verification: "Independent security assessment and named risk-owner approval before production and after material change.",
+  },
+] as const;
+
+export const ASSURANCE_DIMENSIONS: readonly AssuranceDimension[] = [
+  {
+    id: "data",
+    label: "Data classification",
+    question: "What is the highest University data classification stored, processed, generated, or accessible?",
+    level2Trigger: "Moderate-risk data or credentials providing access to it.",
+    level3Trigger: "High-risk data, regulated data requiring heightened assurance, or bulk access with severe disclosure impact.",
+  },
+  {
+    id: "actions",
+    label: "Protected actions",
+    question: "What decisions or state changes can a user, administrator, integration, or automated process perform?",
+    level2Trigger: "Any protected action affecting another person, institutional record, access, or money.",
+    level3Trigger: "Any high-consequence action or bulk protected action.",
+  },
+  {
+    id: "exposure",
+    label: "Exposure and adversaries",
+    question: "Who can reach the service and what attacker capability is credible?",
+    level2Trigger: "Internet exposure, external identities, vendor access, or untrusted file/data input.",
+    level3Trigger: "Public high-value target, sophisticated adversary, or exposure of privileged administrative functions.",
+  },
+  {
+    id: "privilege",
+    label: "Identity and privilege",
+    question: "What roles exist and what is the maximum authority of one identity or service account?",
+    level2Trigger: "Authenticated users, delegated administration, or service-to-service credentials.",
+    level3Trigger: "Institution-wide privilege, security administration, identity provisioning, or ability to override separation of duties.",
+  },
+  {
+    id: "reach",
+    label: "Scale and blast radius",
+    question: "How many people, records, units, or dependent systems could one failure affect?",
+    level2Trigger: "A college/division, 500 or more people or records, or multiple dependent systems.",
+    level3Trigger: "Institution-wide population, 10,000 or more records, or cascading impact across critical services.",
+  },
+  {
+    id: "availability",
+    label: "Availability and recovery",
+    question: "What happens when the service is unavailable, incorrect, or unrecoverable?",
+    level2Trigger: "Material operational delay or maximum tolerable outage below three business days.",
+    level3Trigger: "Critical service, safety impact, irreversible deadline, or maximum tolerable outage below one business day.",
+  },
+  {
+    id: "obligation",
+    label: "External obligation",
+    question: "What legal, contractual, grant, accreditation, or research obligation applies?",
+    level2Trigger: "Documented compliance or contractual security/accessibility obligation.",
+    level3Trigger: "Obligation requiring independent assurance, severe breach reporting, or material institutional liability.",
+  },
+] as const;
+
+export const THREAT_MODEL_SECTIONS: readonly TemplateSection[] = [
+  { id: "purpose", label: "Purpose and decision scope", prompt: "What does the system do, what release or decision does this model support, and what is explicitly out of scope?", acceptableEvidence: "One-paragraph purpose, assessed version, environment, owner, and out-of-scope list." },
+  { id: "diagram", label: "System and data flows", prompt: "Where do users, services, vendors, data stores, models, and external systems exchange data?", acceptableEvidence: "Current architecture/data-flow diagram with trust boundaries, protocols, and data classifications." },
+  { id: "assets", label: "Assets and protected actions", prompt: "What information, functions, credentials, decisions, or institutional capabilities require protection?", acceptableEvidence: "Prioritized asset and protected-action inventory tied to accountable owners." },
+  { id: "actors", label: "Actors and capabilities", prompt: "Who uses, administers, integrates with, or may attack the system, and what access or capability can each possess?", acceptableEvidence: "User/role list plus plausible internal, external, vendor, and automated threat actors." },
+  { id: "boundaries", label: "Trust boundaries and entry points", prompt: "Where does trust, identity, administration, code, or data cross between differently controlled environments?", acceptableEvidence: "Annotated boundaries and entry points, including APIs, uploads, prompts, webhooks, admin tools, and support access." },
+  { id: "abuse", label: "Misuse and abuse cases", prompt: "How could an actor misuse a protected action, bypass a rule, manipulate data, exhaust a resource, or create harmful output?", acceptableEvidence: "Concrete abuse cases written as actor, action, target, and consequence." },
+  { id: "controls", label: "Controls and verification", prompt: "What prevents, detects, contains, or recovers from each plausible threat, and how will it be tested?", acceptableEvidence: "Threat-to-control-to-test mapping with ASVS identifiers where applicable." },
+  { id: "residual", label: "Residual risk and decisions", prompt: "What remains possible after controls, who owns that risk, and what disposition was approved?", acceptableEvidence: "Residual-risk statement, likelihood/impact rationale, treatment, owner, approval, and expiry if accepted." },
+  { id: "review", label: "Review and change triggers", prompt: "When must this model be revisited?", acceptableEvidence: "Named reviewer and triggers including material change, incident, new threat, failed control, and scheduled annual review for Levels 2–3." },
+] as const;
+
+export const EVIDENCE_ARTIFACTS: readonly EvidenceArtifact[] = [
+  { id: "assurance-profile", name: "Application Assurance Profile", purpose: "Selects the minimum assurance level through explicit, non-averaged triggers.", minimumContents: ["System and owner", "Seven dimension decisions", "Highest trigger", "Selected level", "Reviewer and date"], freshness: "Before production and after material change", relatedStandards: ["i-4"] },
+  { id: "threat-model", name: "Threat Model", purpose: "Connects architecture and plausible abuse to controls, tests, and residual-risk ownership.", minimumContents: THREAT_MODEL_SECTIONS.map((section) => section.label), freshness: "Current release; Level 2–3 annual review", relatedStandards: ["i-1", "i-4", "i-7", "i-9"] },
+  { id: "architecture-record", name: "Architecture and Data-Flow Record", purpose: "Shows components, integrations, trust boundaries, data stores, classifications, protocols, and owners.", minimumContents: ["Context diagram", "Data flows", "Trust boundaries", "Data classification", "Version and owner"], freshness: "After material architecture or data-use change", relatedStandards: ["i-1", "i-3", "i-5", "i-6"] },
+  { id: "control-profile", name: "Control Applicability Profile", purpose: "Records which versioned controls apply and why any control is excluded or replaced.", minimumContents: ["Framework and version", "Requirement identifier", "Applicability", "Evidence link", "Result", "Disposition"], freshness: "Each material release", relatedStandards: ["i-4"] },
+  { id: "accessibility-report", name: "Accessibility Conformance Report", purpose: "Records WCAG scope, sample, manual and automated methods, findings, and conformance conclusion.", minimumContents: ["WCAG version/level", "Scope and sample", "Evaluator", "Methods", "Criterion results", "Critical-process results", "Open findings"], freshness: "Before launch, after material change, and annually", relatedStandards: ["ii-2", "ii-3", "ii-4"] },
+  { id: "usability-report", name: "Critical-Task Usability Report", purpose: "Shows whether representative users can complete the tasks that matter.", minimumContents: ["Participants and coverage", "Tasks", "Measures and thresholds", "Observations", "Findings", "Decisions and retest"], freshness: "Each material workflow release", relatedStandards: ["ii-4", "ii-7", "ii-8"] },
+  { id: "performance-report", name: "Production Performance Report", purpose: "Provides field measurements for user experience and service objectives.", minimumContents: ["Measured population", "Period", "p75 Core Web Vitals", "Critical transaction SLOs", "Coverage gaps", "Owner and actions"], freshness: "Rolling 28 days; monthly review", relatedStandards: ["i-10", "ii-5"] },
+  { id: "exception-record", name: "Standards Exception Record", purpose: "Makes deviations time-bounded, owned, compensating, and reviewable.", minimumContents: ["Requirement", "Scope", "Reason", "Risk", "Compensating controls", "Evidence", "Owner", "Approver", "Expiry", "Exit plan"], freshness: "Until expiry; review after material change", relatedStandards: ["i-8", "ii-10"] },
+  { id: "evidence-index", name: "Evidence Index", purpose: "Gives an assessor one durable map from requirements to current evidence.", minimumContents: ["Requirement ID", "Artifact", "Version/environment", "Produced date", "Freshness date", "Owner", "Result"], freshness: "Each assessment and material release", relatedStandards: ["i-8", "ii-10"] },
+] as const;
+
+export const PROVISIONAL_DEFAULT_PROCESS: readonly ProvisionalDefaultStep[] = [
+  { step: 1, label: "State the decision", requirement: "Name the concrete behavior, threshold, or definition that must be supplied." },
+  { step: 2, label: "Trace the evidence", requirement: "Record the strongest applicable sources and distinguish binding, consensus, sector, and implementation guidance." },
+  { step: 3, label: "Reason from harm", requirement: "Describe the adverse outcome, affected people or mission, likelihood assumptions, reversibility, and operational burden." },
+  { step: 4, label: "Publish a default", requirement: "Choose the simplest conservative rule that is measurable and feasible; identify alternatives considered." },
+  { step: 5, label: "Declare confidence", requirement: "Mark the default High, Moderate, or Experimental and explain the uncertainty." },
+  { step: 6, label: "Set calibration", requirement: "Name the evidence, pilot result, incident, cost, or institutional decision that would trigger revision." },
+] as const;
+
+export const FOUNDATION_TEMPLATE_LINKS = [
+  { href: "/templates/application-assurance-profile.md", label: "Application Assurance Profile", file: "public/templates/application-assurance-profile.md" },
+  { href: "/templates/threat-model.md", label: "Threat Model", file: "public/templates/threat-model.md" },
+  { href: "/templates/standards-exception.md", label: "Standards Exception", file: "public/templates/standards-exception.md" },
+  { href: "/templates/evidence-index.md", label: "Evidence Index", file: "public/templates/evidence-index.md" },
+] as const;
+
+export function foundationSummary() {
+  return {
+    definitions: FOUNDATION_DEFINITIONS.length,
+    assuranceDimensions: ASSURANCE_DIMENSIONS.length,
+    threatModelSections: THREAT_MODEL_SECTIONS.length,
+    evidenceArtifacts: EVIDENCE_ARTIFACTS.length,
+    templates: FOUNDATION_TEMPLATE_LINKS.length,
+  };
+}
+
+export function validateStandardsFoundation(sourceIds: ReadonlySet<string>): string[] {
+  const errors: string[] = [];
+  const definitionIds = new Set<string>();
+  const artifactIds = new Set<string>();
+
+  for (const definition of FOUNDATION_DEFINITIONS) {
+    if (definitionIds.has(definition.id)) errors.push(`Duplicate foundation definition ${definition.id}`);
+    definitionIds.add(definition.id);
+    if (definition.relatedStandards.length === 0) errors.push(`Definition ${definition.id} has no related standards`);
+    for (const sourceId of definition.sourceIds) {
+      if (!sourceIds.has(sourceId)) errors.push(`Definition ${definition.id} references unknown source ${sourceId}`);
+    }
+  }
+
+  for (const artifact of EVIDENCE_ARTIFACTS) {
+    if (artifactIds.has(artifact.id)) errors.push(`Duplicate evidence artifact ${artifact.id}`);
+    artifactIds.add(artifact.id);
+    if (artifact.minimumContents.length === 0) errors.push(`Evidence artifact ${artifact.id} has no minimum contents`);
+  }
+
+  if (ASSURANCE_LEVELS.length !== 3) errors.push("Foundation must define three assurance levels");
+  if (ASSURANCE_DIMENSIONS.length === 0) errors.push("Foundation has no assurance dimensions");
+  if (THREAT_MODEL_SECTIONS.length === 0) errors.push("Foundation has no threat-model sections");
+
+  return errors;
+}

--- a/lib/standards-watch.ts
+++ b/lib/standards-watch.ts
@@ -262,8 +262,8 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Keyboard navigation: full operability without a mouse (2.1.1); no keyboard traps (2.1.2); visible focus indicator on every interactive element (2.4.7); skip-to-content link on pages with repetitive navigation (2.4.1).",
       "Text alternatives for non-text content (1.1.1); captions for prerecorded media (1.2.2); resize text up to 200% without loss of content or functionality (1.4.4); reflow at 320 CSS px without horizontal scroll (1.4.10).",
       "ARIA usage: semantic HTML first; ARIA only when no native element conveys the same semantics. Name / role / value correct on custom widgets (4.1.2). Status messages programmatically determinable (4.1.3).",
-      "Reduced motion: respect prefers-reduced-motion (3.3.1 / WCAG 2.2 candidate) for any animation triggered by interaction or page load.",
-      "Testing: automated tooling (axe-core, Lighthouse, pa11y) catches roughly 30% of WCAG criteria. Manual review is required for the remainder — keyboard walkthrough, screen-reader pass (NVDA on Windows, VoiceOver on macOS/iOS), contrast spot-check, reduced-motion check.",
+      "Motion: avoid flashing; provide pause, stop, or hide controls when required; do not require device motion; and, as an institutional implementation practice, respect prefers-reduced-motion for non-essential animation.",
+      "Testing: automated tooling (axe-core, Lighthouse, pa11y) covers only a subset of WCAG criteria. Manual review is also required — keyboard walkthrough, screen-reader pass (NVDA on Windows, VoiceOver on macOS/iOS), contrast spot-check, zoom/reflow, and reduced-motion check.",
     ],
     links: [
       {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "migrate": "tsx --env-file=.env.local scripts/migrate.ts",
     "seed:portfolio": "tsx --env-file=.env.local scripts/seed-portfolio.ts",
     "verify:portfolio": "tsx scripts/verify-portfolio.ts",
+    "verify:standards": "tsx scripts/validate-standards-drafts.ts",
     "refresh:commit-dates": "tsx scripts/refresh-commit-dates.ts",
     "sync:clickup": "tsx --env-file=.env.local scripts/sync-clickup.ts",
     "eval:agent": "NODE_OPTIONS='--conditions=react-server' tsx --env-file=.env.local --tsconfig tsconfig.json evals/agent/run.ts"

--- a/public/templates/application-assurance-profile.md
+++ b/public/templates/application-assurance-profile.md
@@ -1,0 +1,72 @@
+# Application Assurance Profile
+
+Status: Proposed working instrument — not yet University policy
+
+## 1. System and decision
+
+- System/service:
+- Assessed version and environment:
+- Business owner:
+- Technical owner:
+- Data Owner or Steward:
+- Assessor:
+- Assessment date:
+- Decision supported: design approval / production approval / material change / reassessment
+
+## 2. Assurance dimensions
+
+For every dimension, record the facts, evidence, and highest triggered level. Do not average levels; the highest applicable trigger determines the minimum assurance level.
+
+| Dimension | Facts and evidence | Level 1 | Level 2 trigger | Level 3 trigger | Result |
+|---|---|---|---|---|---|
+| Data classification | | Low or public only | Moderate-risk data or credentials | High-risk data or severe bulk exposure | |
+| Protected actions | | No protected action | Protected action affecting another person, record, access, or money | High-consequence or bulk action | |
+| Exposure/adversaries | | Limited, low-value exposure | Internet, external identity, vendor, or untrusted input | High-value public target or privileged surface | |
+| Identity/privilege | | No accounts or ordinary low-risk access | Authentication, delegation, or service credentials | Institution-wide/security privilege or separation-of-duty override | |
+| Scale/blast radius | | Small contained population | College/division, 500+ people/records, or multiple dependencies | Institution-wide, 10,000+ records, or critical-service cascade | |
+| Availability/recovery | | Limited tolerable disruption | Material delay or outage tolerance under three business days | Critical service, irreversible deadline, safety impact, or outage tolerance under one day | |
+| External obligation | | No special obligation | Contractual, grant, accessibility, or compliance obligation | Independent assurance, severe reporting, or material liability | |
+
+## 3. Selected level
+
+- Highest triggered level:
+- Selected OWASP ASVS version: 5.0.0
+- Selected level: 1 / 2 / 3
+- Rationale:
+- Any higher voluntary target:
+- Any disputed trigger:
+
+## 4. Required evidence
+
+### Level 1
+
+- Architecture/attack-surface sketch
+- ASVS 5.0.0 Level 1 control results
+- Dependency, vulnerability, and secret-scan results
+
+### Level 2
+
+- All Level 1 evidence
+- Lightweight threat model
+- ASVS 5.0.0 Level 2 control results
+- Authorization and integration tests
+- Finding dispositions
+
+### Level 3
+
+- All Level 2 evidence
+- Detailed independently reviewed threat model
+- ASVS 5.0.0 Level 3 control results
+- Independent security assessment
+- Residual-risk acceptance
+- Recovery exercise
+
+## 5. Review and approval
+
+- Reviewer:
+- Review result: accepted / changes required / exception required
+- Conditions:
+- Approval authority:
+- Approval date:
+- Next review date:
+- Material-change triggers that require reassessment:

--- a/public/templates/evidence-index.md
+++ b/public/templates/evidence-index.md
@@ -1,0 +1,40 @@
+# Standards Evidence Index
+
+Status: Proposed working instrument — not yet University policy
+
+## Assessment
+
+- System/service:
+- Assessed version and environment:
+- Assessment type:
+- Assurance level:
+- Assessor:
+- Assessment date:
+- Business and technical owners:
+
+## Evidence register
+
+| Requirement ID | Result | Artifact/evidence | Version or environment | Produced | Fresh through | Evidence owner | Finding or exception |
+|---|---|---|---|---|---|---|---|
+| | Met / Partially met / Not met / Not applicable / Not assessed | | | | | | |
+
+## Result rules
+
+- **Met:** current evidence demonstrates every part of the requirement.
+- **Partially met:** evidence demonstrates only part of the requirement; record the exact gap and remediation date.
+- **Not met:** evidence demonstrates failure or the required practice is absent.
+- **Not applicable:** a named assessor approved a documented applicability rationale.
+- **Not assessed:** no current conclusion is supportable.
+
+Critical gates cannot be averaged away. A critical Not met or Not assessed result makes the assessed scope nonconforming unless an authorized, current exception explicitly permits operation.
+
+## Assessment conclusion
+
+- Critical gates:
+- Non-critical requirements:
+- Open findings:
+- Open exceptions:
+- Overall conclusion:
+- Required remediation and dates:
+- Approver:
+- Next assessment trigger/date:

--- a/public/templates/standards-exception.md
+++ b/public/templates/standards-exception.md
@@ -1,0 +1,61 @@
+# Standards Exception Record
+
+Status: Proposed working instrument — not yet University policy
+
+## Request
+
+- System/service:
+- Requirement ID and version:
+- Requested by:
+- Business owner:
+- Technical owner:
+- Risk owner:
+- Date requested:
+- Requested expiration date:
+
+## Scope
+
+Describe the exact systems, environments, users, data, workflows, and time period covered. An exception must not silently apply to future systems or releases.
+
+## Reason the requirement cannot be met
+
+Describe the technical, operational, contractual, accessibility, or timing constraint. Cost or inconvenience alone does not establish equivalence.
+
+## Risk
+
+- Threat or failure scenario:
+- Affected people, data, service, or mission:
+- Likelihood rationale:
+- Impact and reversibility:
+- Data classification:
+- Critical workflow/service impact:
+
+## Compensating controls
+
+| Control | How it addresses the same objective | Evidence/test | Owner | Review frequency |
+|---|---|---|---|---|
+| | | | | |
+
+## Alternatives considered
+
+| Alternative | Why it was not selected | Remaining option or trigger to revisit |
+|---|---|---|
+| | | |
+
+## Exit plan
+
+- Remediation or replacement:
+- Milestones:
+- Funded/assigned owner:
+- Target completion:
+- Closure evidence:
+
+## Decision
+
+- Decision: approved / denied / changes required
+- Conditions:
+- Approver and authority:
+- Decision date:
+- Expiration date:
+- Next review date:
+- Related decision/risk records:

--- a/public/templates/threat-model.md
+++ b/public/templates/threat-model.md
@@ -1,0 +1,80 @@
+# Threat Model
+
+Status: Proposed working instrument — not yet University policy
+
+## Document control
+
+- System/service:
+- Assessed release and environment:
+- Assurance level:
+- Business owner:
+- Technical owner:
+- Risk owner:
+- Authors/reviewers:
+- Date and next review:
+
+## 1. Purpose and decision scope
+
+Describe what the system does, the release or decision this model supports, and what is explicitly out of scope.
+
+## 2. System and data flows
+
+Attach or link a current diagram showing:
+
+- Users and administrators
+- Application and infrastructure components
+- Data stores and classifications
+- External systems and vendors
+- APIs, webhooks, uploads, models, and support access
+- Protocols and authentication
+- Trust boundaries
+
+## 3. Assets and protected actions
+
+| Asset or protected action | Why it matters | Classification/consequence | Accountable owner |
+|---|---|---|---|
+| | | | |
+
+## 4. Actors and capabilities
+
+| Actor | Legitimate access | Plausible malicious/error capability | Goal or adverse outcome |
+|---|---|---|---|
+| | | | |
+
+Include users, administrators, vendors, integrations, insiders, external attackers, and automated processes where applicable.
+
+## 5. Trust boundaries and entry points
+
+| Boundary or entry point | Data/action crossing it | Existing trust assumption | How the assumption is verified |
+|---|---|---|---|
+| | | | |
+
+## 6. Misuse and abuse cases
+
+Write concrete cases as: actor + action + target + adverse consequence.
+
+| ID | Abuse case | Preconditions | Consequence |
+|---|---|---|---|
+| TM-01 | | | |
+
+## 7. Controls and verification
+
+| Threat ID | Preventive/detective/recovery control | ASVS or standard reference | Test/evidence | Owner | Result |
+|---|---|---|---|---|---|
+| TM-01 | | | | | |
+
+## 8. Residual risk and decisions
+
+| Threat ID | Residual risk after controls | Likelihood/impact rationale | Disposition | Risk owner | Approval/expiry |
+|---|---|---|---|---|---|
+| | | | mitigate / accept / transfer / avoid | | |
+
+## 9. Review triggers
+
+Review after:
+
+- A material architecture, data-use, identity, vendor, model, integration, or protected-action change
+- A security or privacy incident
+- A new credible threat or failed control
+- A material change in applicable requirements
+- At least annually for Assurance Levels 2 and 3

--- a/scripts/validate-standards-drafts.ts
+++ b/scripts/validate-standards-drafts.ts
@@ -1,0 +1,67 @@
+import { standardsWatch } from "../lib/standards-watch";
+import { existsSync } from "node:fs";
+import {
+  STANDARD_DRAFTS,
+  STANDARDS_SOURCES,
+  draftSummary,
+  validateStandardsDrafts,
+} from "../lib/standards-drafts";
+import {
+  FOUNDATION_TEMPLATE_LINKS,
+  foundationSummary,
+  validateStandardsFoundation,
+} from "../lib/standards-foundation";
+
+const errors = validateStandardsDrafts(
+  standardsWatch.map((standard) => standard.id),
+);
+errors.push(
+  ...validateStandardsFoundation(
+    new Set(STANDARDS_SOURCES.map((source) => source.id)),
+  ),
+);
+
+for (const source of STANDARDS_SOURCES) {
+  if (!source.href.startsWith("https://")) {
+    errors.push(`Source ${source.id} does not use HTTPS`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(source.checkedOn)) {
+    errors.push(`Source ${source.id} has an invalid checkedOn date`);
+  }
+}
+
+for (const draft of STANDARD_DRAFTS) {
+  if (draft.localDecisions.length === 0) {
+    errors.push(`Draft ${draft.standardId} has no local decisions`);
+  }
+  if (!draft.assessment.conformanceRule) {
+    errors.push(`Draft ${draft.standardId} has no conformance rule`);
+  }
+  for (const requirement of draft.requirements) {
+    if (!requirement.id.startsWith(draft.standardId.toUpperCase().replace("-", ""))) {
+      errors.push(
+        `Requirement ${requirement.id} does not match draft ${draft.standardId}`,
+      );
+    }
+    if (!requirement.statement.includes(" shall ")) {
+      errors.push(`Requirement ${requirement.id} is not a shall statement`);
+    }
+  }
+}
+
+for (const template of FOUNDATION_TEMPLATE_LINKS) {
+  if (!existsSync(template.file)) {
+    errors.push(`Foundation template is missing: ${template.file}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+const summary = draftSummary();
+const foundation = foundationSummary();
+console.log(
+  `Validated ${summary.drafts} drafts, ${summary.requirements} requirements (${summary.criticalRequirements} critical), ${summary.sources} draft sources, ${foundation.definitions} definitions, ${foundation.evidenceArtifacts} evidence artifacts, and ${foundation.templates} templates.`,
+);


### PR DESCRIPTION
## Summary

- add measurable working drafts for all 20 standards categories: 80 atomic requirements, 35 critical gates, evidence expectations, assessment methods, rationales, exceptions, and source provenance
- add a Standards Foundation with an evidence hierarchy, 13 controlled definitions, seven application-assurance dimensions, threat-model guidance, and nine defined evidence artifacts
- add downloadable templates for the Application Assurance Profile, threat model, standards exception, and evidence index
- cross-link standards to their controlled definitions and add an integrity validator
- correct the existing WCAG reduced-motion language so institutional implementation practice is not presented as a WCAG success criterion

## Purpose and boundary

This is a **working reference and reference implementation**, not University or OIT policy. The interface states that distinction prominently.

The PR demonstrates what transparent, evidence-based, measurable standards can look like: requirement + justification + acceptable evidence + assessment method + exception path. Published sources support the proposals, while unresolved local choices remain visibly identified as calibration items. Only a named University authority can adopt, revise, or reject those choices.

This PR is intended to support a governance decision about the model and an owner-led pilot. It does not assign IIDS authority to establish or maintain institutional IT policy.

## User impact

Reviewers can explore the complete draft from `/standards`, follow contextual terms into `/standards/foundation`, and download reusable assessment instruments instead of beginning with blank documents or undocumented institutional knowledge.

## Validation

- `npm run verify:standards`
- `npx tsc --noEmit`
- targeted ESLint for all changed TypeScript/TSX files
- `npm run build`
- desktop and mobile browser QA, including page-level overflow and glossary cross-links
