### PR TITLE
Ingest OIT's draft SDLC standard across the standards surfaces

### DIFF
--- a/app/coordination/oit-pathway/page.tsx
+++ b/app/coordination/oit-pathway/page.tsx
@@ -4,6 +4,7 @@ import {
   PATHWAY_STAGES,
   PATHWAY_MILESTONES,
   PATHWAY_RULES,
+  SDLC_DRAFT_REQUIREMENTS,
   IN_SCOPE_TRIGGERS,
   OUT_OF_SCOPE_EXAMPLES,
   PATHWAY_PROJECTS,
@@ -15,7 +16,7 @@ import {
 export const metadata = {
   title: "OIT Pathway — Coordination",
   description:
-    "How teams outside OIT build and deploy AI applications on OIT-managed infrastructure: the two governing documents, the six-stage lifecycle with gates, the six rules, and where our projects sit.",
+    "How teams outside OIT build and deploy AI applications on OIT-managed infrastructure: the governing documents, the six-stage lifecycle with gates, the six rules, and where our projects sit.",
 };
 
 const LEAD_STYLE: Record<StageLead, string> = {
@@ -141,10 +142,16 @@ export default function OitPathwayPage() {
           </span>{" "}
           sets the process for teams outside OIT who want their applications
           hosted, supported, and maintained on OIT-managed infrastructure.
-          The platform both documents describe is what our inventory tracks
+          Beneath both, OIT&rsquo;s draft{" "}
+          <span className="font-semibold text-brand-black">
+            Software Development Lifecycle standard
+          </span>{" "}
+          (June 2026) sets the security floor for all university code — the
+          floor the Stage 3 gate measures against. The platform these
+          documents describe is what our inventory tracks
           as <Link href="/portfolio/nexus">Nexus</Link> — the OIT-managed
           application platform built collaboratively by OIT and IIDS. This
-          page covers the second track: the lifecycle, the gates, the rules,
+          page covers the builder track: the lifecycle, the gates, the rules,
           and where our projects stand in it.
         </p>
       </header>
@@ -157,16 +164,20 @@ export default function OitPathwayPage() {
         >
           Source documents
         </p>
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {OIT_SOURCE_DOCS.map((doc) => (
             <article
-              key={doc.href}
+              key={doc.title}
               className="rounded-lg border border-hairline bg-white p-4"
             >
               <h2 className="text-sm font-bold tracking-tight text-brand-black">
-                <a href={doc.href} target="_blank" rel="noopener noreferrer">
-                  {doc.title}
-                </a>
+                {doc.href ? (
+                  <a href={doc.href} target="_blank" rel="noopener noreferrer">
+                    {doc.title}
+                  </a>
+                ) : (
+                  doc.title
+                )}
               </h2>
               <p className="mt-1 text-xs text-ink-subtle">
                 Updated{" "}
@@ -184,8 +195,9 @@ export default function OitPathwayPage() {
           ))}
         </div>
         <p className="text-xs text-ink-subtle">
-          Both governance documents remain discussion drafts; entries here
-          track the published wiki versions and update as OIT revises them.
+          All of these documents remain drafts; entries here track the
+          versions we have and update as OIT revises them. The SDLC standard
+          is OIT-internal and not yet publicly linkable.
         </p>
       </section>
 
@@ -283,6 +295,44 @@ export default function OitPathwayPage() {
               </h3>
               <p className="mt-1.5 text-xs leading-relaxed text-ink-muted">
                 {rule.detail}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Draft SDLC standard — what's coming */}
+      <section aria-labelledby="sdlc-heading" className="space-y-4">
+        <div className="max-w-3xl">
+          <h2
+            id="sdlc-heading"
+            className="text-xl font-black tracking-tight text-brand-black"
+          >
+            What the draft SDLC standard adds
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            OIT&rsquo;s draft Software Development Lifecycle standard (June
+            2026) sets the baseline the Stage 3 security gate will measure
+            against — for all university code, not just AI applications.
+            Still in draft; these are the requirements most likely to change
+            how a builder works. The document itself is tracked on the{" "}
+            <Link href="/standards">Standards ledger</Link>.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {SDLC_DRAFT_REQUIREMENTS.map((req) => (
+            <article
+              key={req.title}
+              className="rounded-lg border border-hairline bg-white p-4"
+            >
+              <h3 className="text-sm font-bold tracking-tight text-brand-black">
+                {req.title}
+              </h3>
+              <p className="mt-1.5 text-xs leading-relaxed text-ink-muted">
+                {req.detail}
+              </p>
+              <p className="mt-2.5 border-t border-hairline pt-2 text-[11px] font-medium uppercase tracking-wider text-brand-silver">
+                {req.appliesTo}
               </p>
             </article>
           ))}

--- a/app/standards/page.tsx
+++ b/app/standards/page.tsx
@@ -239,7 +239,7 @@ export default function StandardsWatchPage() {
           Active sources
         </p>
         <h2 className="mt-2 text-lg font-black tracking-tight text-brand-black">
-          OIT&rsquo;s AI governance runs on two tracks
+          Three OIT drafts now answer these asks
         </h2>
         <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
           The joint IIDS/OIT &ldquo;AI for UI&rdquo; effort (OIT delivery
@@ -256,10 +256,19 @@ export default function StandardsWatchPage() {
           </span>{" "}
           (May 2026) sets the process for teams outside OIT deploying on
           OIT infrastructure — a six-stage lifecycle with gates and six
-          rules for every in-scope application. Open decisions include
-          the AI model gateway (MindRouter is the named candidate),
-          model-registry ownership, local AI tooling policy, and
-          long-term application ownership.
+          rules for every in-scope application. Beneath both, OIT&rsquo;s
+          draft{" "}
+          <span className="font-semibold text-brand-black">
+            Software Development Lifecycle standard
+          </span>{" "}
+          (June 2026; OIT-internal, not yet publicly linkable) sets the
+          security baseline for all code developed for or by the
+          university — risk classification, secure development, environment
+          separation, and repository requirements aligned to NIST SP800-218
+          and the CIS GitHub benchmarks. Open decisions include the AI
+          model gateway (MindRouter is the named candidate), model-registry
+          ownership, local AI tooling policy, and long-term application
+          ownership.
         </p>
         <p className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm">
           <a

--- a/lib/builder-guide-data.ts
+++ b/lib/builder-guide-data.ts
@@ -454,6 +454,7 @@ export const tiers: TierRecommendation[] = [
       "Implement proper error handling and logging from the start",
       "Set up automated testing before your first deployment",
       "Document your API endpoints and data schemas",
+      "Keep a record of which AI models and tools you used to build — OIT's draft development standards require it",
     ],
   },
   {
@@ -480,6 +481,7 @@ export const tiers: TierRecommendation[] = [
       "Plan for backup and disaster recovery from day one",
       "You will need a data flow diagram approved before handling regulated data",
       "Consider load testing before launch if serving 100+ concurrent users",
+      "Expect peer review by someone other than the author, plus automated secret and dependency scanning — both required at this tier under OIT's draft development standards",
     ],
   },
   {
@@ -515,6 +517,7 @@ export const tiers: TierRecommendation[] = [
       "Budget for ongoing security monitoring and incident response",
       "Multi-tenant architectures need data isolation verification",
       "Consider hiring or designating a technical lead for ongoing maintenance",
+      "Development environments may not hold production data at this tier — plan for synthetic or sanitized test data under OIT's draft development standards",
     ],
   },
 ];

--- a/lib/oit-pathway.ts
+++ b/lib/oit-pathway.ts
@@ -6,7 +6,7 @@
 // and where our projects sit — and so tsc catches drift when a stage or
 // rule is renamed.
 //
-// Two tracks, two documents:
+// Two tracks, plus a base layer:
 //   - Enterprise AI Development Framework — the TECH standards (approved
 //     stack, two-zone hosted environment, APM 30.11 classification,
 //     required pre-deploy artifacts). Tracked ask-by-ask in
@@ -14,6 +14,12 @@
 //   - AI-Assisted Builder Guide — the PROCESS for builders outside OIT
 //     (six-stage lifecycle with gates, enterprise tooling from day one,
 //     six binding rules). Modeled here.
+//   - Software Development Lifecycle standard (draft, June 2026) — the
+//     SECURITY floor for all university code, AI or not (risk
+//     classification, secure development, environments, repositories;
+//     NIST SP800-218 + CIS GitHub benchmark alignment). OIT-internal, no
+//     public URL. Builder-facing asks modeled in SDLC_DRAFT_REQUIREMENTS
+//     below; the document is tracked per-ask in lib/standards-watch.ts.
 //
 // The hosted environment these documents describe is what the project
 // inventory tracks as Nexus (lib/portfolio.ts, slug "nexus") — the
@@ -24,8 +30,10 @@
 
 export interface OitSourceDoc {
   title: string;
-  href: string;
-  updated: string; // ISO date of the wiki page's last update
+  // Absent when the document has no publicly accessible URL (the draft
+  // SDLC standard is OIT-internal); the card renders unlinked.
+  href?: string;
+  updated: string; // ISO date of the document's last update
   role: string; // one-line description of what this document governs
 }
 
@@ -47,6 +55,11 @@ export const OIT_SOURCE_DOCS: OitSourceDoc[] = [
     href: "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19582/AI-Development",
     updated: "2026-05-20",
     role: "The joint IIDS/OIT effort behind both documents, with the named delivery, security, IAM, infrastructure, and development contacts.",
+  },
+  {
+    title: "Software Development Lifecycle standard (draft)",
+    updated: "2026-06-26",
+    role: "OIT's draft baseline for all code developed for or by the university — risk classification, secure development, environments, and repository requirements, aligned to NIST SP800-218 and the CIS GitHub benchmarks. OIT-internal; no public link yet. Tracked ask-by-ask on the Standards ledger.",
   },
 ];
 
@@ -193,6 +206,63 @@ export const PATHWAY_RULES: PathwayRule[] = [
     title: "Named ownership required",
     detail:
       "Every application has a named individual owner responsible for maintenance, updates, and decommissioning. A department name is not sufficient.",
+  },
+];
+
+// ---- Draft SDLC standard — what it adds for builders --------------------
+
+// OIT's draft Software Development Lifecycle standard (June 2026) sits
+// beneath the Builder Guide: the guide defines the process, the draft
+// standard defines the floor the Stage 3 security gate measures against.
+// Still in draft and OIT-internal (no public link), so requirements are
+// modeled here at ask level — the ones most likely to change how a
+// builder works — and the Standards ledger tracks the document itself.
+export interface SdlcDraftRequirement {
+  title: string;
+  detail: string;
+  // The draft's own applicability tag — which risk tiers the requirement
+  // binds. Rendered verbatim; the draft classifies code by the highest
+  // risk of the data it touches, the systems it configures, and the
+  // information embedded in it.
+  appliesTo: string;
+}
+
+export const SDLC_DRAFT_REQUIREMENTS: SdlcDraftRequirement[] = [
+  {
+    title: "AI-assisted code is explainable code",
+    detail:
+      "AI-generated or AI-assisted code must be thoroughly understood, reviewed, and reasonably tested before production — and the author must be able to explain it to the peer reviewer and product owner, including the behavior of any integrated applications or services.",
+    appliesTo: "All risk tiers",
+  },
+  {
+    title: "Document the AI models used",
+    detail:
+      "Documentation of which AI models were used in development must exist, and only AI tools approved for the relevant risk tier may be used.",
+    appliesTo: "All risk tiers",
+  },
+  {
+    title: "A reviewer who is not the author",
+    detail:
+      "Approvals must include at least one person separate from the developer(s) for the change set under review; pull-request self-approval on production branches is prohibited, and approvals are dismissed when updates land.",
+    appliesTo: "Moderate and high risk",
+  },
+  {
+    title: "Separated environments, production-like data",
+    detail:
+      "Development, testing, and production environments fully separated — testing may hold read-only rights into production, and development environments carry production-like data only, never production data.",
+    appliesTo: "Separation: all tiers · data rule: high risk",
+  },
+  {
+    title: "Four scans, on everything",
+    detail:
+      "Secret, dependency, config/IaC, and OWASP/CWE code scanning on every deployment pipeline, every pull request, and weekly — results shared with the developer automatically and reported to a central OIT Security platform.",
+    appliesTo: "Moderate and high risk",
+  },
+  {
+    title: "Pinned, quarantined dependencies",
+    detail:
+      "Specific versions only (never latest or nightly), trusted registries with checksum validation, a 60-day quarantine on newly released open-source dependencies, and an auto-generated SBOM covering transitive dependencies before production.",
+    appliesTo: "Moderate and high risk",
   },
 ];
 

--- a/lib/standards-watch.ts
+++ b/lib/standards-watch.ts
@@ -40,6 +40,14 @@ const OIT_FRAMEWORK_URL =
 const OIT_BUILDER_GUIDE_URL =
   "https://dev.azure.com/uidaho/Development/_wiki/wikis/Development.wiki/19581/AI-Assisted-Builder-Guide";
 
+// A third OIT document reached us August 2026: the draft Software
+// Development Lifecycle standard (revision dated 2026-06-26 — a full
+// rewrite aligning existing practice to NIST SP800-218 and the CIS
+// GitHub benchmarks; standards owner: OIT). It is OIT-internal with no
+// publicly accessible URL, so items it advances cite it by name in
+// responseNote rather than via responseUrl. It remains a draft — no
+// item moves to "approved" on its account.
+
 const PLACEHOLDER_DATE = "2026-02-15"; // mid-February — when these items first surfaced; refine per-entry as needed
 
 export const standardsWatch: StandardsWatchItem[] = [
@@ -97,7 +105,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-discussion",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework adopts APM 30.11 (Low / Moderate / High) as the binding classification scheme and specifies PostgreSQL with pgvector, pgaudit, and pgsodium (containerized, per application) — pgaudit covering audit logging. Prompt and completion logs inherit the classification of underlying data. The draft notes dev and test environments currently house production data. Canonical data models, retention, lineage, and DR standards are not yet specified.",
+      "Framework adopts APM 30.11 (Low / Moderate / High) as the binding classification scheme and specifies PostgreSQL with pgvector, pgaudit, and pgsodium (containerized, per application) — pgaudit covering audit logging. Prompt and completion logs inherit the classification of underlying data. OIT's draft Software Development Lifecycle standard (June 2026) extends classification to code itself — a codebase is classified by the highest risk of the data it touches, the systems it configures, and the information embedded in it — and makes the environment rule binding: development environments must hold production-like data only, never production data (high risk). Its own action-item list flags dev-data sanitization as currently incomplete. Canonical data models, retention, lineage, and DR standards are not yet specified.",
   },
   {
     id: "i-4",
@@ -116,7 +124,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework specifies 1Password Connect for secrets management (no hardcoded credentials), Microsoft Entra ID for auth, governance-shifts-left posture, and explicit handling of FERPA (Moderate) and HIPAA PHI / SSN / CUI (High) under APM 30.11. EAR + VASA reviews are required pre-deploy for new tech and new vendors. Specific OS/container hardening baselines and SAST/DAST tooling are not yet specified.",
+      "Framework specifies 1Password Connect for secrets management (no hardcoded credentials), Microsoft Entra ID for auth, governance-shifts-left posture, and explicit handling of FERPA (Moderate) and HIPAA PHI / SSN / CUI (High) under APM 30.11. EAR + VASA reviews are required pre-deploy for new tech and new vendors. OIT's draft Software Development Lifecycle standard (June 2026; NIST SP800-218 + CIS GitHub benchmark alignment) now drafts the secure-development core: OWASP Top 10 Proactive Controls as the minimum control set; credential rules (encrypted at rest, never stored with the decryptor, keys reset on any exposure including role departures); encryption at rest and in transit; and four required scan types — secret, dependency, config/IaC, and OWASP/CWE code scanning — run on every deployment pipeline, every pull request, weekly, and on newly disclosed significant vulnerabilities, with results reported to a central OIT Security platform and high/critical pipeline findings requiring OIT Security approval before production. Specific OS/container hardening baselines and the SAST/DAST tool choices are still unspecified.",
   },
   {
     id: "i-5",
@@ -134,7 +142,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework defines OCI OKE + on-prem Kubernetes as the approved hosting environments (the Builder Guide adds Azure for production deployment), Azure Pipelines as the CI/CD pipeline (GitHub Actions under review), ADO as source control (GitHub Enterprise under review), ArgoCD + Kustomize for GitOps deployment, and per-team K8s namespaces with no direct cluster access in test/prod. Each team gets a starter deployment repository. Specific environment-structure rules and IaC standards beyond Kustomize are not yet specified.",
+      "Framework defines OCI OKE + on-prem Kubernetes as the approved hosting environments (the Builder Guide adds Azure for production deployment), Azure Pipelines as the CI/CD pipeline (GitHub Actions under review), ADO as source control (GitHub Enterprise under review), ArgoCD + Kustomize for GitOps deployment, and per-team K8s namespaces with no direct cluster access in test/prod. Each team gets a starter deployment repository. OIT's draft Software Development Lifecycle standard (June 2026) supplies the environment-structure rules: development, testing, and production fully separated (testing may hold read-only rights into production; development restricted to OIT-managed networks), and for high-risk work a build process defined as code — worker configuration at build time, pipeline event logging (scans, stage events, approvals), locked dependencies, verified IaC manifests — plus signed containers from approved registries, verified before run (moderate/high risk).",
   },
   {
     id: "i-6",
@@ -152,7 +160,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_BUILDER_GUIDE_URL,
     responseNote:
-      "The AI-Assisted Builder Guide (May 2026) now drafts the lifecycle end-to-end: a six-stage pathway with gates at stages 1, 3, 4, and 5, a hard security gate with no bypass, named-individual ownership (a department is not sufficient), and a runbook + documented decommission path on file before go-live, plus an annual ownership confirmation. The Framework separately names the pre-deploy artifact set (architecture diagram, data-flow diagrams, risk assessment, runbook, EAR, VASA). Long-term support responsibility remains an explicit open question — options range from full product-team ownership to OIT-assumed support.",
+      "The AI-Assisted Builder Guide (May 2026) now drafts the lifecycle end-to-end: a six-stage pathway with gates at stages 1, 3, 4, and 5, a hard security gate with no bypass, named-individual ownership (a department is not sufficient), and a runbook + documented decommission path on file before go-live, plus an annual ownership confirmation. The Framework separately names the pre-deploy artifact set (architecture diagram, data-flow diagrams, risk assessment, runbook, EAR, VASA). OIT's draft Software Development Lifecycle standard (June 2026) adds a formal ownership model: seven required roles with defined responsibilities — product owner, developer, approver/reviewer, tester, administrator, end user, and designer (who owns accessibility) — with assignment left to the relevant department's discretion. Long-term support responsibility remains an explicit open question — options range from full product-team ownership to OIT-assumed support.",
   },
   {
     id: "i-7",
@@ -169,7 +177,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework specifies the approved tooling stack: Ruff + Pyright (Python lint/type), Biome (JS/TS lint/format), pytest (Python tests), Vitest + Testing Library (JS/TS tests), uv + pyproject.toml (Python deps), SQLAlchemy + Alembic (ORM/migrations). Frontend is React + Vite + TypeScript. Specific testing-coverage thresholds, refactoring approval paths, and tech-debt tracking processes are not yet specified.",
+      "Framework specifies the approved tooling stack: Ruff + Pyright (Python lint/type), Biome (JS/TS lint/format), pytest (Python tests), Vitest + Testing Library (JS/TS tests), uv + pyproject.toml (Python deps), SQLAlchemy + Alembic (ORM/migrations). Frontend is React + Vite + TypeScript. OIT's draft Software Development Lifecycle standard (June 2026) adds the review and documentation floor: peer reviews check for environment-specific leakage, secrets/PII, comment quality, project code standards, and confidentiality/integrity/availability impact; approvals must include at least one person separate from the developer (moderate/high risk); pull requests are required for production branches, with self-approval prohibited and stale approvals dismissed on update. Documentation minimums: ownership, a defined version scheme such as semantic versioning, and code history recording who changed what, when, why, and who approved. AI-generated or -assisted code must be understood and explainable by its author, and the AI models used must be documented. Testing-coverage thresholds and tech-debt tracking processes are still unspecified.",
   },
   {
     id: "i-8",
@@ -199,10 +207,10 @@ export const standardsWatch: StandardsWatchItem[] = [
       "Communication expectations for breaking changes",
     ],
     dateRequested: PLACEHOLDER_DATE,
-    status: "in-discussion",
+    status: "in-draft",
     responseUrl: OIT_BUILDER_GUIDE_URL,
     responseNote:
-      "The AI-Assisted Builder Guide's Stage 6 (Operate & Maintain) starts on this: builders notify OIT before any change, all updates follow the same review process as the original build, AI-vendor API deprecation remediation is the builder's responsibility, and an annual review confirms compliance, ownership, and continued need. Version-upgrade cadence, backward-compatibility rules, and breaking-change communication are not yet specified.",
+      "The AI-Assisted Builder Guide's Stage 6 (Operate & Maintain) starts on this: builders notify OIT before any change, all updates follow the same review process as the original build, AI-vendor API deprecation remediation is the builder's responsibility, and an annual review confirms compliance, ownership, and continued need. OIT's draft Software Development Lifecycle standard (June 2026) drafts the dependency side: pin specific versions (never latest or nightly, verified security patches excepted), resolve only from trusted registries with checksum validation, a 60-day quarantine on newly released open-source dependencies, patch-management compliance per the maintenance standard, and auto-generated SBOMs covering transitive dependencies before production. Version-upgrade cadence, backward-compatibility rules, and breaking-change communication are not yet specified.",
   },
   {
     id: "i-10",
@@ -219,7 +227,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     status: "in-draft",
     responseUrl: OIT_FRAMEWORK_URL,
     responseNote:
-      "Framework requires all four observability components: OpenTelemetry, Prometheus, Jaeger, and Splunk. Splunk is deployed first. Observability diagrams must be completed and ownership assigned before production. Specific dashboards, alert thresholds, and metric expectations are not yet specified.",
+      "Framework requires all four observability components: OpenTelemetry, Prometheus, Jaeger, and Splunk. Splunk is deployed first. Observability diagrams must be completed and ownership assigned before production. OIT's draft Software Development Lifecycle standard (June 2026) adds log-content rules: data access, transfer, and change events captured (high risk); sensitive information never written to logs; user-facing errors stripped of debugging and stack-trace detail; and error handling on security controls denying access by default. Specific dashboards, alert thresholds, and metric expectations are not yet specified.",
   },
 
   // ───── Agenda Item II — User Experience Standards ─────
@@ -290,7 +298,7 @@ export const standardsWatch: StandardsWatchItem[] = [
     dateRequested: PLACEHOLDER_DATE,
     status: "in-discussion",
     responseNote:
-      "WCAG 2.1 Level AA confirmed as the binding compliance level for institutional UI applications. The OIT Enterprise AI Development Framework draft does not yet enumerate accessibility-specific testing requirements, ARIA expectations, or per-component checks; this entry tracks the elaboration alongside the WCAG references.",
+      "WCAG 2.1 Level AA confirmed as the binding compliance level for institutional UI applications. OIT's draft Software Development Lifecycle standard (June 2026) assigns accessibility to a required Designer role — ensuring all accessibility requirements are met is that role's defined responsibility. The Framework draft does not yet enumerate accessibility-specific testing requirements, ARIA expectations, or per-component checks; this entry tracks the elaboration alongside the WCAG references.",
   },
   {
     id: "ii-4",


### PR DESCRIPTION
## What

OIT's draft **Software Development Lifecycle standard** (rev. 2026-06-26 — a full rewrite aligning existing practice to NIST SP800-218 and the CIS GitHub benchmarks) reached us August 2026 via Dan. It is OIT-internal (no public URL) and still in draft, so per owner direction it is **not hosted or linked** — cited by name in `responseNote` fields — and **no ledger item moves to approved**.

## Changes

**`lib/standards-watch.ts`** — eight entries enriched with what the draft now covers:
- **i-4 Security & Compliance**: OWASP Top 10 Proactive Controls floor, credential rules, encryption, four required scan types with cadence (pipelines / PRs / weekly / new vulns), central OIT Security reporting, high/critical findings gate production.
- **i-5 DevOps/Deployment**: full dev/test/prod separation, build-process-as-code, pipeline event logging, locked deps, verified IaC, signed containers.
- **i-7 Code Quality**: peer-review checklist, reviewer separate from author (mod/high), PR rules for production branches, documentation minimums, AI-code explainability + model documentation.
- **i-6 Lifecycle/Handoff**: seven required roles with defined responsibilities (designer owns accessibility).
- **i-9 Upgrade/Change Mgmt**: pinned versions, trusted registries, 60-day open-source quarantine, transitive-dep SBOMs — **moves in-discussion → in-draft**.
- **i-3 Data Standards**: code classified by highest risk of data/systems/embedded info; no production data in dev (high risk); the draft's own action items flag dev-data sanitization as incomplete.
- **i-10 Observability**: log-content rules (no sensitive data, no stack traces to users, deny-by-default error handling).
- **ii-3 Accessibility**: required Designer role owns accessibility.

**`lib/oit-pathway.ts` + `/coordination/oit-pathway`** — the draft added as a fourth source document (`href` now optional for unlinkable docs; card renders unlinked), plus a new `SDLC_DRAFT_REQUIREMENTS` module and page section: the six asks most likely to change how a builder works, each with the draft's own risk-tier applicability tag.

**`/standards`** — Active sources block now names all three OIT drafts.

**`lib/builder-guide-data.ts`** — tier 2–4 considerations surface the AI-model-documentation, reviewer-separation/scanning, and no-production-data-in-dev asks.

## Verification

- `npm run build` passes.
- `/coordination/oit-pathway` and `/standards` verified rendering in dev — four source-doc cards (SDLC unlinked), new six-card requirements section with applies-to tags, updated ledger notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)