### PR TITLE
Add the UTR Landscape read model and mismatch ledger (ADR 0008, PR 3)

### DIFF
--- a/lib/utr-landscape.ts
+++ b/lib/utr-landscape.ts
@@ -1,0 +1,416 @@
+// ============================================================
+// UTR Landscape — the destination-harmonized activity model
+// ============================================================
+// ADR 0008, PR 3: one read model joining the two activity populations
+// (projects in flight, open requests) against the five-target supply
+// model, plus the computed mismatch ledger the surface leads with.
+//
+// Pure by design: `buildUtrLandscape()` takes its sources as arguments
+// and touches no I/O, so the page composes it from lib/work.ts +
+// lib/requests.ts while scripts and tests can feed it lib/portfolio.ts
+// entries or fixtures directly (lib/work.ts is server-only; this module
+// must not be).
+//
+// Honesty rules (ADR 0008 §5), enforced structurally here:
+// - Maturity language comes only from lib/deployment-targets.ts.
+// - Every count in a finding is computed from the sources at build
+//   time; a finding whose condition doesn't hold is not emitted.
+// - A request's inferred target never loses its 'inferred' marking.
+// - Activities with no classification land in an explicit unclassified
+//   pool — never silently dropped.
+
+import {
+  OPERATIONAL_LABEL,
+  type ProjectStatus,
+} from "./portfolio";
+import type { DeploymentEnvironment } from "./project-governance";
+import {
+  DEPLOYMENT_TARGETS,
+  type DeploymentTargetProfile,
+  type DeploymentTarget,
+} from "./deployment-targets";
+import { REQUEST_ORIGIN_LABEL } from "./utr";
+import type { TechRequest } from "./requests";
+
+// ---- Sources ----------------------------------------------------------
+// Structural subsets: lib/portfolio.ts `Project` and lib/work.ts
+// `Application` both satisfy LandscapeProjectSource, so either side of
+// the typed-shadow/Postgres seam can feed the builder.
+
+export interface LandscapeProjectSource {
+  slug: string;
+  name: string;
+  homeUnits: string[];
+  operationalOwners: { name: string; title?: string }[];
+  status: ProjectStatus;
+  proposedDeploymentEnvironment: DeploymentEnvironment;
+  currentDeploymentEnvironment?: DeploymentEnvironment;
+  trackingOnly?: boolean;
+}
+
+export type LandscapeRequestSource = Pick<
+  TechRequest,
+  | "id"
+  | "title"
+  | "origin"
+  | "disposition"
+  | "requestorName"
+  | "requestorUnit"
+  | "proposedDeploymentTarget"
+  | "targetConfidence"
+  | "targetInferenceRationale"
+>;
+
+// ---- Activities -------------------------------------------------------
+
+/**
+ * How a target classification is known. Projects are 'authored' — the
+ * entry is owner-reviewed in lib/portfolio.ts. Requests are 'inferred'
+ * (machine proposal, provenance recorded) until triage confirms.
+ */
+export type TargetProvenance = "authored" | "inferred" | "confirmed";
+
+export interface LandscapeActivity {
+  kind: "project" | "request";
+  /** Portfolio slug or tech_request id. */
+  ref: string;
+  /** Where the site tells this activity's full story (one-story rule:
+   *  the Landscape is a projection, never a second detail view). */
+  href: string;
+  name: string;
+  unit: string | null;
+  ownerName: string | null;
+  /** Human-readable position: operational status or request origin. */
+  position: string;
+  currentTarget: DeploymentEnvironment | null;
+  proposedTarget: DeploymentEnvironment | null;
+  provenance: TargetProvenance | null;
+  /** The one-line machine rationale, present on inferred requests. */
+  inferenceRationale: string | null;
+}
+
+function projectActivity(p: LandscapeProjectSource): LandscapeActivity {
+  return {
+    kind: "project",
+    ref: p.slug,
+    href: `/portfolio/${p.slug}`,
+    name: p.name,
+    unit: p.homeUnits[0] ?? null,
+    ownerName: p.operationalOwners[0]?.name ?? null,
+    position: OPERATIONAL_LABEL[p.status],
+    currentTarget: p.currentDeploymentEnvironment ?? null,
+    proposedTarget: p.proposedDeploymentEnvironment,
+    provenance: "authored",
+    inferenceRationale: null,
+  };
+}
+
+function requestActivity(r: LandscapeRequestSource): LandscapeActivity {
+  return {
+    kind: "request",
+    ref: r.id,
+    href: "/portfolio/pipeline",
+    name: r.title,
+    unit: r.requestorUnit,
+    ownerName: r.requestorName,
+    position: `Open request · ${REQUEST_ORIGIN_LABEL[r.origin]}`,
+    currentTarget: null,
+    proposedTarget: r.proposedDeploymentTarget,
+    provenance: r.targetConfidence,
+    inferenceRationale:
+      r.targetConfidence === "inferred" ? r.targetInferenceRationale : null,
+  };
+}
+
+// ---- Bands and pools --------------------------------------------------
+
+export interface TargetBand {
+  profile: DeploymentTargetProfile;
+  /** Projects whose current environment is this target. */
+  running: LandscapeActivity[];
+  /** Projects proposed here that don't run here yet. */
+  headed: LandscapeActivity[];
+  /** Open requests classified to this target. */
+  queued: LandscapeActivity[];
+}
+
+/**
+ * Activity that classifies outside the five targets. Each pool is a
+ * deliberate bucket, not a leftover: vendor-hosted demand shapes the
+ * Track A story, `oit-managed-tbd` records a made decision awaiting a
+ * platform pick, `noDeployment` is request substance that never
+ * deploys, `platforms` are the entries that ARE supply, and
+ * `unclassified` is the honesty pool the ADR requires.
+ */
+export interface LandscapePools {
+  externalHosted: LandscapeActivity[];
+  oitManagedTbd: LandscapeActivity[];
+  noDeployment: LandscapeActivity[];
+  platforms: LandscapeActivity[];
+  unclassified: LandscapeActivity[];
+}
+
+// ---- Findings (the mismatch ledger) -----------------------------------
+
+export type LandscapeFindingKind =
+  | "transitional-load"
+  | "gate-concentration"
+  | "demand-on-aspirational-supply"
+  | "unproven-supply"
+  | "vendor-demand"
+  | "unclassified-pool";
+
+export interface LandscapeFinding {
+  kind: LandscapeFindingKind;
+  /** The ledger sentence — every number computed from the sources. */
+  headline: string;
+  /** Supporting sentence(s); may carry typed context (e.g. the survey
+   *  evidence behind the Databricks understatement). */
+  detail: string;
+  /** Where a reader verifies the claim. */
+  evidence: { label: string; href: string }[];
+  /** The raw numbers behind the headline, for rendering emphasis. */
+  counts: Record<string, number>;
+}
+
+export interface UtrLandscape {
+  bands: TargetBand[];
+  pools: LandscapePools;
+  findings: LandscapeFinding[];
+  totals: {
+    projects: number;
+    openRequests: number;
+    classifiedOpenRequests: number;
+  };
+}
+
+// ---- Builder ----------------------------------------------------------
+
+const OIT_MANAGED_NEXT_HOMES: DeploymentEnvironment[] = [
+  "databricks-dashboard",
+  "nexus-module",
+  "standalone-oci",
+  "standalone-oit-k8s",
+  "oit-managed-tbd",
+];
+
+function plural(n: number, singular: string, pluralForm?: string): string {
+  return n === 1 ? singular : (pluralForm ?? `${singular}s`);
+}
+
+export function buildUtrLandscape(
+  projectSources: LandscapeProjectSource[],
+  requestSources: LandscapeRequestSource[]
+): UtrLandscape {
+  // Archived entries are history, not landscape. Everything else —
+  // including paused and tracked work — is honestly part of the map.
+  const projects = projectSources
+    .filter((p) => p.status !== "archived")
+    .map(projectActivity);
+  const openRequests = requestSources
+    .filter((r) => r.disposition === "open")
+    .map(requestActivity);
+
+  const bands: TargetBand[] = DEPLOYMENT_TARGETS.map((profile) => ({
+    profile,
+    running: projects.filter((a) => a.currentTarget === profile.value),
+    headed: projects.filter(
+      (a) =>
+        a.proposedTarget === profile.value &&
+        a.currentTarget !== profile.value
+    ),
+    queued: openRequests.filter((a) => a.proposedTarget === profile.value),
+  }));
+
+  const pools: LandscapePools = {
+    externalHosted: [...projects, ...openRequests].filter(
+      (a) => a.proposedTarget === "external-hosted"
+    ),
+    oitManagedTbd: [...projects, ...openRequests].filter(
+      (a) => a.proposedTarget === "oit-managed-tbd"
+    ),
+    noDeployment: openRequests.filter(
+      (a) => a.proposedTarget === "not-applicable"
+    ),
+    platforms: projects.filter((a) => a.proposedTarget === "platform"),
+    unclassified: [
+      ...projects.filter((a) => a.proposedTarget === "to-be-determined"),
+      ...openRequests.filter((a) => a.proposedTarget === null),
+    ],
+  };
+
+  const classifiedOpenRequests = openRequests.filter(
+    (a) => a.proposedTarget !== null
+  );
+
+  const findings = computeFindings(bands, pools, openRequests.length, classifiedOpenRequests.length);
+
+  return {
+    bands,
+    pools,
+    findings,
+    totals: {
+      projects: projects.length,
+      openRequests: openRequests.length,
+      classifiedOpenRequests: classifiedOpenRequests.length,
+    },
+  };
+}
+
+function band(bands: TargetBand[], value: DeploymentTarget): TargetBand {
+  const found = bands.find((b) => b.profile.value === value);
+  if (!found) throw new Error(`Missing target band: ${value}`);
+  return found;
+}
+
+function computeFindings(
+  bands: TargetBand[],
+  pools: LandscapePools,
+  openRequestCount: number,
+  classifiedCount: number
+): LandscapeFinding[] {
+  const findings: LandscapeFinding[] = [];
+
+  // 1 — Transitional load: workloads on the RCDS VM, and how many have
+  // no confirmed next home (proposed is TBD or the VM itself).
+  const rcds = band(bands, "rcds-vm");
+  if (rcds.running.length > 0) {
+    const noNextHome = rcds.running.filter(
+      (a) =>
+        a.proposedTarget === null ||
+        !OIT_MANAGED_NEXT_HOMES.includes(a.proposedTarget)
+    );
+    findings.push({
+      kind: "transitional-load",
+      headline: `${rcds.running.length} ${plural(rcds.running.length, "workload")} run on the RCDS VM — transitional by decision — and ${noNextHome.length} of them ${noNextHome.length === 1 ? "has" : "have"} no confirmed next home.`,
+      detail:
+        "The RCDS VM is staging, not a destination. Every workload here eventually needs a pathway plan to an OIT-managed target or an explicit decision to stay.",
+      evidence: [
+        { label: "RCDS VM band", href: "/utr-landscape/rcds-vm" },
+        { label: "Projects", href: "/portfolio" },
+      ],
+      counts: {
+        running: rcds.running.length,
+        noNextHome: noNextHome.length,
+      },
+    });
+  }
+
+  // 2 — Gate concentration: everything pointed at Nexus vs. how many
+  // workloads have actually completed the pathway.
+  const nexus = band(bands, "nexus-module");
+  const nexusDemand = nexus.headed.length + nexus.queued.length;
+  if (nexusDemand > 0) {
+    findings.push({
+      kind: "gate-concentration",
+      headline: `${nexusDemand} ${plural(nexusDemand, "activity", "activities")} point at Nexus — ${nexus.headed.length} ${plural(nexus.headed.length, "project")} in flight and ${nexus.queued.length} open ${plural(nexus.queued.length, "request")} — while ${nexus.running.length} ${nexus.running.length === 1 ? "workload has" : "workloads have"} completed the pathway to date.`,
+      detail: nexus.profile.timeToDeploy,
+      evidence: [
+        { label: "Nexus band", href: "/utr-landscape/nexus-module" },
+        { label: "OIT pathway", href: "/coordination/oit-pathway" },
+      ],
+      counts: {
+        headed: nexus.headed.length,
+        queued: nexus.queued.length,
+        running: nexus.running.length,
+      },
+    });
+  }
+
+  // 3 — Demand on aspirational supply: requests classified to
+  // Databricks while the service is not yet offered. The request count
+  // understates this demand: the reconciliation theme in the
+  // Operational Excellence survey is dashboard-on-lakehouse shaped but
+  // never entered the request queue.
+  const databricks = band(bands, "databricks-dashboard");
+  if (
+    databricks.profile.maturity === "aspirational" &&
+    databricks.queued.length > 0
+  ) {
+    findings.push({
+      kind: "demand-on-aspirational-supply",
+      headline: `${databricks.queued.length} open ${plural(databricks.queued.length, "request")} ${databricks.queued.length === 1 ? "classifies" : "classify"} to the Databricks dashboard target, which cannot receive them: ${databricks.profile.maturityNote}`,
+      detail:
+        "The request count understates report-shaped demand — the Operational Excellence survey's reconciliation theme (numbers that don't agree across Banner, Slate, Argos, Sunapsis) is dashboard-on-lakehouse shaped and never entered the request queue.",
+      evidence: [
+        {
+          label: "Databricks band",
+          href: "/utr-landscape/databricks-dashboard",
+        },
+        {
+          label: "Op Excellence survey",
+          href: "/coordination/operational-excellence",
+        },
+      ],
+      counts: { queued: databricks.queued.length },
+    });
+  }
+
+  // 4 — Unproven supply: activity pointed at sanctioned targets nothing
+  // has landed on.
+  const oci = band(bands, "standalone-oci");
+  const k8s = band(bands, "standalone-oit-k8s");
+  const unprovenDemand =
+    oci.headed.length + oci.queued.length + k8s.headed.length + k8s.queued.length;
+  const unprovenLanded = oci.running.length + k8s.running.length;
+  if (unprovenDemand > 0 && unprovenLanded === 0) {
+    findings.push({
+      kind: "unproven-supply",
+      headline: `${unprovenDemand} ${plural(unprovenDemand, "activity", "activities")} point at the standalone OIT targets (OCI, on-prem Kubernetes) — no workload has ever landed on either.`,
+      detail:
+        "Both targets are named in the OIT drafts as approved platforms. The first landing will set the real timeline for everything behind it.",
+      evidence: [
+        { label: "OCI band", href: "/utr-landscape/standalone-oci" },
+        { label: "OIT K8s band", href: "/utr-landscape/standalone-oit-k8s" },
+      ],
+      counts: { demand: unprovenDemand },
+    });
+  }
+
+  // 5 — Vendor demand: the share of classified open requests that are
+  // purchase-shaped and land on vendor infrastructure.
+  const vendorRequests = pools.externalHosted.filter(
+    (a) => a.kind === "request"
+  );
+  if (vendorRequests.length > 0 && classifiedCount > 0) {
+    const share = Math.round((vendorRequests.length / classifiedCount) * 100);
+    findings.push({
+      kind: "vendor-demand",
+      headline: `${share}% of classified open demand (${vendorRequests.length} of ${classifiedCount} requests) is purchase-shaped — it lands on vendor infrastructure, not a university target.`,
+      detail:
+        "The institutional build capacity question is smaller than the raw queue suggests; most of the queue is a Track A governance question, not a deployment question.",
+      evidence: [
+        { label: "Request queue", href: "/portfolio/pipeline" },
+      ],
+      counts: {
+        vendor: vendorRequests.length,
+        classified: classifiedCount,
+      },
+    });
+  }
+
+  // 6 — The honesty pool: what the model doesn't cover yet.
+  const unclassifiedRequests = pools.unclassified.filter(
+    (a) => a.kind === "request"
+  ).length;
+  const undeterminedProjects = pools.unclassified.filter(
+    (a) => a.kind === "project"
+  ).length;
+  if (unclassifiedRequests + undeterminedProjects > 0) {
+    findings.push({
+      kind: "unclassified-pool",
+      headline: `${undeterminedProjects} ${plural(undeterminedProjects, "project")} and ${unclassifiedRequests} open ${plural(unclassifiedRequests, "request")} carry no destination yet.`,
+      detail:
+        "Unclassified is a state, not an omission — these rows are the working queue for target triage.",
+      evidence: [
+        { label: "Unclassified pool", href: "/utr-landscape#unclassified" },
+      ],
+      counts: {
+        projects: undeterminedProjects,
+        requests: unclassifiedRequests,
+      },
+    });
+  }
+
+  return findings;
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "import:idea-requests": "tsx --env-file=.env.local scripts/import-idea-requests.ts",
     "infer:idea-requests": "tsx --env-file=.env.local scripts/infer-idea-requests.ts",
     "infer:request-targets": "tsx --env-file=.env.local scripts/infer-request-targets.ts",
+    "print:utr-landscape": "tsx --env-file=.env.local scripts/print-utr-landscape.ts",
     "eval:agent": "NODE_OPTIONS='--conditions=react-server' tsx --env-file=.env.local --tsconfig tsconfig.json evals/agent/run.ts"
   },
   "dependencies": {

--- a/scripts/print-utr-landscape.ts
+++ b/scripts/print-utr-landscape.ts
@@ -1,0 +1,60 @@
+// scripts/print-utr-landscape.ts
+//
+// Smoke harness for lib/utr-landscape.ts (ADR 0008, PR 3): builds the
+// landscape from the typed portfolio module + the live request registry
+// and prints the bands, pools, and mismatch-ledger sentences. This is
+// the same pure builder the surface (PR 4) renders — the script exists
+// so the computations can be reviewed against real data before any UI.
+//
+// Project source note: this harness feeds lib/portfolio.ts (the typed
+// shadow) rather than lib/work.ts (the Postgres read path the page
+// uses) because work.ts is server-only. The two carry the same rows
+// whenever the seed is current; buildUtrLandscape accepts either.
+//
+// Usage (needs DATABASE_URL):
+//   npm run print:utr-landscape
+//   npm run print:utr-landscape -- --json   # full model as JSON
+
+import { projects } from "../lib/portfolio.js";
+import { listTechRequests } from "../lib/requests.js";
+import { buildUtrLandscape } from "../lib/utr-landscape.js";
+
+async function main(): Promise<void> {
+  const requests = await listTechRequests();
+  const landscape = buildUtrLandscape(projects, requests);
+
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(landscape, null, 2));
+    return;
+  }
+
+  console.log(
+    `UTR Landscape — ${landscape.totals.projects} projects, ${landscape.totals.openRequests} open requests (${landscape.totals.classifiedOpenRequests} classified)\n`
+  );
+
+  console.log("── Bands ──────────────────────────────────────────");
+  for (const b of landscape.bands) {
+    console.log(
+      `  ${b.profile.name.padEnd(42)} [${b.profile.maturity}] running ${b.running.length} · headed ${b.headed.length} · queued ${b.queued.length}`
+    );
+  }
+
+  console.log("\n── Pools ──────────────────────────────────────────");
+  const pools = landscape.pools;
+  console.log(`  external-hosted ${pools.externalHosted.length} · oit-managed-tbd ${pools.oitManagedTbd.length} · no-deployment ${pools.noDeployment.length} · platforms ${pools.platforms.length} · unclassified ${pools.unclassified.length}`);
+
+  console.log("\n── Mismatch ledger ────────────────────────────────");
+  for (const f of landscape.findings) {
+    console.log(`\n  [${f.kind}]`);
+    console.log(`  ${f.headline}`);
+    console.log(`    ${f.detail}`);
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error("Landscape build failed:", err);
+    process.exit(1);
+  }
+);


### PR DESCRIPTION
PR 3 of the [ADR 0008](docs/adr/0008-utr-landscape.md) sequence — the data model the surface (PR 4) renders. No UI in this PR.

## What

**`lib/utr-landscape.ts`** — one pure builder over the two activity populations:

- **Bands** per target: *running* (projects by current environment) / *headed* (proposed, not yet there) / *queued* (open requests by classification), each carrying its `lib/deployment-targets.ts` profile.
- **Pools** — deliberate buckets, not leftovers: vendor-hosted demand, `oit-managed-tbd` (decision made, platform unpicked), no-deployment requests, platform entries, and the unclassified honesty pool the ADR requires.
- **Mismatch ledger** — findings emitted only when their condition holds, every number computed, maturity language sourced from the targets module. Six kinds: transitional-load, gate-concentration, demand-on-aspirational-supply (with the survey-understatement context), unproven-supply, vendor-demand, unclassified-pool.

**Pure by design**: `buildUtrLandscape(projects, requests)` takes structural source types satisfied by `lib/portfolio.ts` entries, `lib/work.ts` applications, and fixtures alike — `server-only` stays out of this module. `scripts/print-utr-landscape.ts` (`npm run print:utr-landscape`) exercises the same builder the page will render.

## The ledger against dev data (2026-08-05)

> **10 workloads run on the RCDS VM — transitional by decision — and 8 of them have no confirmed next home.**
> **23 activities point at Nexus — 3 projects in flight and 20 open requests — while 1 workload has completed the pathway to date.**
> **3 open requests classify to the Databricks dashboard target, which cannot receive them** (+ the survey reconciliation-theme understatement note).
> **7 activities point at the standalone OIT targets — no workload has ever landed on either.**
> **53% of classified open demand (49 of 93 requests) is purchase-shaped.**
> **19 projects and 0 open requests carry no destination yet.**

## Verified

- Smoke run against the local dev DB (unclassified-heavy: pools and conditional-emission paths) and against the remote dev DB via tunnel (fully classified: all six findings fire, output above).
- `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)