### PR TITLE
Make the ROI ledger kind-discriminated; record Ben's VandalChat case

### DIFF
--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -235,7 +235,12 @@ resolved_at      DATE
         origin (<code>tdx</code> | <code>clickup</code> |{" "}
         <code>site-submission</code> | <code>direct</code>), with an append-only
         event trail, a request↔request and request↔project link graph, and an
-        ROI claims ledger. Backs <code>/portfolio/pipeline</code>, the single
+        ROI claims ledger. Since Migration 021 the ledger is
+        kind-discriminated: quantified claims carry numbers justified in{" "}
+        <code>basis</code>; qualitative claims carry no numbers and must cite
+        verbatim <code>evidence</code> instead (read through{" "}
+        <code>lib/roi-claims.ts</code>, which keeps qualitative rows out of
+        sums). Backs <code>/portfolio/pipeline</code>, the single
         all-origin request queue.
       </p>
       <p>

--- a/db/migrations/021_qualitative_roi_claims.sql
+++ b/db/migrations/021_qualitative_roi_claims.sql
@@ -1,0 +1,79 @@
+-- Migration 021: qualitative ROI claims — kind-discriminated ledger.
+--
+-- roi_claims (Migration 018) required every claim to carry a number
+-- (annual_value_usd or fte), which made narrative-only ROI cases —
+-- like Ben Hunter's five-part VandalChat justification — unrecordable.
+-- This migration keeps ONE ledger and discriminates by kind instead of
+-- adding a parallel "impact narratives" table.
+--
+-- Vocabulary posture: `claim_kind` is structural — it changes what
+-- integrity means for the row — so it carries a CHECK, mirroring
+-- tech_requests.origin. The kind-shape constraint is deliberately
+-- two-sided: a qualitative claim may NOT carry numbers (if you can put
+-- a number on it, it's quantified — no half-quantified rows), and
+-- where a quantified claim's honesty lives in `basis`, a qualitative
+-- claim's honesty lives in `evidence` (verbatim quotes, document
+-- paths), so evidence is mandatory for that kind.
+--
+-- Promotion path: when a qualitative claim gains real numbers, the row
+-- flips kind and gains values in one UPDATE — the updated_at trigger
+-- dates the promotion. No supersession machinery.
+--
+-- Aggregation guard: anything summing the ledger must filter
+-- claim_kind = 'quantified' explicitly (lib/roi-claims.ts is the read
+-- seam). The portfolio bottom-line number is unaffected — it derives
+-- from lib/portfolio.ts replacement facts, not this table.
+
+BEGIN;
+
+ALTER TABLE roi_claims
+  ADD COLUMN IF NOT EXISTS claim_kind TEXT NOT NULL DEFAULT 'quantified';
+ALTER TABLE roi_claims
+  ADD COLUMN IF NOT EXISTS evidence TEXT;
+
+DO $$
+DECLARE
+  numbers_check TEXT;
+BEGIN
+  -- Structural CHECK on claim_kind (named, so later migrations can
+  -- evolve it deliberately).
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'roi_claims'::regclass AND conname = 'roi_claims_claim_kind'
+  ) THEN
+    ALTER TABLE roi_claims ADD CONSTRAINT roi_claims_claim_kind
+      CHECK (claim_kind IN ('quantified', 'qualitative'));
+  END IF;
+
+  -- Drop 018's numbers-required check. It was created inline and
+  -- auto-named, so find it by definition: it is the only check besides
+  -- the ones this migration names that mentions annual_value_usd
+  -- (the subject-XOR check mentions only application_slug/request_id).
+  SELECT conname INTO numbers_check
+  FROM pg_constraint
+  WHERE conrelid = 'roi_claims'::regclass
+    AND contype = 'c'
+    AND conname NOT IN ('roi_claims_claim_kind', 'roi_claims_kind_shape')
+    AND pg_get_constraintdef(oid) ILIKE '%annual_value_usd%';
+  IF numbers_check IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE roi_claims DROP CONSTRAINT %I', numbers_check);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'roi_claims'::regclass AND conname = 'roi_claims_kind_shape'
+  ) THEN
+    ALTER TABLE roi_claims ADD CONSTRAINT roi_claims_kind_shape CHECK (
+      (claim_kind = 'quantified'
+        AND (annual_value_usd IS NOT NULL OR fte IS NOT NULL))
+      OR
+      (claim_kind = 'qualitative'
+        AND annual_value_usd IS NULL AND fte IS NULL AND evidence IS NOT NULL)
+    );
+  END IF;
+END $$;
+
+INSERT INTO schema_migrations (version) VALUES ('021_qualitative_roi_claims')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/db/migrations/022_vandalchat_roi_claims.sql
+++ b/db/migrations/022_vandalchat_roi_claims.sql
@@ -1,0 +1,66 @@
+-- Migration 022: record Ben Hunter's qualitative ROI case for the
+-- VandalChat request (Migration 020) as five kind-discriminated
+-- roi_claims rows (Migration 021).
+--
+-- Source: Hunter's ROI/impact justification from the "MindRouter vs.
+-- boisestate.ai" thread (2026-07-30) as cleaned up and delivered
+-- 2026-08-03, with verbatim Operational Excellence survey responses as
+-- evidence — the assignment Robison's 2026-07-31 email gave him.
+-- Dimensions come from lib/utr.ts; `strategic-enablement` lands there
+-- alongside this migration.
+--
+-- Ordering: depends on the VandalChat registry row from Migration 020.
+-- Lexicographic application order guarantees 020 runs first in any
+-- single migration batch; the exception below only fires if this file
+-- somehow reaches a database that never applied 020 — loud beats a
+-- silent forever-skip, because the runner records this migration as
+-- applied either way.
+
+DO $mig$
+DECLARE
+  rid UUID;
+BEGIN
+
+SELECT id INTO rid FROM tech_requests
+WHERE origin = 'direct' AND title = 'VandalChat — campus-wide AI chat on MindRouter';
+
+IF rid IS NULL THEN
+  RAISE EXCEPTION 'Migration 022 requires the VandalChat request from Migration 020 — apply 020 first.';
+END IF;
+
+IF NOT EXISTS (
+  SELECT 1 FROM roi_claims WHERE request_id = rid AND claim_kind = 'qualitative'
+) THEN
+
+  INSERT INTO roi_claims
+    (request_id, claim_kind, dimension, basis, evidence, source, status, claimed_by, claimed_at)
+  VALUES
+  (rid, 'qualitative', 'cost-avoidance',
+    $t$Adoption yield on the fall marketing spend. The awareness push drives the whole campus at MindRouter at once; most arrivals will expect a chat box, and without one they read MindRouter as a complicated tool "not for them" and don't come back. First impressions are non-renewable — losing them means paying the acquisition cost twice.$t$,
+    $t$Operational Excellence survey, on the Inside U of I rollout: "It's one thing to handle the technical aspects of rolling out a web platform. It's another to provide the needs discovery, training, communication and post-launch adjustments to support your population through the adoption of that platform."$t$,
+    'owner-attested', 'attested', 'Ben Hunter', '2026-08-03'),
+
+  (rid, 'qualitative', 'cost-avoidance',
+    $t$License cost avoidance. Every user who lands on MindRouter is a user not requesting an individual frontier-model seat. Staff are already paying out of pocket and out of grants — uncontrolled spend the university absorbs anyway, just less visibly.$t$,
+    $t$Operational Excellence survey: "I think premium plans to chat GPT and Gemini could be of great value to us. I use these all the time, but I have to find grants or other sources to pay for this type of program."$t$,
+    'owner-attested', 'attested', 'Ben Hunter', '2026-08-03'),
+
+  (rid, 'qualitative', 'risk-reduction',
+    $t$Data retention on our own network. Staff handle university data (Banner, Slate, grants, student records) as the core of their work; novice-friendly access is what keeps that work inside the perimeter instead of pasted into a free consumer tier. The highest-leverage risk reduction in the proposal — and it only works if the tool is easy enough that people don't route around it.$t$,
+    $t$Ben Hunter, 2026-07-30 thread: "More than any other group on campus, our staff are dealing with university data as a core part of their work. Making MindRouter approachable and usable to novice users keeps that much more data within our network."$t$,
+    'owner-attested', 'attested', 'Ben Hunter', '2026-08-03'),
+
+  (rid, 'qualitative', 'strategic-enablement',
+    $t$Makes broad staff training possible at all. Senior leadership wants staff AI training, and a broad-based curriculum requires a common, accessible interface — it can't be built on free tiers or on tools people buy individually.$t$,
+    $t$Operational Excellence survey: "I would love it if the UofI created a position to give training and 'office hours' for admin and finance people to help in ways AI may be used to make our jobs easier, and what are the regulations regarding AI."$t$,
+    'owner-attested', 'attested', 'Ben Hunter', '2026-08-03'),
+
+  (rid, 'qualitative', 'strategic-enablement',
+    $t$A real answer to the recurring campus-license question. "When is the university going to provide ChatGPT/Claude/Gemini to everyone?" currently gets answered with "we can't afford it"; VandalChat on MindRouter is a credible institutional answer.$t$,
+    $t$Operational Excellence survey: "the dearth of options for AI... their whole strategy on AI appears muddled. Most universities now have signed up for ChatGPT.edu."$t$,
+    'owner-attested', 'attested', 'Ben Hunter', '2026-08-03');
+
+END IF;
+
+END
+$mig$;

--- a/lib/roi-claims.ts
+++ b/lib/roi-claims.ts
@@ -1,0 +1,142 @@
+// lib/roi-claims.ts
+//
+// Postgres read module for the ROI claims ledger (roi_claims,
+// Migrations 018 + 021). Mirrors the lib/requests.ts pattern: typed
+// rows out, SQL in one place, callers never touch the pool directly.
+//
+// The ledger is kind-discriminated (Migration 021): quantified claims
+// carry numbers whose honesty lives in `basis`; qualitative claims
+// carry no numbers and their honesty lives in `evidence` (verbatim
+// quotes, document paths). The discriminated union below makes every
+// renderer handle both — tsc enforces it.
+//
+// Aggregation guard: only quantified claims may enter a sum. Callers
+// never filter by hand; sumQuantified() is the one blessed reducer.
+
+import { query } from "./db";
+import { type RoiClaimKind } from "./utr";
+
+interface RoiClaimBase {
+  id: string;
+  /** Exactly one subject: a portfolio project (soft slug) or a request. */
+  applicationSlug: string | null;
+  requestId: string | null;
+  /** Dimension slug from lib/utr.ts — render via roiDimensionLabel(),
+   *  which falls back to the raw slug for vocabulary drift. */
+  dimension: string;
+  /** Plain-language justification; for qualitative claims, the claim itself. */
+  basis: string;
+  /** clickup-sync | worksheet | triage | cadso-rubric | owner-attested. */
+  source: string;
+  /** estimated | attested | verified | realized. */
+  status: string;
+  effectiveFy: string | null;
+  claimedBy: string | null;
+  /** ISO date (YYYY-MM-DD). */
+  claimedAt: string | null;
+}
+
+export interface QuantifiedRoiClaim extends RoiClaimBase {
+  kind: "quantified";
+  annualValueUsd: number | null;
+  fte: number | null;
+}
+
+export interface QualitativeRoiClaim extends RoiClaimBase {
+  kind: "qualitative";
+  /** Verbatim quotes and document paths — mandatory for this kind. */
+  evidence: string;
+}
+
+export type RoiClaim = QuantifiedRoiClaim | QualitativeRoiClaim;
+
+interface RoiClaimRow {
+  id: string;
+  application_slug: string | null;
+  request_id: string | null;
+  claim_kind: string;
+  dimension: string;
+  // node-postgres returns NUMERIC as string to preserve precision.
+  annual_value_usd: string | null;
+  fte: string | null;
+  basis: string;
+  evidence: string | null;
+  source: string;
+  status: string;
+  effective_fy: string | null;
+  claimed_by: string | null;
+  // node-postgres returns DATE columns as JS Date objects.
+  claimed_at: Date | null;
+}
+
+function toRoiClaim(row: RoiClaimRow): RoiClaim {
+  const base: RoiClaimBase = {
+    id: row.id,
+    applicationSlug: row.application_slug,
+    requestId: row.request_id,
+    dimension: row.dimension,
+    basis: row.basis,
+    source: row.source,
+    status: row.status,
+    effectiveFy: row.effective_fy,
+    claimedBy: row.claimed_by,
+    claimedAt: row.claimed_at ? row.claimed_at.toISOString().slice(0, 10) : null,
+  };
+  // Migration 021's kind-shape constraint guarantees evidence on
+  // qualitative rows; anything else — including an unknown kind slug —
+  // degrades to quantified rather than corrupting the union (same
+  // posture as disposition in lib/requests.ts).
+  if (row.claim_kind === ("qualitative" satisfies RoiClaimKind) && row.evidence !== null) {
+    return { ...base, kind: "qualitative", evidence: row.evidence };
+  }
+  return {
+    ...base,
+    kind: "quantified",
+    annualValueUsd:
+      row.annual_value_usd === null ? null : Number(row.annual_value_usd),
+    fte: row.fte === null ? null : Number(row.fte),
+  };
+}
+
+const CLAIM_COLUMNS = `
+  id, application_slug, request_id, claim_kind, dimension,
+  annual_value_usd, fte, basis, evidence, source, status,
+  effective_fy, claimed_by, claimed_at`;
+
+/**
+ * Claims attached to requests, grouped by request id — the join the
+ * pipeline surface reads alongside listTechRequests(). Within a
+ * request, quantified claims sort before qualitative, then by
+ * dimension, so the numbers lead and the narrative follows.
+ */
+export async function roiClaimsByRequest(): Promise<Map<string, RoiClaim[]>> {
+  const rows = await query<RoiClaimRow>(
+    `SELECT ${CLAIM_COLUMNS}
+     FROM roi_claims
+     WHERE request_id IS NOT NULL
+     ORDER BY request_id, claim_kind DESC, dimension, created_at`
+  );
+  const byRequest = new Map<string, RoiClaim[]>();
+  for (const row of rows) {
+    const claim = toRoiClaim(row);
+    const list = byRequest.get(row.request_id!) ?? [];
+    list.push(claim);
+    byRequest.set(row.request_id!, list);
+  }
+  return byRequest;
+}
+
+/**
+ * Annual USD total across a set of claims. Only quantified claims may
+ * enter a sum — qualitative rows carry no numbers by constraint, and
+ * this is the one place that rule is enforced in code.
+ */
+export function sumQuantified(claims: RoiClaim[]): number {
+  let total = 0;
+  for (const claim of claims) {
+    if (claim.kind === "quantified" && claim.annualValueUsd !== null) {
+      total += claim.annualValueUsd;
+    }
+  }
+  return total;
+}

--- a/lib/utr.ts
+++ b/lib/utr.ts
@@ -195,7 +195,8 @@ export type RoiDimension =
   | "cost-avoidance"
   | "revenue"
   | "risk-reduction"
-  | "time-savings";
+  | "time-savings"
+  | "strategic-enablement";
 
 export const ROI_DIMENSION_LABEL: Record<RoiDimension, string> = {
   "hard-dollar-replacement": "Bottom-line (contract replacement)",
@@ -204,6 +205,30 @@ export const ROI_DIMENSION_LABEL: Record<RoiDimension, string> = {
   revenue: "Revenue",
   "risk-reduction": "Risk reduction",
   "time-savings": "Time savings",
+  "strategic-enablement": "Strategic enablement",
+};
+
+/**
+ * Label for a dimension value read back from the database. The column
+ * carries no CHECK by design, so a row written by a newer vocabulary
+ * than this module falls back to its raw slug rather than crashing the
+ * renderer.
+ */
+export function roiDimensionLabel(value: string): string {
+  return (ROI_DIMENSION_LABEL as Record<string, string>)[value] ?? value;
+}
+
+// Structural (CHECKed in Migration 021): whether a claim carries
+// numbers or narrative + evidence. Qualitative claims may NOT carry
+// numbers — if you can put a number on it, it's quantified — and must
+// carry evidence (verbatim quotes, document paths); a quantified
+// claim's honesty lives in `basis` instead.
+
+export type RoiClaimKind = "quantified" | "qualitative";
+
+export const ROI_CLAIM_KIND_LABEL: Record<RoiClaimKind, string> = {
+  quantified: "Quantified",
+  qualitative: "Qualitative",
 };
 
 export type RoiClaimSource =


### PR DESCRIPTION

## What

**Migration 021 — qualitative ROI claims.** One ledger, discriminated by kind, instead of a parallel "impact narratives" table:

- `claim_kind` (`quantified` | `qualitative`) is structural and CHECKed, mirroring `tech_requests.origin`.
- The 018 numbers-required CHECK is replaced by a **two-sided** kind-shape constraint: quantified claims must carry `annual_value_usd` or `fte`; qualitative claims may **not** carry numbers (if you can put a number on it, it's quantified) and must cite `evidence` — where a quantified claim's honesty lives in `basis`, a qualitative claim's lives in verbatim quotes and document paths.
- Promotion path: a qualitative claim that gains real numbers flips kind in one UPDATE; `updated_at` dates it.

**Vocabulary (`lib/utr.ts`).** `RoiDimension` gains `strategic-enablement`; new `RoiClaimKind` + labels; `roiDimensionLabel()` falls back to the raw slug on vocabulary drift instead of crashing renderers.

**Read seam (`lib/roi-claims.ts`).** `QuantifiedRoiClaim | QualitativeRoiClaim` discriminated union (tsc forces renderers to handle both), `roiClaimsByRequest()` for the pipeline surface, and `sumQuantified()` as the one blessed reducer — narrative rows can never enter a total. The portfolio bottom-line is unaffected either way (it derives from `lib/portfolio.ts` replacement facts).

**Migration 022 — Ben's VandalChat case.** Hunter's five returns (adoption yield, license cost avoidance → `cost-avoidance`; data retention → `risk-reduction`; training enablement, campus-license answer → `strategic-enablement`) as qualitative claims, `owner-attested`/`attested`, each carrying its Operational Excellence survey quote as evidence. Raises loudly if the 020 row is missing rather than being recorded as applied while silently skipping forever.

## Verification

- Throwaway Postgres 16: 018→022 apply in order; 021/022 re-run as no-ops.
- Constraint probes: qualitative-with-number, qualitative-without-evidence, quantified-without-numbers, and unknown-kind all rejected; quantified-with-number still inserts; subject-XOR check untouched; the old auto-named numbers check confirmed dropped.
- 022's ordering guard fires on a database without Migration 020.
- `npm run build` and `npm run verify:portfolio` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
