### PR TITLE
Replace the deployment vocabulary with the five-target model

### DIFF
--- a/app/docs/architecture/page.tsx
+++ b/app/docs/architecture/page.tsx
@@ -109,8 +109,11 @@ github_repo       TEXT           -- e.g. "ui-insight/my-app"
 url               TEXT           -- Production URL
 tier              INTEGER        -- 1-4
 proposed_deployment_environment TEXT
-                                 -- OIT-hosted/Azure/OCI/on-prem, IIDS,
-                                 -- external, not-applicable, or TBD
+                                 -- Five-target vocabulary (Databricks
+                                 -- dashboard, Nexus module, standalone
+                                 -- OCI / OIT K8s / RCDS VM) + meta values
+current_deployment_environment TEXT
+                                 -- Where it runs today; NULL = not running
 enterprise_replacement_status TEXT -- yes | no | to-be-determined
 existing_enterprise_system_name TEXT
 existing_enterprise_system_annual_cost_usd NUMERIC(14,2)

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -433,12 +433,33 @@ export default function ProjectDetail({
         <dl className="mt-3 grid max-w-3xl gap-3 sm:grid-cols-2">
           <div className="rounded-lg border border-hairline bg-white p-4">
             <dt className="text-xs font-medium uppercase tracking-wider text-brand-silver">
-              Proposed environment
+              Deployment environment
             </dt>
+            {app.currentDeploymentEnvironment &&
+              app.currentDeploymentEnvironment !==
+                app.proposedDeploymentEnvironment && (
+                <>
+                  <dd className="mt-1 text-sm font-semibold text-brand-black">
+                    {DEPLOYMENT_ENVIRONMENT_LABELS[
+                      app.currentDeploymentEnvironment
+                    ]}
+                  </dd>
+                  <dd className="mt-1 text-xs leading-relaxed text-ink-muted">
+                    Currently running here.
+                  </dd>
+                </>
+              )}
             <dd className="mt-1 text-sm font-semibold text-brand-black">
               {DEPLOYMENT_ENVIRONMENT_LABELS[
                 app.proposedDeploymentEnvironment
               ]}
+              {app.currentDeploymentEnvironment &&
+                app.currentDeploymentEnvironment !==
+                  app.proposedDeploymentEnvironment && (
+                  <span className="ml-1 font-normal text-ink-muted">
+                    (proposed)
+                  </span>
+                )}
             </dd>
             <dd className="mt-1 text-xs leading-relaxed text-ink-muted">
               {DEPLOYMENT_ENVIRONMENT_DESCRIPTIONS[

--- a/db/migrations/024_deployment_target_vocabulary.sql
+++ b/db/migrations/024_deployment_target_vocabulary.sql
@@ -1,0 +1,124 @@
+-- Migration 024: Five-target deployment vocabulary + current/proposed split
+--
+-- Replaces the hosting-only vocabulary from Migration 012 with the
+-- five-target model settled 2026-08-05: two platform-hosted form factors
+-- (databricks-dashboard, nexus-module) plus three standalone-app hosting
+-- locations (standalone-oci, standalone-oit-k8s, rcds-vm), a rollup
+-- (oit-managed-tbd), and the surviving meta values. Azure is dropped
+-- with zero uses. The RCDS VM is transitional by decision, which forces
+-- the current/proposed split: where a project runs now and where it is
+-- headed are separate facts. NULL current means nothing is running.
+--
+-- Typed source of truth: lib/project-governance.ts (vocabulary) and
+-- lib/deployment-targets.ts (per-target characteristics).
+
+BEGIN;
+
+ALTER TABLE applications
+  DROP CONSTRAINT IF EXISTS applications_proposed_deployment_environment_check;
+
+-- Value-level remaps (no rows carry the OIT platform-specific values
+-- today; mapped anyway so a drifted database can't strand a row).
+UPDATE applications
+SET proposed_deployment_environment = 'standalone-oci'
+WHERE proposed_deployment_environment = 'oit-oci-oke';
+
+UPDATE applications
+SET proposed_deployment_environment = 'standalone-oit-k8s'
+WHERE proposed_deployment_environment = 'oit-on-prem-kubernetes';
+
+UPDATE applications
+SET proposed_deployment_environment = 'oit-managed-tbd'
+WHERE proposed_deployment_environment = 'oit-azure';
+
+-- Per-slug remaps of the coarse 'oit-hosted' claim: three projects are
+-- explicitly Nexus-bound per the OIT pathway material; Nexus itself is a
+-- platform, not a workload targeting one.
+UPDATE applications
+SET proposed_deployment_environment = 'nexus-module'
+WHERE proposed_deployment_environment = 'oit-hosted'
+  AND slug IN ('retroactive-payment-requests', 'openera', 'ucm-daily-register');
+
+UPDATE applications
+SET proposed_deployment_environment = 'platform'
+WHERE proposed_deployment_environment = 'oit-hosted'
+  AND slug = 'nexus';
+
+-- Out-of-State Tax Tracking is feature-complete and paused pending
+-- Nexus onboarding (its own description) — the target is known.
+UPDATE applications
+SET proposed_deployment_environment = 'nexus-module'
+WHERE slug = 'out-of-state-tax-tracking';
+
+-- Remaining 'oit-hosted' rows (Vandals Stats Pipeline) keep the
+-- governance decision without a platform pick.
+UPDATE applications
+SET proposed_deployment_environment = 'oit-managed-tbd'
+WHERE proposed_deployment_environment = 'oit-hosted';
+
+-- 'iids-hosted' splits: MindRouter and DGX Stack are platforms; the
+-- Data Infrastructure Pilot delivers the AI4RA lakehouse platform; any
+-- straggler falls back to to-be-determined (the Video Storyboard app's
+-- running home is recorded in current_deployment_environment below).
+UPDATE applications
+SET proposed_deployment_environment = 'platform'
+WHERE slug IN ('mindrouter', 'dgx-stack', 'data-infrastructure-pilot');
+
+UPDATE applications
+SET proposed_deployment_environment = 'to-be-determined'
+WHERE proposed_deployment_environment = 'iids-hosted';
+
+ALTER TABLE applications
+  ADD CONSTRAINT applications_proposed_deployment_environment_check
+    CHECK (proposed_deployment_environment IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'platform',
+      'external-hosted',
+      'not-applicable',
+      'to-be-determined'
+    ));
+
+-- Where the project runs today. NULL = nothing running;
+-- 'to-be-determined' is deliberately excluded (absence carries it).
+ALTER TABLE applications
+  ADD COLUMN current_deployment_environment TEXT
+    CHECK (current_deployment_environment IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'platform',
+      'external-hosted',
+      'not-applicable'
+    ));
+
+UPDATE applications
+SET current_deployment_environment = 'rcds-vm'
+WHERE slug IN (
+  'stratplan',
+  'audit-dashboard',
+  'ucm-daily-register',
+  'mindrouter-video-storyboard',
+  'vandalizer',
+  'processmapping',
+  'openera',
+  'execord',
+  'rfd-career',
+  'universo'
+);
+
+UPDATE applications
+SET current_deployment_environment = 'nexus-module'
+WHERE slug = 'retroactive-payment-requests';
+
+CREATE INDEX idx_applications_current_deployment_environment
+  ON applications(current_deployment_environment);
+
+COMMIT;

--- a/lib/deployment-targets.ts
+++ b/lib/deployment-targets.ts
@@ -1,0 +1,254 @@
+// ============================================================
+// Deployment targets — per-target characteristics
+// ============================================================
+// The five deployment targets settled in the 2026-08-05 definitional
+// session, characterized along the dimensions that drive target
+// selection. The vocabulary (typed values, labels, the OIT-managed
+// flag) lives in lib/project-governance.ts; this module carries the
+// reference facts a surface renders and the harmonization work
+// classifies against.
+//
+// The selection model the five targets encode is a two-step decision:
+// form factor first (report-shaped → Databricks dashboard; transactional
+// module fitting the template → Nexus; otherwise a standalone app),
+// then hosting by operator and risk (OIT-managed for institutional-data
+// production; RCDS VM as transitional staging). This maps onto the UTR
+// tracks (lib/utr.ts): Track D requests are Databricks-shaped, Tracks
+// B/C land on Nexus or a standalone target.
+//
+// Honesty rule: `maturity` states what the target IS today, not what
+// it should become. Only Nexus and the RCDS VM have running workloads;
+// nothing has landed on OCI or OIT Kubernetes, and OIT's Databricks
+// service is aspirational until their implementation completes.
+
+import type { DeploymentEnvironment } from "./project-governance";
+
+/** The five concrete targets — the subset of the vocabulary that names
+ * a real place work can land (excludes rollup + meta values). */
+export type DeploymentTarget = Extract<
+  DeploymentEnvironment,
+  | "databricks-dashboard"
+  | "nexus-module"
+  | "standalone-oci"
+  | "standalone-oit-k8s"
+  | "rcds-vm"
+>;
+
+export type TargetMaturity =
+  /** Running workloads exist; the path in is defined. */
+  | "available"
+  /** Sanctioned on paper; no workload has landed yet. */
+  | "unproven"
+  /** The offering itself is not yet stood up or defined. */
+  | "aspirational"
+  /** Available but explicitly not a destination — staging until a
+   * project enters the OIT pathway. */
+  | "transitional";
+
+export const TARGET_MATURITY_LABEL: Record<TargetMaturity, string> = {
+  available: "Available",
+  unproven: "Sanctioned — unproven",
+  aspirational: "Aspirational",
+  transitional: "Transitional",
+};
+
+export interface DeploymentTargetProfile {
+  value: DeploymentTarget;
+  name: string;
+  /** Platform-hosted artifact vs. self-contained application. */
+  formFactor: "platform-artifact" | "standalone-app";
+  /** What actually ships to this target. */
+  shipUnit: string;
+  /** The workload shapes that belong here. */
+  fits: string[];
+  /** Who runs the runtime the workload lands on. */
+  operator: string;
+  /** Who performs the deployment. */
+  deployer: string;
+  /** The governance path a workload travels to get here. */
+  governancePath: string;
+  /** Standards and obligations that bind once here. */
+  standardsBinding: string;
+  /** Stack limits the target imposes. */
+  techConstraint: string;
+  /** Data classification / access posture. */
+  dataPosture: string;
+  /** Realistic time-to-production, with the gating factor named. */
+  timeToDeploy: string;
+  maturity: TargetMaturity;
+  /** The evidence behind the maturity claim. */
+  maturityNote: string;
+  /** What must be answered before this characterization firms up.
+   * Every entry names a real unknown — do not pad. */
+  openQuestions?: string[];
+  /** lib/portfolio.ts slugs currently on (or headed to) this target. */
+  exampleSlugs: string[];
+}
+
+export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
+  {
+    value: "databricks-dashboard",
+    name: "Databricks dashboard",
+    formFactor: "platform-artifact",
+    shipUnit:
+      "A dashboard or governed data product inside OIT's Databricks lakehouse workspace — no application to host.",
+    fits: [
+      "Report-shaped requests and recurring metrics",
+      "BI over governed institutional data",
+      "Cross-system reconciliation views (the survey's numbers-don't-agree theme)",
+    ],
+    operator:
+      "OIT — the workspace is OIT-controlled in its entirety (Application Administration; Randy Wood TPM per the FY2027 EA portfolio). Distinct from the IIDS lakehouse pilot, which serves AI4RA.",
+    deployer: "Undefined until OIT defines the service.",
+    governancePath:
+      "UTR Track D (data & report access): classification and entitlement screen, data steward review. The Governance Decision Worksheets already treat a new governed data product as a governance trigger.",
+    standardsBinding:
+      "Data classification enforced at the platform level; no application code, so no application security gate.",
+    techConstraint:
+      "Medallion architecture with data marts. Dashboard tooling undecided — PowerBI, Tableau, or custom is an open question.",
+    dataPosture:
+      "Potentially the highest-leverage target: governed lakehouse with per-user entitlements. Contents unconfirmed — Banner assumed but not verified.",
+    timeToDeploy:
+      "Fast for report-shaped needs once the platform is live and the data is in the lake; currently blocked on OIT's implementation finishing.",
+    maturity: "aspirational",
+    maturityNote:
+      "OIT's Databricks implementation is not finished; the dashboard service is undefined beyond an aspiration (Barrie Robison, 2026-08-05).",
+    openQuestions: [
+      "Who builds dashboards, with what approved tooling (PowerBI, Tableau, custom)?",
+      "What sources are attached to the lakehouse today (Banner assumed, unverified)?",
+      "What does the offered service look like — self-service with entitlements, or central build on request?",
+      "Which lakehouse/API routes are allowed; are direct source-system connections prohibited outright or case-by-case? (Outstanding Decisions Worksheet — confirm with Ben.)",
+    ],
+    exampleSlugs: [],
+  },
+  {
+    value: "nexus-module",
+    name: "Nexus module",
+    formFactor: "platform-artifact",
+    shipUnit:
+      "A module inside the shared React + FastAPI Nexus application at nexus.uidaho.edu.",
+    fits: [
+      "Transactional staff workflows: validated intake, review queues, dashboards",
+      "Banner-adjacent business processes (read and verify)",
+      "SSO-gated internal enterprise apps",
+    ],
+    operator:
+      "OIT-managed secure infrastructure; the platform was built collaboratively by OIT and IIDS (Kali Armitage, Colin Addington).",
+    deployer:
+      "Builders write module code; OIT gates pull requests and operates production.",
+    governancePath:
+      "The full six-stage Builder Guide pathway with the Stage 3 security gate and OIT acceptance; UTR Tracks B/C.",
+    standardsBinding:
+      "OIT Enterprise AI Development Framework stack; the draft OIT SDLC standard once adopted. OIT-managed production satisfies the ADR 0001 accessibility rule.",
+    techConstraint: "The Nexus template stack only — React + FastAPI.",
+    dataPosture:
+      "Moderate-risk institutional data proven in production: Retroactive Payment Requests verifies submissions against Banner.",
+    timeToDeploy:
+      "The slowest gate today — recurring security-review tickets and PR approval steps are the reported friction — but the one sanctioned enterprise path with a completed traversal.",
+    maturity: "available",
+    maturityNote:
+      "Retroactive Payment Requests in production for Payroll since July 2026; OpenERA and UCM Daily Register entering Stage 1.",
+    exampleSlugs: [
+      "retroactive-payment-requests",
+      "openera",
+      "ucm-daily-register",
+      "out-of-state-tax-tracking",
+    ],
+  },
+  {
+    value: "standalone-oci",
+    name: "Standalone app on OCI",
+    formFactor: "standalone-app",
+    shipUnit:
+      "A containerized standalone application on Oracle Cloud Infrastructure, in OIT-provisioned capacity.",
+    fits: [
+      "Apps that don't fit the Nexus template (different stack, own database, public-facing)",
+      "AI-heavy applications needing OIT-managed production",
+    ],
+    operator: "OIT.",
+    deployer:
+      "OIT DevOps deploys to production; builders do not deploy directly. Named owner, runbook, and documented decommission path required before go-live.",
+    governancePath:
+      "The six-stage Builder Guide pathway and OIT acceptance gate; UTR Tracks B/C.",
+    standardsBinding:
+      "Draft OIT SDLC standard once adopted (managed hosts, pipeline scanning, central scan reporting). OIT-managed production satisfies the ADR 0001 accessibility rule.",
+    techConstraint: "Any containerized stack.",
+    dataPosture: "Institutional data per classification, OIT-managed.",
+    timeToDeploy:
+      "Unknown — no project has traversed this path; expect pathway-gate timelines comparable to Nexus.",
+    maturity: "unproven",
+    maturityNote:
+      "Named in the OIT drafts as an approved platform; no workload has landed there.",
+    exampleSlugs: [],
+  },
+  {
+    value: "standalone-oit-k8s",
+    name: "Standalone app on OIT on-prem Kubernetes",
+    formFactor: "standalone-app",
+    shipUnit:
+      "A containerized standalone application in an OIT-provisioned namespace on the on-premises Kubernetes platform.",
+    fits: [
+      "Standalone apps where on-prem residency matters",
+      "Workloads wanting adjacency to on-prem AI compute (MindRouter, DGX Stack)",
+    ],
+    operator: "OIT.",
+    deployer:
+      "OIT DevOps deploys to production; builders do not deploy directly. Named owner, runbook, and documented decommission path required before go-live.",
+    governancePath:
+      "The six-stage Builder Guide pathway and OIT acceptance gate; UTR Tracks B/C.",
+    standardsBinding:
+      "Draft OIT SDLC standard once adopted. OIT-managed production satisfies the ADR 0001 accessibility rule.",
+    techConstraint: "Any containerized stack.",
+    dataPosture: "Institutional data per classification, OIT-managed.",
+    timeToDeploy: "Unknown — no project has traversed this path.",
+    maturity: "unproven",
+    maturityNote:
+      "Named in the OIT drafts as an approved platform; no workload has landed there.",
+    exampleSlugs: [],
+  },
+  {
+    value: "rcds-vm",
+    name: "Standalone app on an RCDS VM",
+    formFactor: "standalone-app",
+    shipUnit:
+      "A Docker-composed stack on an IIDS/RCDS self-managed VM — the insight.uidaho.edu class.",
+    fits: [
+      "Pilots and staged applications iterating with their unit before entering the pathway",
+      "Research-adjacent work outside enterprise governance",
+      "AI-enabled apps needing MindRouter/DGX adjacency during development",
+    ],
+    operator: "IIDS/RCDS self-managed.",
+    deployer: "Builders deploy directly — same-day deploys.",
+    governancePath:
+      "Outside the OIT pathway. The Builder Guide's term for apps here is 'staged on IIDS infrastructure' — pre-Stage-1.",
+    standardsBinding:
+      "No OIT acceptance gate. The ADR 0001 accessibility rule is NOT satisfied by the environment — accessibility falls on the project.",
+    techConstraint: "Any Docker-composed stack (10.x address space, not 172.x).",
+    dataPosture:
+      "The lowest ceiling — not a home for high-risk institutional data per the draft SDLC standard's managed-hosts posture.",
+    timeToDeploy: "Fastest — hours, not stages.",
+    maturity: "transitional",
+    maturityNote:
+      "Nine portfolio projects run here today, but the target is staging by decision (2026-08-05): projects are expected to move through the pathway to an OIT-managed target or Databricks, not to stay.",
+    exampleSlugs: [
+      "stratplan",
+      "openera",
+      "ucm-daily-register",
+      "processmapping",
+      "audit-dashboard",
+      "mindrouter-video-storyboard",
+      "execord",
+      "rfd-career",
+      "universo",
+      "vandalizer",
+    ],
+  },
+];
+
+export function getDeploymentTarget(
+  value: DeploymentTarget
+): DeploymentTargetProfile {
+  const profile = DEPLOYMENT_TARGETS.find((t) => t.value === value);
+  if (!profile) throw new Error(`Unknown deployment target: ${value}`);
+  return profile;
+}

--- a/lib/oit-ea-portfolio.ts
+++ b/lib/oit-ea-portfolio.ts
@@ -185,10 +185,11 @@ export const OIT_EA_PROJECTS: readonly OitEaProject[] = [
       administration: "High",
       systems: "High",
     },
-    portfolioSlug: "data-infrastructure-pilot",
-    crosswalkConfidence: "confirmed",
-    crosswalkNote:
-      "Databricks is the main technical platform deliverable of the Data Infrastructure Pilot — one effort, tracked from both sides (confirmed by Barrie Robison, July 2026).",
+    relatedSurface: {
+      label: "Data Infrastructure Pilot",
+      href: "/portfolio/data-infrastructure-pilot",
+      note: "Related but distinct. OIT's Databricks workspace is OIT-controlled in its entirety; the IIDS pilot serves AI4RA. Corrected 2026-08-05 by Barrie Robison, superseding the July 2026 one-effort crosswalk.",
+    },
   },
   {
     id: "nacubo-dashboards-data-architecture",

--- a/lib/portfolio-verification.ts
+++ b/lib/portfolio-verification.ts
@@ -18,7 +18,10 @@
 
 import type { Project, ProjectStatus } from "./portfolio";
 import { portfolioMeta } from "./portfolio-meta";
-import { isDeploymentEnvironment } from "./project-governance";
+import {
+  isDeploymentEnvironment,
+  isOitManagedEnvironment,
+} from "./project-governance";
 
 export interface VerificationProblem {
   slug: string;
@@ -55,12 +58,16 @@ function hasPubliclyAccessibleArtifact(i: Project): boolean {
   // either a liveUrl OR a public repoUrl (the repo IS the deliverable
   // for infrastructure / scaffolds / self-hostable appliances).
   // ADR sub-decision #5 (2026-07-24 amendment): production operated on
-  // an OIT-managed environment (`oit-*`) also satisfies it — internal
-  // enterprise apps (e.g. Nexus modules) are SSO-gated with no anonymous
-  // URL; the operated platform is the artifact.
+  // an OIT-managed environment also satisfies it — internal enterprise
+  // apps (e.g. Nexus modules) are SSO-gated with no anonymous URL; the
+  // operated platform is the artifact. Keyed on the vocabulary's
+  // oitManaged flag, judged where the project actually runs (current)
+  // over where it is headed (proposed).
   if (i.liveUrl && !i.liveUrlIsStaging) return true;
   if (i.repoUrl && !i.isPrivateRepo) return true;
-  if (i.proposedDeploymentEnvironment.startsWith("oit-")) return true;
+  const operatedEnvironment =
+    i.currentDeploymentEnvironment ?? i.proposedDeploymentEnvironment;
+  if (isOitManagedEnvironment(operatedEnvironment)) return true;
   return false;
 }
 
@@ -364,6 +371,26 @@ const verifyUniversal: Verifier = (i) => {
         "proposedDeploymentEnvironment is missing or is not in the governance vocabulary."
       )
     );
+  }
+
+  if (i.currentDeploymentEnvironment !== undefined) {
+    if (!isDeploymentEnvironment(i.currentDeploymentEnvironment)) {
+      problems.push(
+        problem(
+          i,
+          "currentDeploymentEnvironment, when present, must be in the governance vocabulary",
+          "currentDeploymentEnvironment is not in the governance vocabulary."
+        )
+      );
+    } else if (i.currentDeploymentEnvironment === "to-be-determined") {
+      problems.push(
+        problem(
+          i,
+          "currentDeploymentEnvironment must name where the project runs — omit the field when nothing is running",
+          "currentDeploymentEnvironment is 'to-be-determined'; absence carries that meaning."
+        )
+      );
+    }
   }
 
   const replacement = i.enterpriseSystemReplacement;

--- a/lib/portfolio.ts
+++ b/lib/portfolio.ts
@@ -92,7 +92,14 @@ export interface Project {
   // Governance intake — deployment target and incumbent-system economics.
   // Every project records an explicit value; use `to-be-determined` rather
   // than omitting facts that still need confirmation.
+  //
+  // The current/proposed split follows from the RCDS VM being a
+  // transitional target (2026-08-05): where a thing runs now and where
+  // it is headed are separate facts. `currentDeploymentEnvironment` is
+  // omitted when nothing is running yet; `to-be-determined` is not a
+  // valid current value (absence carries that meaning).
   proposedDeploymentEnvironment: DeploymentEnvironment;
+  currentDeploymentEnvironment?: DeploymentEnvironment;
   enterpriseSystemReplacement: EnterpriseSystemReplacement;
 
   // Lifecycle taxonomy — see docs/adr/0001-product-lifecycle-taxonomy.md.
@@ -166,6 +173,7 @@ export const projects: Project[] = [
     status: "production",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -224,6 +232,7 @@ export const projects: Project[] = [
     status: "paused",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -331,7 +340,7 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "paused",
     visibility: "Public",
-    proposedDeploymentEnvironment: "to-be-determined",
+    proposedDeploymentEnvironment: "nexus-module",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Colin Addington",
@@ -358,7 +367,8 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "production",
     visibility: "Public",
-    proposedDeploymentEnvironment: "oit-hosted",
+    proposedDeploymentEnvironment: "nexus-module",
+    currentDeploymentEnvironment: "nexus-module",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Colin Addington",
@@ -476,7 +486,8 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "piloting",
     visibility: "Public",
-    proposedDeploymentEnvironment: "oit-hosted",
+    proposedDeploymentEnvironment: "nexus-module",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -509,7 +520,8 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "building",
     visibility: "Public",
-    proposedDeploymentEnvironment: "iids-hosted",
+    proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "no" },
     ai4raRelationship: "None",
     iidsSponsor: "Luke Sheneman",
@@ -554,6 +566,7 @@ export const projects: Project[] = [
     status: "production",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
@@ -585,6 +598,7 @@ export const projects: Project[] = [
     status: "building",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
@@ -619,7 +633,8 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "building",
     visibility: "Partial",
-    proposedDeploymentEnvironment: "oit-hosted",
+    proposedDeploymentEnvironment: "nexus-module",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: {
       status: "yes",
       systemName: "VERAS",
@@ -658,6 +673,7 @@ export const projects: Project[] = [
     status: "prototype",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -720,7 +736,7 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "building",
     visibility: "Public",
-    proposedDeploymentEnvironment: "oit-hosted",
+    proposedDeploymentEnvironment: "oit-managed-tbd",
     enterpriseSystemReplacement: { status: "no" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -804,6 +820,7 @@ export const projects: Project[] = [
     status: "piloting",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Adjacent",
     iidsSponsor: "Barrie Robison",
@@ -837,6 +854,7 @@ export const projects: Project[] = [
     status: "piloting",
     visibility: "Public",
     proposedDeploymentEnvironment: "to-be-determined",
+    currentDeploymentEnvironment: "rcds-vm",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",
@@ -879,7 +897,7 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "production",
     visibility: "Public",
-    proposedDeploymentEnvironment: "iids-hosted",
+    proposedDeploymentEnvironment: "platform",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Core",
     dualDestinyPlanned: true,
@@ -909,7 +927,7 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "production",
     visibility: "Public",
-    proposedDeploymentEnvironment: "iids-hosted",
+    proposedDeploymentEnvironment: "platform",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Adjacent",
     externalDeployments: ["Southern Utah University"],
@@ -930,9 +948,9 @@ export const projects: Project[] = [
     slug: "data-infrastructure-pilot",
     name: "Data Infrastructure Pilot",
     tagline:
-      "Institutional data lakehouse pilot aligning the data behind AI4UI applications.",
+      "AI4RA data lakehouse pilot aligning the data behind the AI4UI application family.",
     description:
-      "Pilot connecting institutional structured and unstructured data sources to a shared data lakehouse, starting with Banner plus at least one other system — fully documented with a data dictionary. The longer vision expands the lake to include ArchAI contract data, targeted core documents from proposals, and other sources the AI4UI application family draws on.",
+      "Pilot connecting structured and unstructured data sources to a shared data lakehouse serving the AI4RA partnership, starting with Banner plus at least one other system — fully documented with a data dictionary. The longer vision expands the lake to include ArchAI contract data, targeted core documents from proposals, and other sources the AI4UI application family draws on. Distinct from OIT's Databricks platform deployment, whose workspace OIT controls in its entirety (clarified 2026-08-05, superseding the July reading that the two were one effort).",
     homeUnits: ["IIDS"],
     operationalOwners: [
       { name: "Arpan Pal" },
@@ -941,7 +959,7 @@ export const projects: Project[] = [
     buildParticipants: ["IIDS"],
     status: "approved",
     visibility: "Public",
-    proposedDeploymentEnvironment: "to-be-determined",
+    proposedDeploymentEnvironment: "platform",
     enterpriseSystemReplacement: { status: "to-be-determined" },
     ai4raRelationship: "Adjacent",
     iidsSponsor: "Colin Addington",
@@ -1055,7 +1073,7 @@ export const projects: Project[] = [
     buildParticipants: ["OIT", "IIDS"],
     status: "tracked",
     visibility: "Public",
-    proposedDeploymentEnvironment: "oit-hosted",
+    proposedDeploymentEnvironment: "platform",
     enterpriseSystemReplacement: { status: "no" },
     ai4raRelationship: "None",
     iidsSponsor: "Barrie Robison",

--- a/lib/project-governance.ts
+++ b/lib/project-governance.ts
@@ -1,56 +1,90 @@
 // Project-level governance fields that cut across the portfolio, registry,
 // and public project detail pages.
 //
-// Deployment values follow the two OIT discussion drafts tracked in
-// lib/oit-pathway.ts. The drafts allow Azure, OCI OKE, or on-prem Kubernetes
-// for OIT-managed production. `oit-hosted` records the governance decision
-// before OIT and the product team select one of those concrete platforms.
+// Deployment values follow the five-target model settled in the
+// 2026-08-05 definitional session (superseding the hosting-only
+// vocabulary from Migration 012): two platform-hosted form factors
+// (Databricks dashboard, Nexus module) plus three standalone-app
+// hosting locations (OCI, OIT on-prem Kubernetes, RCDS VM). The RCDS VM
+// is transitional — a staging home until a project enters the OIT
+// pathway, not a destination. Per-target characteristics live in
+// lib/deployment-targets.ts; Azure was dropped with zero uses and can
+// be re-added the day OIT actually lands something there.
+//
+// `oitManaged` drives ADR 0001 sub-decision #5: production operated on
+// an OIT-managed environment satisfies the accessibility rule even
+// without an anonymous URL (lib/portfolio-verification.ts).
 
 export const DEPLOYMENT_ENVIRONMENTS = [
+  // ---- The five targets ----------------------------------------------
   {
-    value: "oit-hosted",
-    label: "OIT-hosted infrastructure (platform TBD)",
+    value: "databricks-dashboard",
+    label: "Databricks dashboard (OIT lakehouse)",
+    oitManaged: true,
     description:
-      "OIT-managed production is proposed; Azure, OCI OKE, or on-prem Kubernetes has not yet been selected.",
+      "A dashboard delivered inside OIT's Databricks lakehouse workspace (medallion architecture with data marts). OIT controls the workspace entirely; the service is aspirational until OIT's implementation completes. Distinct from the IIDS lakehouse pilot, which serves AI4RA.",
   },
   {
-    value: "oit-azure",
-    label: "OIT-managed Azure",
-    description: "OIT-managed production deployment on Microsoft Azure.",
+    value: "nexus-module",
+    label: "Nexus module",
+    oitManaged: true,
+    description:
+      "A module inside Nexus, the shared React + FastAPI application platform on OIT-managed secure infrastructure. Reached through the six-stage Builder Guide pathway.",
   },
   {
-    value: "oit-oci-oke",
-    label: "OIT-managed OCI OKE",
+    value: "standalone-oci",
+    label: "Standalone app — OIT-managed OCI",
+    oitManaged: true,
     description:
-      "An OIT-provisioned product-team namespace on the Oracle Cloud Infrastructure Kubernetes platform.",
+      "A containerized standalone application on Oracle Cloud Infrastructure, deployed and operated by OIT DevOps per the OIT pathway.",
   },
   {
-    value: "oit-on-prem-kubernetes",
-    label: "OIT-managed on-prem Kubernetes",
+    value: "standalone-oit-k8s",
+    label: "Standalone app — OIT on-prem Kubernetes",
+    oitManaged: true,
     description:
-      "An OIT-provisioned product-team namespace on the university's on-premises Kubernetes platform.",
+      "A containerized standalone application in an OIT-provisioned namespace on the university's on-premises Kubernetes platform.",
   },
   {
-    value: "iids-hosted",
-    label: "IIDS-hosted infrastructure",
+    value: "rcds-vm",
+    label: "Standalone app — RCDS VM (transitional)",
+    oitManaged: false,
     description:
-      "Hosted and operated on IIDS infrastructure outside the emerging OIT hosted-environment pathway.",
+      "A Docker-composed application on an IIDS/RCDS self-managed VM (the insight.uidaho.edu class). Staging and pilot hosting, not a long-term destination — projects here are pre-pathway.",
+  },
+  // ---- Rollup + meta values ------------------------------------------
+  {
+    value: "oit-managed-tbd",
+    label: "OIT-managed (target TBD)",
+    oitManaged: true,
+    description:
+      "OIT-managed production is the governance decision; which of the OIT targets has not yet been selected.",
+  },
+  {
+    value: "platform",
+    label: "Platform / shared infrastructure",
+    oitManaged: false,
+    description:
+      "This entry is itself a deployment platform or shared infrastructure (e.g. Nexus, MindRouter); workload target classification does not apply.",
   },
   {
     value: "external-hosted",
     label: "External or partner-hosted",
+    oitManaged: false,
     description:
       "Hosted by an external partner or vendor rather than on University of Idaho infrastructure.",
   },
   {
     value: "not-applicable",
     label: "Not applicable",
+    oitManaged: false,
     description:
       "The project is a scaffold, reference asset, or other deliverable without its own deployment target.",
   },
   {
     value: "to-be-determined",
     label: "To be determined",
+    oitManaged: false,
     description:
       "The proposed production environment has not yet been documented.",
   },
@@ -77,6 +111,19 @@ export function isDeploymentEnvironment(
   value: unknown
 ): value is DeploymentEnvironment {
   return DEPLOYMENT_ENVIRONMENTS.some((item) => item.value === value);
+}
+
+/**
+ * ADR 0001 sub-decision #5: production operated on an OIT-managed
+ * environment satisfies the accessibility rule. Encoded as a vocabulary
+ * flag rather than a value-name prefix so renames can't silently break
+ * the verifier.
+ */
+export function isOitManagedEnvironment(value: DeploymentEnvironment): boolean {
+  return (
+    DEPLOYMENT_ENVIRONMENTS.find((item) => item.value === value)?.oitManaged ??
+    false
+  );
 }
 
 export const ENTERPRISE_REPLACEMENT_STATUSES = [

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -138,6 +138,7 @@ interface ApplicationRow {
   external_deployments: string[];
   institutional_review_status: string | null;
   proposed_deployment_environment: DeploymentEnvironment;
+  current_deployment_environment: DeploymentEnvironment | null;
   enterprise_replacement_status: EnterpriseReplacementStatus;
   existing_enterprise_system_name: string | null;
   existing_enterprise_system_annual_cost_usd: string | number | null;
@@ -218,6 +219,7 @@ function toApplication(row: ApplicationRow): Application {
       (row.institutional_review_status as InstitutionalReviewStatus | null) ??
       undefined,
     proposedDeploymentEnvironment: row.proposed_deployment_environment,
+    currentDeploymentEnvironment: row.current_deployment_environment ?? undefined,
     enterpriseSystemReplacement: toEnterpriseSystemReplacement(row),
 
     // Project — lifecycle taxonomy (ADR 0001)
@@ -308,6 +310,7 @@ const APPLICATION_COLUMNS = `
   ai4ra_relationship, dual_destiny_planned, external_deployments,
   institutional_review_status,
   proposed_deployment_environment,
+  current_deployment_environment,
   enterprise_replacement_status,
   existing_enterprise_system_name,
   existing_enterprise_system_annual_cost_usd,

--- a/scripts/seed-portfolio.ts
+++ b/scripts/seed-portfolio.ts
@@ -302,7 +302,8 @@ async function seedProject(i: Project): Promise<{ id: string; blockers: number }
        enterprise_replacement_status,
        existing_enterprise_system_name,
        existing_enterprise_system_annual_cost_usd,
-       existing_enterprise_system_renewal_date
+       existing_enterprise_system_renewal_date,
+       current_deployment_environment
      )
      VALUES (
        $1, $2, $3, $4,
@@ -323,7 +324,8 @@ async function seedProject(i: Project): Promise<{ id: string; blockers: number }
        $39, $40, $41,
        $42::jsonb, $43, $44,
        $45, $46,
-       $47, $48, $49, $50, $51
+       $47, $48, $49, $50, $51,
+       $52
      )
      RETURNING id`,
     [
@@ -378,6 +380,7 @@ async function seedProject(i: Project): Promise<{ id: string; blockers: number }
       replacement.status === "yes" ? replacement.systemName : null,
       replacement.status === "yes" ? replacement.annualCostUsd : null,
       replacement.status === "yes" ? replacement.renewalDate ?? null : null,
+      i.currentDeploymentEnvironment ?? null,
     ]
   );
 


### PR DESCRIPTION
## What

Encodes the 2026-08-05 deployment-target definitional session as the typed vocabulary the harmonization work (projects + requests + survey themes) will classify against.

**The five targets** — form factor first, then hosting:

| Target | Form factor | Maturity |
|---|---|---|
| `databricks-dashboard` | Platform artifact (OIT lakehouse) | Aspirational — OIT's implementation unfinished, service undefined |
| `nexus-module` | Platform artifact (shared React+FastAPI app) | Available — RPR in production since Jul 2026 |
| `standalone-oci` | Standalone app, OIT-managed | Sanctioned, unproven |
| `standalone-oit-k8s` | Standalone app, OIT-managed | Sanctioned, unproven |
| `rcds-vm` | Standalone app, IIDS/RCDS self-managed | **Transitional by decision** — staging, not a destination |

Plus the `oit-managed-tbd` rollup (governance decision made, platform unpicked), a `platform` posture for entries that *are* infrastructure (Nexus, MindRouter, DGX Stack, Data Infrastructure Pilot), and the surviving meta values. Azure is dropped with zero uses — re-add the day OIT lands something there.

## Structural changes

- **Current/proposed split** (Migration 024): the RCDS VM being transitional means where a project runs now and where it's headed are separate facts. Nine insight.uidaho.edu apps + Vandalizer now record `currentDeploymentEnvironment: "rcds-vm"`; OpenERA and UCM Daily Register honestly show *running on RCDS VM, proposed Nexus module*.
- **Verifier**: ADR 0001 sub-decision #5 (OIT-managed production satisfies accessibility) now keys on the vocabulary's `oitManaged` flag instead of a `startsWith("oit-")` prefix, judged on current-over-proposed. New rule: `currentDeploymentEnvironment` may not be `to-be-determined` — absence carries that meaning.
- **`lib/deployment-targets.ts`** (new): per-target characteristics — operator, governance path, standards binding, data posture, time-to-deploy, maturity with evidence, and open questions (the Databricks unknowns are recorded as such). Data layer only; a rendering surface is a follow-up.

## Owner correction folded in

The Databricks Platform Deployment row in `lib/oit-ea-portfolio.ts` carried a **confirmed** crosswalk to the Data Infrastructure Pilot ("one effort, tracked from both sides", July 2026). Per Barrie 2026-08-05: **OIT's Databricks workspace is OIT-controlled in its entirety; the IIDS pilot serves AI4RA.** The crosswalk is decoupled to a `relatedSurface` note and the pilot's portfolio entry is reframed AI4RA-scoped.

## Verification

- `npm run build` ✓
- `npm run verify:portfolio` ✓ (29 projects, 0 errors; 2 pre-existing commit-date warnings)
- Migration 024 + full reseed against a local dev database (exercised the remap path on a DB five migrations behind) ✓
- Both detail-page render states checked in the browser (OpenERA: current ≠ proposed; RPR: current = proposed) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)