### PR TITLE
Add Track D (data & report access) per the Aug 2026 UTR revision

### DIFF
--- a/lib/governance-profile.ts
+++ b/lib/governance-profile.ts
@@ -283,6 +283,7 @@ export function governanceCoverage(
     "track-a": 0,
     "track-b": 0,
     "track-c": 0,
+    "track-d": 0,
     external: 0,
   };
   let classificationPending = 0;

--- a/lib/oit-idea.ts
+++ b/lib/oit-idea.ts
@@ -31,6 +31,7 @@ const SUGGESTED_TRACKS: readonly IdeaSuggestedTrack[] = [
   "track-a",
   "track-b",
   "track-c",
+  "track-d",
 ];
 
 export function isIdeaSuggestedTrack(v: unknown): v is IdeaSuggestedTrack {

--- a/lib/utr.ts
+++ b/lib/utr.ts
@@ -7,10 +7,15 @@
 // types. Editing a vocabulary here is the taxonomy change; tsc
 // surfaces every consumer (006/007/008 pattern).
 //
-// Source process: the July 2026 "Unified Technology Request Process"
-// draft (one intake form, three tracks, DATA/AI/BUY flags, two gates).
-// Flag and gate vocabularies land with their tables in ADR 0005
-// Phase 3; this module carries what Phase 1 writes and renders.
+// Source process: Ben Hunter's "Unified Technology Request Process"
+// draft, August 2026 revision (one intake form, four tracks — D added
+// 2026-08-03 per worksheet W29 — DATA/AI/BUY flags, two gates):
+// https://bhunter-uidaho.github.io/UnifiedTechnologyRequest/
+// Point-in-time transcription (oit-ea-portfolio posture): the source
+// is a hand-authored page with no machine-readable catalog, so
+// re-transcribe here when the flow revises. Flag and gate vocabularies
+// land with their tables in ADR 0005 Phase 3; this module carries what
+// Phase 1 writes and renders.
 
 // ---- Tracks -----------------------------------------------------------
 // Fast Lane / Track A / B / C from the request routing, plus `external`
@@ -23,6 +28,7 @@ export type IntakeTrack =
   | "track-a"
   | "track-b"
   | "track-c"
+  | "track-d"
   | "external";
 
 export const INTAKE_TRACK_LABEL: Record<IntakeTrack, string> = {
@@ -30,6 +36,7 @@ export const INTAKE_TRACK_LABEL: Record<IntakeTrack, string> = {
   "track-a": "Track A · Standard software",
   "track-b": "Track B · Built in-house",
   "track-c": "Track C · Idea / concept",
+  "track-d": "Track D · Data & report access",
   external: "External — tracked",
 };
 
@@ -41,6 +48,7 @@ export const INTAKE_TRACK_SHORT: Record<IntakeTrack, string> = {
   "track-a": "A",
   "track-b": "B",
   "track-c": "C",
+  "track-d": "D",
   external: "Ext",
 };
 
@@ -49,6 +57,7 @@ export const INTAKE_TRACK_TITLE: Record<IntakeTrack, string> = {
   "track-a": "Track A — commercial purchase or subscription requiring governance review.",
   "track-b": "Track B — fully realized in-house application needing security and operational acceptance.",
   "track-c": "Track C — early-stage build requiring feasibility assessment and the development queue.",
+  "track-d": "Track D — access to existing data or a report; routes to data governance, not a build or purchase track.",
   external: "External — owned outside IIDS; tracked in the inventory, not routed through the intake process.",
 };
 
@@ -100,6 +109,14 @@ export const UTR_STAGES: Record<Exclude<IntakeTrack, "external">, UtrStage[]> =
       { slug: "design-flag-reviews", label: "Design-stage flag reviews" },
       { slug: "prioritization", label: "Prioritization" },
       { slug: "development", label: "Development" },
+    ],
+    // W29 (2026-08-03): data/report-access requests enter the single
+    // front door but route to the existing data-governance process.
+    "track-d": [
+      { slug: "access-request", label: "Access request" },
+      { slug: "entitlement-screen", label: "Classification & entitlement screen" },
+      { slug: "steward-review", label: "Data steward review" },
+      { slug: "grant-provisioning", label: "Grant, conditions & provisioning" },
     ],
   };
 

--- a/scripts/infer-idea-requests.ts
+++ b/scripts/infer-idea-requests.ts
@@ -68,7 +68,7 @@ const DATA_SIGNAL_DEFS = (
 const SYSTEM_PROMPT = `You classify technology requests submitted to the University of Idaho's OIT IDEA form. Given a request's title, requesting department, and prose description, return ONLY a JSON object with exactly these fields:
 
 {
-  "track": "fast-lane" | "track-a" | "track-b" | "track-c",
+  "track": "fast-lane" | "track-a" | "track-b" | "track-c" | "track-d",
   "ai_involvement": "none" | "ai-feature" | "ai-core",
   "tool": string | null,
   "need_summary": string,
@@ -83,7 +83,8 @@ Field definitions:
   - "track-a": ${INTAKE_TRACK_TITLE["track-a"]}
   - "track-b": ${INTAKE_TRACK_TITLE["track-b"]}
   - "track-c": ${INTAKE_TRACK_TITLE["track-c"]}
-  Requests to buy, license, subscribe to, or integrate an existing commercial product are track-a (or fast-lane when it is a low-risk single-user purchase). Requests where something new would have to be designed or built are track-c. track-b applies only when the requestor has already built a working application.
+  - "track-d": ${INTAKE_TRACK_TITLE["track-d"]}
+  Requests to buy, license, subscribe to, or integrate an existing commercial product are track-a (or fast-lane when it is a low-risk single-user purchase). Requests where something new would have to be designed or built are track-c. track-b applies only when the requestor has already built a working application. Requests whose substance is access — to existing institutional data, a report, a dashboard, or a system's records (rather than acquiring or building software) — are track-d.
 
 - ai_involvement: "ai-core" when AI/LLM functionality is the point of the request; "ai-feature" when the requested product happens to include AI capabilities but the need itself is not AI; "none" when no AI involvement is apparent. Classify from what the text says, not what a product might offer.
 


### PR DESCRIPTION
Ben Hunter's August 2026 process revision adds Track D (worksheet W29,
2026-08-03): data/report-access requests enter the single front door
but route to the existing data-governance process rather than a
purchase or build track. Transcribed into lib/utr.ts (point-in-time
posture — the source is a hand-authored page, nothing to vendor):
track union, labels, and the four W29 stages. Inference vocabulary and
prompt extended so IDEA-backlog classification can suggest track-d.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
