### PR TITLE
Add deployment-target classification to the request registry (ADR 0008, PR 2)

### DIFF
--- a/db/migrations/025_request_deployment_targets.sql
+++ b/db/migrations/025_request_deployment_targets.sql
@@ -1,0 +1,65 @@
+-- Migration 025: Deployment-target classification on the request registry
+--
+-- ADR 0008 (UTR Landscape), PR 2 of the delivery sequence: every open
+-- request gets a proposed deployment target so the Landscape can show
+-- demand against the five-target supply model (Migration 024).
+--
+-- Posture notes:
+--
+-- Registry-level, not per-origin: unlike the inferred_* columns on
+-- oit_idea_requests (Migration 023), destination classification applies
+-- to requests from every origin, so it lives on tech_requests itself.
+--
+-- CHECKed, not free: ADR 0008 binds this column to the same two-place
+-- discipline Migration 024 established for applications — the CHECK
+-- here and the vocabulary in lib/project-governance.ts change together.
+-- 'platform' is excluded (a request that would stand up a platform
+-- converts to a project first) and 'to-be-determined' is excluded
+-- (NULL carries "not yet classified"; the Landscape renders NULL rows
+-- as an explicit unclassified pool). 'external-hosted' is included
+-- because Track A purchase requests land on the vendor's
+-- infrastructure — much of the IDEA backlog is expected to classify
+-- there.
+--
+-- Confidence is structural: 'inferred' rows come from the MindRouter
+-- pass (scripts/infer-request-targets.ts) with provenance; 'confirmed'
+-- requires a named human and a timestamp. Inference NEVER overwrites a
+-- confirmed classification, and — mirroring Migrations 019/020/023 —
+-- never writes track/stage. Target assignment stays triage's call;
+-- the machine only proposes.
+
+BEGIN;
+
+ALTER TABLE tech_requests
+  ADD COLUMN proposed_deployment_target TEXT
+    CHECK (proposed_deployment_target IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'external-hosted',
+      'not-applicable'
+    )),
+  ADD COLUMN target_confidence TEXT
+    CHECK (target_confidence IN ('inferred', 'confirmed')),
+  ADD COLUMN target_inference_rationale TEXT,
+  ADD COLUMN target_inference_model TEXT,
+  ADD COLUMN target_inferred_at TIMESTAMPTZ,
+  ADD COLUMN target_confirmed_by TEXT,
+  ADD COLUMN target_confirmed_at TIMESTAMPTZ,
+  -- A classification always carries its confidence, and vice versa.
+  ADD CONSTRAINT tech_requests_target_coherence_check CHECK (
+    (proposed_deployment_target IS NULL) = (target_confidence IS NULL)
+  ),
+  -- 'confirmed' is a human act: it names who and when.
+  ADD CONSTRAINT tech_requests_target_confirmed_check CHECK (
+    target_confidence IS DISTINCT FROM 'confirmed'
+    OR (target_confirmed_by IS NOT NULL AND target_confirmed_at IS NOT NULL)
+  );
+
+CREATE INDEX idx_tech_requests_proposed_deployment_target
+  ON tech_requests (proposed_deployment_target);
+
+COMMIT;

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -12,9 +12,13 @@
 
 import { query } from "./db";
 import {
+  isRequestDeploymentTarget,
   isRequestDisposition,
+  isTargetConfidence,
+  type RequestDeploymentTarget,
   type RequestDisposition,
   type RequestOrigin,
+  type TargetConfidence,
 } from "./utr";
 import {
   isIdeaAiInvolvement,
@@ -62,6 +66,17 @@ export interface TechRequest {
   inferredTool: string | null;
   inferredDataSignals: IdeaDataSignal[];
   inferenceModel: string | null;
+  /**
+   * Deployment-target classification (Migration 025, ADR 0008).
+   * Confidence rides with the target — 'inferred' rows come from the
+   * MindRouter pass and must render distinguishably from 'confirmed';
+   * both null = the unclassified pool. The rationale is the one-line
+   * evidence a triage reviewer checks before confirming.
+   */
+  proposedDeploymentTarget: RequestDeploymentTarget | null;
+  targetConfidence: TargetConfidence | null;
+  targetInferenceRationale: string | null;
+  targetConfirmedBy: string | null;
 }
 
 interface TechRequestRow {
@@ -89,6 +104,10 @@ interface TechRequestRow {
   inferred_tool: string | null;
   inferred_data_signals: string[] | null;
   inference_model: string | null;
+  proposed_deployment_target: string | null;
+  target_confidence: string | null;
+  target_inference_rationale: string | null;
+  target_confirmed_by: string | null;
 }
 
 function toTechRequest(row: TechRequestRow): TechRequest {
@@ -128,6 +147,18 @@ function toTechRequest(row: TechRequestRow): TechRequest {
       isIdeaDataSignal
     ),
     inferenceModel: row.inference_model,
+    // Target + confidence degrade together: the DB coherence CHECK
+    // (Migration 025) makes them non-null in pairs, and a value outside
+    // the typed vocabulary drops the pair rather than corrupting it.
+    ...(isRequestDeploymentTarget(row.proposed_deployment_target) &&
+    isTargetConfidence(row.target_confidence)
+      ? {
+          proposedDeploymentTarget: row.proposed_deployment_target,
+          targetConfidence: row.target_confidence,
+        }
+      : { proposedDeploymentTarget: null, targetConfidence: null }),
+    targetInferenceRationale: row.target_inference_rationale,
+    targetConfirmedBy: row.target_confirmed_by,
   };
 }
 
@@ -154,7 +185,11 @@ export async function listTechRequests(): Promise<TechRequest[]> {
        oir.inferred_ai_involvement,
        oir.inferred_tool,
        oir.inferred_data_signals,
-       oir.inference_model
+       oir.inference_model,
+       tr.proposed_deployment_target,
+       tr.target_confidence,
+       tr.target_inference_rationale,
+       tr.target_confirmed_by
      FROM tech_requests tr
      LEFT JOIN clickup_requests cr ON cr.clickup_task_id = tr.clickup_task_id
      LEFT JOIN submissions s ON s.id = tr.submission_id

--- a/lib/utr.ts
+++ b/lib/utr.ts
@@ -17,6 +17,8 @@
 // land with their tables in ADR 0005 Phase 3; this module carries what
 // Phase 1 writes and renders.
 
+import type { DeploymentEnvironment } from "./project-governance";
+
 // ---- Tracks -----------------------------------------------------------
 // Fast Lane / Track A / B / C from the request routing, plus `external`
 // for work tracked in the inventory that predates (or sits outside) the
@@ -210,6 +212,64 @@ export type RequestProjectLinkType =
 // Request ↔ request (tech_request_links).
 
 export type RequestLinkType = "duplicate-of" | "roi-aggregates-to" | "related";
+
+// ---- Deployment-target classification (ADR 0008) ----------------------
+// Which deployment targets a request may classify to (Migration 025).
+// The values are a subset of the governance vocabulary
+// (lib/project-governance.ts): 'platform' is excluded (a platform-
+// standing request converts to a project first) and 'to-be-determined'
+// is excluded (NULL carries "not yet classified" — the UTR Landscape
+// renders those as an explicit unclassified pool, never silently).
+// 'external-hosted' is included: Track A purchase requests land on the
+// vendor's infrastructure.
+
+export type RequestDeploymentTarget = Extract<
+  DeploymentEnvironment,
+  | "databricks-dashboard"
+  | "nexus-module"
+  | "standalone-oci"
+  | "standalone-oit-k8s"
+  | "rcds-vm"
+  | "oit-managed-tbd"
+  | "external-hosted"
+  | "not-applicable"
+>;
+
+export const REQUEST_DEPLOYMENT_TARGETS: RequestDeploymentTarget[] = [
+  "databricks-dashboard",
+  "nexus-module",
+  "standalone-oci",
+  "standalone-oit-k8s",
+  "rcds-vm",
+  "oit-managed-tbd",
+  "external-hosted",
+  "not-applicable",
+];
+
+export function isRequestDeploymentTarget(
+  value: unknown
+): value is RequestDeploymentTarget {
+  return (
+    typeof value === "string" &&
+    (REQUEST_DEPLOYMENT_TARGETS as string[]).includes(value)
+  );
+}
+
+// Structural (CHECKed in Migration 025): a classification is either a
+// machine proposal with provenance or a named human's confirmation.
+// Surfaces must render 'inferred' distinguishably, always (ADR 0008
+// honesty rules).
+
+export type TargetConfidence = "inferred" | "confirmed";
+
+export const TARGET_CONFIDENCE_LABEL: Record<TargetConfidence, string> = {
+  inferred: "Inferred",
+  confirmed: "Confirmed",
+};
+
+export function isTargetConfidence(value: unknown): value is TargetConfidence {
+  return value === "inferred" || value === "confirmed";
+}
 
 // ---- ROI claim vocabularies (roi_claims) ------------------------------
 // Dimensions extend as the ROI framework the working group is drafting

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sync:clickup": "tsx --env-file=.env.local scripts/sync-clickup.ts",
     "import:idea-requests": "tsx --env-file=.env.local scripts/import-idea-requests.ts",
     "infer:idea-requests": "tsx --env-file=.env.local scripts/infer-idea-requests.ts",
+    "infer:request-targets": "tsx --env-file=.env.local scripts/infer-request-targets.ts",
     "eval:agent": "NODE_OPTIONS='--conditions=react-server' tsx --env-file=.env.local --tsconfig tsconfig.json evals/agent/run.ts"
   },
   "dependencies": {

--- a/scripts/infer-request-targets.ts
+++ b/scripts/infer-request-targets.ts
@@ -1,0 +1,321 @@
+// scripts/infer-request-targets.ts
+//
+// The MindRouter deployment-target pass over the request registry
+// (ADR 0008, PR 2): reads each open request from `tech_requests` and
+// proposes which deployment target it would land on (Migration 025),
+// so the UTR Landscape can show demand against the five-target supply
+// model.
+//
+// Posture (mirrors scripts/infer-idea-requests.ts): machine claims
+// with provenance (target_inference_model, target_inferred_at, a
+// one-line rationale for the triage reviewer), rendered only as
+// "inferred" on any surface. The pass NEVER touches a row a human has
+// confirmed (target_confidence = 'confirmed'), and never writes
+// track/stage — target assignment stays triage's call; the machine
+// only proposes.
+//
+// The prompt is built from the same typed vocabulary the site renders
+// (lib/project-governance.ts descriptions; the two-step selection
+// model from lib/deployment-targets.ts), so the model classifies
+// against exactly the targets triage confirms. The model may return
+// null when the text genuinely cannot support a classification — the
+// row stays NULL and the Landscape shows it in the unclassified pool
+// rather than carrying a junk guess.
+//
+// Every response is validated against the typed guards; an invalid
+// response gets one corrective retry with the validation errors
+// appended, then the row is skipped with a warning — junk is never
+// written.
+//
+// Usage (needs DATABASE_URL + MINDROUTER_API_KEY; MINDROUTER_MODEL
+// optional):
+//   npm run infer:request-targets                # open rows not yet inferred
+//   npm run infer:request-targets -- --limit 3   # smoke test
+//   npm run infer:request-targets -- --force     # re-infer (inferred rows only)
+//   npm run infer:request-targets -- --dry-run   # list target rows, no calls
+
+import { Pool } from "pg";
+import {
+  ask,
+  parseJsonLoose,
+  currentMindRouterModel,
+  MindRouterError,
+} from "../lib/mindrouter.js";
+import {
+  isRequestDeploymentTarget,
+  INTAKE_TRACK_TITLE,
+  isIntakeTrack,
+  type RequestDeploymentTarget,
+} from "../lib/utr.js";
+import { DEPLOYMENT_ENVIRONMENT_DESCRIPTIONS } from "../lib/project-governance.js";
+
+const CONCURRENCY = 3;
+const MAX_TOKENS = 4096;
+const RETRY_MAX_TOKENS = 8192;
+
+interface TargetRow {
+  id: string;
+  title: string;
+  need_statement: string | null;
+  requestor_unit: string | null;
+  origin: string;
+  track: string | null;
+  inferred_track: string | null;
+  idea_description: string | null;
+}
+
+interface TargetInference {
+  target: RequestDeploymentTarget | null;
+  rationale: string;
+}
+
+// ── Prompt ───────────────────────────────────────────────────────────
+
+const TARGET_DEFS = (
+  [
+    "databricks-dashboard",
+    "nexus-module",
+    "standalone-oci",
+    "standalone-oit-k8s",
+    "rcds-vm",
+    "oit-managed-tbd",
+    "external-hosted",
+    "not-applicable",
+  ] as const
+)
+  .map((slug) => `- "${slug}": ${DEPLOYMENT_ENVIRONMENT_DESCRIPTIONS[slug]}`)
+  .join("\n");
+
+const SYSTEM_PROMPT = `You classify technology requests at the University of Idaho by the deployment target the requested capability would land on if pursued. Given a request's title, origin, requesting unit, intake track (when assigned), and prose description, return ONLY a JSON object with exactly these fields:
+
+{
+  "target": "databricks-dashboard" | "nexus-module" | "standalone-oci" | "standalone-oit-k8s" | "rcds-vm" | "oit-managed-tbd" | "external-hosted" | "not-applicable" | null,
+  "rationale": string
+}
+
+The targets:
+
+${TARGET_DEFS}
+
+Classify with a two-step decision — form factor first, then hosting:
+
+1. Form factor. Is the substance of the request a report, dashboard, metric, or recurring data product over institutional data? → "databricks-dashboard". Is it a transactional staff workflow (validated intake, review queue, approvals, records over Banner-adjacent data) that fits a template web module? → "nexus-module". Is it the purchase, license, or subscription of an existing commercial product? → "external-hosted" (the vendor hosts it). Is it access to existing data, a report that already exists, a policy question, or otherwise nothing that deploys? → "not-applicable".
+2. Hosting, only for builds that don't fit the above: a standalone application needing OIT-managed production goes to "standalone-oci" or "standalone-oit-k8s" (prefer "oit-managed-tbd" unless the text itself indicates on-prem residency, AI-compute adjacency, or a specific platform); an early pilot that would iterate on IIDS research infrastructure before entering the OIT pathway is "rcds-vm".
+
+Intake-track correlation (a hint, not a rule — the description wins):
+- ${INTAKE_TRACK_TITLE["track-a"]} → usually "external-hosted".
+- ${INTAKE_TRACK_TITLE["track-b"]} / ${INTAKE_TRACK_TITLE["track-c"]} → usually "nexus-module", a standalone target, or "rcds-vm" for early pilots.
+- ${INTAKE_TRACK_TITLE["track-d"]} → "databricks-dashboard" when a new report or data product would be produced; "not-applicable" when it is access to something that already exists.
+
+Return null for "target" when the text genuinely cannot support a classification — a null is more useful than a guess.
+
+"rationale": one plain factual sentence a triage reviewer can check the classification against. No hype, no recommendation.
+
+Return ONLY the JSON object, no markdown fences, no commentary.`;
+
+function userMessage(row: TargetRow): string {
+  const track = row.track ?? row.inferred_track;
+  const description = row.need_statement ?? row.idea_description;
+  return [
+    `Title: ${row.title}`,
+    `Origin: ${row.origin}`,
+    row.requestor_unit ? `Requesting unit: ${row.requestor_unit}` : null,
+    track && isIntakeTrack(track)
+      ? `Intake track${row.track ? "" : " (inferred)"}: ${INTAKE_TRACK_TITLE[track]}`
+      : null,
+    description ? `Description:\n${description}` : "Description: (none provided)",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+// ── Validation ───────────────────────────────────────────────────────
+
+function validate(
+  raw: unknown
+): { ok: true; value: TargetInference } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+  const o = (raw ?? {}) as Record<string, unknown>;
+
+  if (o.target !== null && !isRequestDeploymentTarget(o.target)) {
+    errors.push(`target: got ${JSON.stringify(o.target)}`);
+  }
+  if (typeof o.rationale !== "string" || !o.rationale.trim()) {
+    errors.push("rationale: missing or empty");
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    value: {
+      target: o.target as RequestDeploymentTarget | null,
+      rationale: (o.rationale as string).trim().slice(0, 500),
+    },
+  };
+}
+
+// ── Inference ────────────────────────────────────────────────────────
+
+async function callModel(row: TargetRow, correction?: string): Promise<unknown> {
+  const message = correction
+    ? `${userMessage(row)}\n\nYour previous answer was invalid: ${correction}. Return a corrected JSON object.`
+    : userMessage(row);
+  let raw: string;
+  try {
+    raw = await ask(message, SYSTEM_PROMPT, true, {
+      max_tokens: MAX_TOKENS,
+      temperature: 0.1,
+      reasoning_effort: "low",
+    });
+  } catch (error) {
+    // Same budget-exhaustion fallback as analyzeIdea (lib/mindrouter.ts).
+    if (error instanceof MindRouterError && error.isReasoningBudgetExhausted) {
+      raw = await ask(message, SYSTEM_PROMPT, true, {
+        max_tokens: RETRY_MAX_TOKENS,
+        temperature: 0.1,
+        reasoning_effort: "none",
+      });
+    } else {
+      throw error;
+    }
+  }
+  return parseJsonLoose(raw);
+}
+
+async function inferRow(row: TargetRow): Promise<TargetInference> {
+  let result = validate(await callModel(row));
+  if (!result.ok) {
+    result = validate(await callModel(row, result.errors.join("; ")));
+  }
+  if (!result.ok) {
+    throw new Error(`invalid after retry: ${result.errors.join("; ")}`);
+  }
+  return result.value;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  const limitIdx = args.indexOf("--limit");
+  const limit =
+    limitIdx !== -1 && args[limitIdx + 1] ? Number(args[limitIdx + 1]) : null;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  // Open rows only (the working queue). A confirmed classification is
+  // a human decision and is never re-inferred, --force or not.
+  const rows = (
+    await pool.query<TargetRow>(
+      `SELECT tr.id, tr.title, tr.need_statement, tr.requestor_unit,
+              tr.origin, tr.track,
+              oir.inferred_track,
+              oir.description AS idea_description
+       FROM tech_requests tr
+       LEFT JOIN oit_idea_requests oir ON oir.source_key = tr.oit_idea_key
+       WHERE tr.disposition = 'open'
+         AND tr.target_confidence IS DISTINCT FROM 'confirmed'
+         ${force ? "" : "AND tr.target_inferred_at IS NULL"}
+       ORDER BY tr.received_at DESC
+       ${limit ? `LIMIT ${limit}` : ""}`
+    )
+  ).rows;
+
+  console.log(
+    `${rows.length} open request(s) to infer${force ? " (--force)" : ""}${limit ? ` (limit ${limit})` : ""}.`
+  );
+  if (dryRun) {
+    for (const row of rows) console.log(`  [${row.origin}] ${row.title}`);
+    console.log("--dry-run: no MindRouter calls, no writes.");
+    await pool.end();
+    return;
+  }
+  if (rows.length === 0) {
+    await pool.end();
+    return;
+  }
+
+  const model = currentMindRouterModel();
+  console.log(`Model: ${model}, concurrency ${CONCURRENCY}.\n`);
+
+  const failures: { title: string; error: string }[] = [];
+  let done = 0;
+  let unclassified = 0;
+  const tally = new Map<string, number>();
+  const queue = [...rows];
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const row = queue.shift();
+      if (!row) return;
+      try {
+        const inf = await inferRow(row);
+        if (inf.target === null) {
+          // Provenance still recorded so the row isn't re-queued every
+          // run; target/confidence stay NULL (the unclassified pool).
+          await pool.query(
+            `UPDATE tech_requests SET
+               target_inference_rationale = $2,
+               target_inference_model = $3,
+               target_inferred_at = now()
+             WHERE id = $1`,
+            [row.id, inf.rationale, model]
+          );
+          unclassified++;
+        } else {
+          await pool.query(
+            `UPDATE tech_requests SET
+               proposed_deployment_target = $2,
+               target_confidence = 'inferred',
+               target_inference_rationale = $3,
+               target_inference_model = $4,
+               target_inferred_at = now()
+             WHERE id = $1`,
+            [row.id, inf.target, inf.rationale, model]
+          );
+          tally.set(inf.target, (tally.get(inf.target) ?? 0) + 1);
+        }
+        done++;
+        console.log(
+          `  ✓ (${done}/${rows.length}) ${row.title.slice(0, 55).padEnd(55)} ${inf.target ?? "(unclassified)"}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        failures.push({ title: row.title, error: msg });
+        console.warn(`  ✗ ${row.title}: ${msg}`);
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, rows.length) }, worker)
+  );
+  await pool.end();
+
+  console.log(`\nInferred ${done}/${rows.length}.`);
+  for (const [target, n] of [...tally.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(3)}  ${target}`);
+  }
+  if (unclassified > 0) {
+    console.log(`  ${String(unclassified).padStart(3)}  (unclassified — null)`);
+  }
+  if (failures.length > 0) {
+    console.warn(
+      `${failures.length} failed (re-run to retry just these — they stay NULL):`
+    );
+    for (const f of failures) console.warn(`  - ${f.title}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error("Inference pass failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
PR 2 of the [ADR 0008](docs/adr/0008-utr-landscape.md) sequence — the demand side of the UTR Landscape gets its target axis.

## What

- **Migration 025**: `proposed_deployment_target` + `target_confidence` on `tech_requests`, with provenance columns (`target_inference_rationale`, `target_inference_model`, `target_inferred_at`, `target_confirmed_by/at`). Registry-level — unlike the per-origin `inferred_*` columns from Migration 023 — because destination classification applies to requests from every origin. CHECKed in lockstep with `lib/project-governance.ts` per the ADR. Coherence constraints: target and confidence are non-null together; `confirmed` requires a named human and timestamp.
- **`lib/utr.ts`**: `RequestDeploymentTarget` (the vocabulary subset requests may classify to — `platform` and `to-be-determined` excluded, `external-hosted` included because Track A purchases land on vendor infrastructure) + `TargetConfidence`.
- **`scripts/infer-request-targets.ts`** (`npm run infer:request-targets`): the MindRouter pass, mirroring `infer-idea-requests.ts` — prompt built from the typed vocabulary and the two-step selection model (form factor first, then hosting), track-correlation hints, validated with one corrective retry, junk never written. Open rows only; a **confirmed classification is never re-inferred, `--force` or not**; the model may return null and the row stays in the unclassified pool with provenance recorded.
- **`lib/requests.ts`**: reads the new columns; target + confidence degrade together on vocabulary drift.

## Verified

- Migration 025 applied to the local dev DB; IDEA import (58 rows) + dry-run shows 70 open requests queued correctly.
- `npm run build` and `npm run lint` clean.

## After merge

Run the live pass on dev (`npm run infer:request-targets`, needs `MINDROUTER_API_KEY`) — its closing tally is the first real demand-by-target distribution for the mismatch ledger (PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
