### PR TITLE
Ship the UTR Landscape surface MVP (ADR 0008, PR 4)

### DIFF
--- a/app/utr-landscape/layout.tsx
+++ b/app/utr-landscape/layout.tsx
@@ -1,0 +1,21 @@
+// The UTR Landscape surface (ADR 0008) — the destination-harmonized
+// activity view. Eyebrow matches the sidebar label verbatim (heading
+// rule Form B, .impeccable.md). Sub-nav arrives with the per-target
+// detail pages (delivery PR 5); until then the header carries the
+// eyebrow alone.
+export default function UtrLandscapeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <header className="mb-10 border-b border-gray-200 pb-6">
+        <p className="text-xs font-medium uppercase tracking-wider text-brand-silver">
+          UTR Landscape
+        </p>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/app/utr-landscape/page.tsx
+++ b/app/utr-landscape/page.tsx
@@ -1,0 +1,370 @@
+import Link from "next/link";
+import { listApplications } from "@/lib/work";
+import { listTechRequests } from "@/lib/requests";
+import {
+  buildUtrLandscape,
+  type LandscapeActivity,
+  type LandscapeFinding,
+  type LandscapeFindingKind,
+  type TargetBand,
+} from "@/lib/utr-landscape";
+import {
+  TARGET_MATURITY_CHIP,
+  TARGET_MATURITY_LABEL,
+} from "@/lib/deployment-targets";
+import { DEPLOYMENT_ENVIRONMENT_LABELS } from "@/lib/project-governance";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "UTR Landscape — Institutional AI Initiative",
+  description:
+    "Every project and open technology request at the University of Idaho, harmonized against the five deployment targets institutional work can land on — and the mismatches between demand and supply.",
+};
+
+const linkCls =
+  "font-medium text-brand-black underline decoration-brand-clearwater decoration-1 underline-offset-4 hover:decoration-2";
+
+const FINDING_LABEL: Record<LandscapeFindingKind, string> = {
+  "transitional-load": "Transitional load",
+  "gate-concentration": "Gate concentration",
+  "demand-on-aspirational-supply": "Demand on aspirational supply",
+  "unproven-supply": "Unproven supply",
+  "vendor-demand": "Vendor-hosted demand",
+  "unclassified-pool": "Unclassified",
+};
+
+// How many rows a band list renders before deferring to its canonical
+// surface. Never a silent cap — the overflow line names the remainder.
+const BAND_LIST_LIMIT = 8;
+
+function ProvenanceChip({ activity }: { activity: LandscapeActivity }) {
+  if (activity.kind !== "request" || !activity.provenance) return null;
+  const label = activity.provenance === "inferred" ? "Inferred" : "Confirmed";
+  return (
+    <span
+      title={activity.inferenceRationale ?? undefined}
+      className="inline-flex shrink-0 items-center rounded-full border border-hairline bg-surface-alt px-2 py-0.5 text-[10px] font-medium text-ink-muted"
+    >
+      {label}
+    </span>
+  );
+}
+
+function ActivityRow({ activity }: { activity: LandscapeActivity }) {
+  return (
+    <li className="flex items-baseline gap-2 py-1.5">
+      <Link href={activity.href} className={`${linkCls} text-sm`}>
+        {activity.name}
+      </Link>
+      <span className="min-w-0 flex-1 truncate text-xs text-ink-subtle">
+        {[activity.unit, activity.position].filter(Boolean).join(" · ")}
+      </span>
+      <ProvenanceChip activity={activity} />
+    </li>
+  );
+}
+
+function BandList({
+  heading,
+  activities,
+  overflowHref,
+  overflowLabel,
+}: {
+  heading: string;
+  activities: LandscapeActivity[];
+  overflowHref: string;
+  overflowLabel: string;
+}) {
+  if (activities.length === 0) return null;
+  const shown = activities.slice(0, BAND_LIST_LIMIT);
+  const remainder = activities.length - shown.length;
+  return (
+    <div>
+      <h4 className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+        {heading} · {activities.length}
+      </h4>
+      <ul className="mt-1 divide-y divide-gray-100">
+        {shown.map((a) => (
+          <ActivityRow key={`${a.kind}:${a.ref}`} activity={a} />
+        ))}
+      </ul>
+      {remainder > 0 && (
+        <p className="mt-1 text-xs text-ink-muted">
+          <Link href={overflowHref} className={linkCls}>
+            + {remainder} more {overflowLabel} →
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FindingRow({ finding }: { finding: LandscapeFinding }) {
+  return (
+    <li className="border-t border-gray-200 py-5 first:border-t-0">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-brand-silver">
+        {FINDING_LABEL[finding.kind]}
+      </p>
+      <p className="mt-1.5 max-w-3xl text-base font-semibold leading-snug text-brand-black">
+        {finding.headline}
+      </p>
+      <p className="mt-1.5 max-w-3xl text-sm leading-relaxed text-ink-muted">
+        {finding.detail}
+      </p>
+      <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {finding.evidence.map((e) => (
+          <Link key={e.href} href={e.href} className={linkCls}>
+            {e.label}
+          </Link>
+        ))}
+      </p>
+    </li>
+  );
+}
+
+function BandSection({ band }: { band: TargetBand }) {
+  const { profile } = band;
+  const empty =
+    band.running.length + band.headed.length + band.queued.length === 0;
+  return (
+    <section
+      id={`target-${profile.value}`}
+      className="scroll-mt-8 rounded-lg border border-hairline bg-white p-5"
+    >
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h3 className="text-lg font-black tracking-tight text-brand-black">
+          {profile.name}
+        </h3>
+        <span
+          title={profile.maturityNote}
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${TARGET_MATURITY_CHIP[profile.maturity]}`}
+        >
+          {TARGET_MATURITY_LABEL[profile.maturity]}
+        </span>
+      </div>
+      <p className="mt-1.5 max-w-3xl text-sm leading-relaxed text-ink-muted">
+        {profile.shipUnit}
+      </p>
+      {empty ? (
+        <p className="mt-3 text-sm text-ink-subtle">
+          Nothing runs here, is headed here, or is queued for here yet.
+        </p>
+      ) : (
+        <div className="mt-4 grid gap-5 md:grid-cols-3">
+          <BandList
+            heading="Running here"
+            activities={band.running}
+            overflowHref="/portfolio"
+            overflowLabel="in Projects"
+          />
+          <BandList
+            heading="Headed here"
+            activities={band.headed}
+            overflowHref="/portfolio"
+            overflowLabel="in Projects"
+          />
+          <BandList
+            heading="Queued for here"
+            activities={band.queued}
+            overflowHref="/portfolio/pipeline"
+            overflowLabel="in the request queue"
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default async function UtrLandscapePage() {
+  const [applications, requests] = await Promise.all([
+    listApplications({ audience: "public" }),
+    listTechRequests(),
+  ]);
+  const landscape = buildUtrLandscape(applications, requests);
+  const { totals, pools } = landscape;
+
+  const unclassifiedProjects = pools.unclassified.filter(
+    (a) => a.kind === "project"
+  );
+  const unclassifiedRequests = pools.unclassified.filter(
+    (a) => a.kind === "request"
+  );
+
+  return (
+    <div className="space-y-14">
+      {/* ── Heading ─────────────────────────────────────── */}
+      <section>
+        <h1 className="max-w-3xl text-4xl font-black leading-tight tracking-tight text-brand-black">
+          Where institutional AI work lands
+        </h1>
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-ink-muted">
+          Every technology effort the university tracks —{" "}
+          <span className="font-semibold text-brand-black">
+            {totals.projects} projects
+          </span>{" "}
+          and{" "}
+          <span className="font-semibold text-brand-black">
+            {totals.openRequests} open requests
+          </span>{" "}
+          — mapped against the five deployment targets institutional work
+          can land on. The targets are not equal: one is proven, two are
+          approved but untried, one is an aspiration, and one is a staging
+          ground. The mismatches between demand and that supply are the
+          coordination agenda.
+        </p>
+        <p className="mt-3 max-w-3xl text-xs leading-relaxed text-ink-subtle">
+          Request classifications marked <em>Inferred</em> are machine
+          proposals awaiting triage confirmation. This page is a
+          projection — every activity links to its full story in{" "}
+          <Link href="/portfolio" className={linkCls}>
+            Projects
+          </Link>{" "}
+          or the{" "}
+          <Link href="/portfolio/pipeline" className={linkCls}>
+            request queue
+          </Link>
+          .
+        </p>
+      </section>
+
+      {/* ── The mismatch ledger ─────────────────────────── */}
+      <section>
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          The mismatch ledger
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
+          Computed from the inventory and the request registry on every
+          load — when a target matures or a workload lands, the ledger
+          reflows.
+        </p>
+        <ul className="mt-4">
+          {landscape.findings.map((f) => (
+            <FindingRow key={f.kind} finding={f} />
+          ))}
+        </ul>
+      </section>
+
+      {/* ── The five targets ────────────────────────────── */}
+      <section>
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          The five targets
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
+          Form factor first — a report lands on the lakehouse, a
+          transactional module lands on Nexus — then hosting by operator
+          and risk for everything standalone.
+        </p>
+        <div className="mt-5 space-y-5">
+          {landscape.bands.map((band) => (
+            <BandSection key={band.profile.value} band={band} />
+          ))}
+        </div>
+      </section>
+
+      {/* ── Outside the five targets ────────────────────── */}
+      <section id="unclassified" className="scroll-mt-8">
+        <h2 className="text-2xl font-black tracking-tight text-brand-black">
+          Outside the five targets
+        </h2>
+        <dl className="mt-5 space-y-6">
+          {pools.externalHosted.length > 0 && (
+            <div>
+              <dt className="text-sm font-bold text-brand-black">
+                Vendor-hosted demand ·{" "}
+                {
+                  pools.externalHosted.filter((a) => a.kind === "request")
+                    .length
+                }{" "}
+                requests
+              </dt>
+              <dd className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                Purchase and subscription requests that would land on a
+                vendor&apos;s infrastructure, not a university target — a
+                procurement and governance question rather than a deployment
+                one.{" "}
+                <Link href="/portfolio/pipeline" className={linkCls}>
+                  See them in the request queue
+                </Link>
+                .
+              </dd>
+            </div>
+          )}
+          {pools.oitManagedTbd.length > 0 && (
+            <div>
+              <dt className="text-sm font-bold text-brand-black">
+                {DEPLOYMENT_ENVIRONMENT_LABELS["oit-managed-tbd"]} ·{" "}
+                {pools.oitManagedTbd.length}
+              </dt>
+              <dd className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                The OIT-managed decision is made; which target has not been
+                picked.
+              </dd>
+              <ul className="mt-1 max-w-3xl">
+                {pools.oitManagedTbd.map((a) => (
+                  <ActivityRow key={`${a.kind}:${a.ref}`} activity={a} />
+                ))}
+              </ul>
+            </div>
+          )}
+          {pools.noDeployment.length > 0 && (
+            <div>
+              <dt className="text-sm font-bold text-brand-black">
+                Nothing deploys · {pools.noDeployment.length} requests
+              </dt>
+              <dd className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                Requests whose substance is access, policy, or an existing
+                system — resolved without landing anywhere.{" "}
+                <Link href="/portfolio/pipeline" className={linkCls}>
+                  See them in the request queue
+                </Link>
+                .
+              </dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-sm font-bold text-brand-black">
+              No destination yet · {unclassifiedProjects.length} projects
+              {unclassifiedRequests.length > 0 &&
+                ` and ${unclassifiedRequests.length} requests`}
+            </dt>
+            <dd className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+              The working queue for target triage — unclassified is a
+              state, not an omission.
+              {unclassifiedRequests.length > 0 && (
+                <>
+                  {" "}
+                  <Link href="/portfolio/pipeline" className={linkCls}>
+                    The unclassified requests live in the queue
+                  </Link>
+                  .
+                </>
+              )}
+            </dd>
+            <ul className="mt-1 max-w-3xl">
+              {unclassifiedProjects.map((a) => (
+                <ActivityRow key={`${a.kind}:${a.ref}`} activity={a} />
+              ))}
+            </ul>
+          </div>
+          {pools.platforms.length > 0 && (
+            <div>
+              <dt className="text-sm font-bold text-brand-black">
+                Platforms · {pools.platforms.length}
+              </dt>
+              <dd className="mt-1 max-w-3xl text-sm leading-relaxed text-ink-muted">
+                Entries that are themselves supply — the infrastructure
+                other work lands on.
+              </dd>
+              <ul className="mt-1 max-w-3xl">
+                {pools.platforms.map((a) => (
+                  <ActivityRow key={`${a.kind}:${a.ref}`} activity={a} />
+                ))}
+              </ul>
+            </div>
+          )}
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 const primaryItems = [
   { href: "/", label: "Home", icon: "house" },
   { href: "/portfolio", label: "Projects", icon: "grid" },
+  { href: "/utr-landscape", label: "UTR Landscape", icon: "map" },
   { href: "/builder-guide", label: "Submit a Project", icon: "compass" },
   { href: "/coordination", label: "Coordination", icon: "funnel" },
   { href: "/standards", label: "Standards", icon: "shield" },
@@ -42,6 +43,12 @@ function NavIcon({ icon, className }: { icon: string; className?: string }) {
       return (
         <svg className={c} fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4.5h18l-7 8.25V20l-4-2.5v-4.75L3 4.5z" />
+        </svg>
+      );
+    case "map":
+      return (
+        <svg className={c} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
         </svg>
       );
     case "compass":

--- a/lib/deployment-targets.ts
+++ b/lib/deployment-targets.ts
@@ -52,6 +52,21 @@ export const TARGET_MATURITY_LABEL: Record<TargetMaturity, string> = {
   transitional: "Transitional",
 };
 
+// Tailwind class strings for the maturity chip on Landscape surfaces —
+// colocated with the vocabulary per the PUBLIC_STAGE_CHIP pattern
+// (lib/portfolio.ts). Restraint: the label always carries the meaning;
+// color is reinforcement. Available borrows the "alive" clearwater,
+// transitional the caution amber (the codebase's existing hold signal),
+// aspirational the "future motion" huckleberry, unproven stays neutral.
+export const TARGET_MATURITY_CHIP: Record<TargetMaturity, string> = {
+  available:
+    "border-brand-clearwater/40 bg-brand-clearwater/10 text-brand-clearwater",
+  unproven: "border-brand-silver/40 bg-brand-silver/10 text-brand-silver",
+  aspirational:
+    "border-brand-huckleberry/30 bg-brand-huckleberry/10 text-brand-huckleberry",
+  transitional: "border-amber-300 bg-amber-50 text-amber-700",
+};
+
 export interface DeploymentTargetProfile {
   value: DeploymentTarget;
   name: string;

--- a/lib/utr-landscape.ts
+++ b/lib/utr-landscape.ts
@@ -286,7 +286,7 @@ function computeFindings(
       detail:
         "The RCDS VM is staging, not a destination. Every workload here eventually needs a pathway plan to an OIT-managed target or an explicit decision to stay.",
       evidence: [
-        { label: "RCDS VM band", href: "/utr-landscape/rcds-vm" },
+        { label: "RCDS VM band", href: "/utr-landscape#target-rcds-vm" },
         { label: "Projects", href: "/portfolio" },
       ],
       counts: {
@@ -306,7 +306,7 @@ function computeFindings(
       headline: `${nexusDemand} ${plural(nexusDemand, "activity", "activities")} point at Nexus — ${nexus.headed.length} ${plural(nexus.headed.length, "project")} in flight and ${nexus.queued.length} open ${plural(nexus.queued.length, "request")} — while ${nexus.running.length} ${nexus.running.length === 1 ? "workload has" : "workloads have"} completed the pathway to date.`,
       detail: nexus.profile.timeToDeploy,
       evidence: [
-        { label: "Nexus band", href: "/utr-landscape/nexus-module" },
+        { label: "Nexus band", href: "/utr-landscape#target-nexus-module" },
         { label: "OIT pathway", href: "/coordination/oit-pathway" },
       ],
       counts: {
@@ -335,7 +335,7 @@ function computeFindings(
       evidence: [
         {
           label: "Databricks band",
-          href: "/utr-landscape/databricks-dashboard",
+          href: "/utr-landscape#target-databricks-dashboard",
         },
         {
           label: "Op Excellence survey",
@@ -360,8 +360,8 @@ function computeFindings(
       detail:
         "Both targets are named in the OIT drafts as approved platforms. The first landing will set the real timeline for everything behind it.",
       evidence: [
-        { label: "OCI band", href: "/utr-landscape/standalone-oci" },
-        { label: "OIT K8s band", href: "/utr-landscape/standalone-oit-k8s" },
+        { label: "OCI band", href: "/utr-landscape#target-standalone-oci" },
+        { label: "OIT K8s band", href: "/utr-landscape#target-standalone-oit-k8s" },
       ],
       counts: { demand: unprovenDemand },
     });


### PR DESCRIPTION
PR 4 of the [ADR 0008](docs/adr/0008-utr-landscape.md) sequence — the surface itself.

## What

- **`/utr-landscape`** joins the sidebar directly after Projects (seventh primary surface, per the ADR). Heading rule Form B: eyebrow "UTR Landscape" verbatim, H1 *"Where institutional AI work lands."*
- **Ledger first**: the computed mismatch findings open the page — uppercase kind label, headline sentence with computed numbers, supporting detail, teal evidence links. On dev data that's six findings; locally (unclassified-heavy) three — conditional emission renders honestly either way.
- **The five target bands** as evidence: name + maturity chip (`TARGET_MATURITY_CHIP`, colocated with the vocabulary per the `PUBLIC_STAGE_CHIP` pattern; maturity note in the tooltip), running / headed / queued lists with owner-unit-status rows. Band lists cap at 8 rows with an explicit "+N more →" link — never a silent cap. Empty bands say so plainly.
- **Pools**: vendor-hosted demand (hidden at zero), OIT-managed-TBD, nothing-deploys, the unclassified working queue (anchored — the ledger links here), and platforms.
- **Honesty rules held**: inferred chips on every machine classification with the rationale as tooltip; every count computed per load (`force-dynamic`); maturity language only from `lib/deployment-targets.ts`; the page states it is a projection and links every activity out to `/portfolio` or the pipeline.
- Evidence hrefs point at on-page band anchors (`#target-*`) until PR 5 lands `/utr-landscape/[target]`.

## Verified

- Rendered against the local dev DB in the browser: heading thread, ledger, populated + empty band states, overflow link, pools, sidebar active state; no console errors.
- `npm run build` (route present), `npm run lint`, `npm run verify:portfolio` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)