### PR TITLE
Typed environment definitions with provenance; RCDS VM defined from Sheneman session

### DIFF
--- a/app/utr-landscape/page.tsx
+++ b/app/utr-landscape/page.tsx
@@ -143,6 +143,18 @@ function BandSection({ band }: { band: TargetBand }) {
           {TARGET_MATURITY_LABEL[profile.maturity]}
         </span>
       </div>
+      {profile.definition.status === "defined" ? (
+        <p className="mt-1 text-xs text-ink-subtle">
+          Defined with {profile.definition.definedBy.name} (
+          {profile.definition.definedBy.role}) ·{" "}
+          {profile.definition.definedBy.date}
+        </p>
+      ) : (
+        <p className="mt-1 text-xs italic text-ink-subtle">
+          Not yet defined — characteristics inferred from documents;
+          definition session pending.
+        </p>
+      )}
       <p className="mt-1.5 max-w-3xl text-sm leading-relaxed text-ink-muted">
         {profile.shipUnit}
       </p>

--- a/docs/environments/README.md
+++ b/docs/environments/README.md
@@ -1,0 +1,23 @@
+# Environment definition records
+
+Raw interview records from the deployment-environment definitional pass
+(begun August 2026). Nobody at the university had systematically defined
+the deployment environments — their technical characteristics,
+requirements, and value propositions — so they are being defined one at
+a time in working sessions with their operators.
+
+The distilled, typed facts live in
+[`lib/deployment-targets.ts`](../../lib/deployment-targets.ts) with
+per-environment provenance (`definition.status`); these files are the
+audit trail — the questions as asked and the answers as given, verbatim.
+An environment whose profile says `repo-inferred` has no record here
+yet: its characteristics are this repo's inference from documents, and
+its session is pending.
+
+| Environment | Session | Record |
+|---|---|---|
+| RCDS VM | Luke Sheneman (RCDS), 2026-08-06 | [rcds-vm.md](./rcds-vm.md) |
+| Nexus module | pending | — |
+| Standalone on OCI | pending | — |
+| Standalone on OIT on-prem Kubernetes | pending | — |
+| Databricks dashboard | pending | — |

--- a/docs/environments/rcds-vm.md
+++ b/docs/environments/rcds-vm.md
@@ -1,0 +1,147 @@
+# Environment definition session — RCDS-provided VM
+
+**Date:** 2026-08-06
+**Answers:** Luke Sheneman (RCDS)
+**Questions:** Barrie Robison / agent, from the definitional-pass template
+**Distilled into:** [`lib/deployment-targets.ts`](../../lib/deployment-targets.ts) (`rcds-vm` profile)
+
+Answers are verbatim. The prior repo-inferred characterization this
+session superseded had three material errors: it modeled the service as
+a self-managed VM (it is a managed container-hosting service — RCDS
+holds root exclusively), it claimed MindRouter/DGX network adjacency as
+a property (it is not one), and it invented a vague data ceiling (the
+real rule is exposure-dependent and crisp).
+
+---
+
+## Identity
+
+**1. What exactly does RCDS provide — the VM only, or VM plus patching/backups/monitoring? Where does RCDS's responsibility end and the builder's begin (who has root, who owns the OS)?**
+
+> RCDS can provide virtual machine (VM) and/or container hosting in
+> various flavors. What I think you are mainly describing here is our
+> VM + container solution where we provide individuals with dedicated
+> VMs for deploying their containerized, usually agentically-developed
+> apps.
+>
+> RCDS provisions the VM, has root (only RCDS has root or sudo), and is
+> responsible for OS patching, backups, and monitoring. RCDS owns the
+> OS layer, the host firewall, upstream firewall, and the reverse proxy
+> layer. RCDS manages the DNS and certificates as well.
+>
+> The user has non-root, non-sudo access to the VM, but the ability to
+> deploy and manage docker containers (i.e., member of the docker
+> group).
+
+**2. What's the RCDS–IIDS relationship here: who requests a VM from whom, and is this a service any unit/researcher can get, or effectively IIDS-only?**
+
+> Somebody requests a VM from Luke Sheneman (RCDS), and I review and
+> approve the request. Any unit/researcher can request a VM. There is
+> no formal request process, but there is usually a discussion about
+> what is allowable and whether the VM will be internal only or also
+> external facing.
+
+**3. Is insight.uidaho.edu one VM hosting all those apps, or one VM per app? What hardware does this actually run on?**
+
+> insight.uidaho.edu is a subdomain, and we can allocate multiple VMs to
+> use \<host\>.insight.uidaho.edu. Sometimes we use
+> \<host\>.nkn.uidaho.edu or other subdomains as well. We typically
+> provision one VM per person, and they can host multiple apps on that
+> VM.
+>
+> To date, these VMs run on Dell M640 servers hosted within a Dell VRTX
+> server chassis managed by RCDS in the UI Library basement. Each M640
+> has 1TB of RAM, and 28 CPU cores, SSD and NFS storage.
+
+## Technical characteristics
+
+**4. Network posture: public internet, campus firewall, or both by configuration? Who issues DNS and SSL? Is Azure AD SSO available?**
+
+> Some VMs are public-facing, some are internal-only. It depends on the
+> user's needs and use case. Typically, we configure each VM to be
+> either internal or external. If a user needs one app to be
+> internal-only and one to be external, we would configure the VM to be
+> external and then use web server rules to enforce per-app external
+> availability.
+>
+> These VMs currently sit behind a Watchguard firewall appliance, not
+> the campus border firewall (Palo Alto). The Watchguard firewall is
+> managed by RCDS and generally only does stateless packet filtering.
+> If needed, we can move the VMs behind the campus Palo Alto firewall
+> fairly easily.
+>
+> Luke Sheneman (RCDS) does DNS management, firewall management,
+> requests and issues the SSL certificates. Luke can also work with OIT
+> and the developer to get Azure AD SSO setup on an app-by-app case.
+
+**5. AI adjacency: are these VMs on the same network fabric as MindRouter and the DGX hardware — is low-latency access to on-prem inference a real property?**
+
+> While the VMs are running within the same chassis as MindRouter, I
+> think it's best to consider this as the VMs call MindRouter over the
+> campus network like anyone else.
+>
+> AI network traffic is so tiny (little textual prompts and
+> completions), and all the real latency is in the inference itself (at
+> the GPU), that network latency and throughput to these VMs is never
+> the bottleneck.
+>
+> All requests from these VMs to MindRouter must traverse the Palo Alto
+> border firewall like everything else.
+
+**6. Sizing and lifecycle: typical/maximum VM specs, and is there any snapshot/backup/DR story at all?**
+
+> Typically 4 or 8 vCPU cores, 16GB RAM, 256GB disk, 10Gbps networking.
+> We can snapshot and backup to NFS backup. We're not currently
+> off-siting those backups for DR.
+
+## Requirements and rules
+
+**7. What does it take to get one — approval by whom, any cost or chargeback, and what turnaround?**
+
+> User talks to Luke, Luke approves/denies based on vibe, no cost,
+> turnaround dependent on Luke's backlog. From hours to days.
+
+**8. The real data rule: what data classification is actually permitted (or practiced) on these VMs today?**
+
+> For external-facing apps: Low Risk data. For internal-only: Low to
+> moderate risk.
+>
+> RCDS (Luke) doesn't continually audit user apps to ensure compliance
+> with data classification guidance into the future. Up to the user.
+> Luke can disable the VM at any time.
+
+## Value proposition
+
+**9. What does an RCDS VM offer that no other environment does? Is there a class of work for which this is the permanent right home, or is everything here transitional?**
+
+> There is nothing special about RCDS VMs for this purpose. It is
+> serving an immediate unmet need. If OIT provided a fast, free way for
+> people to host their apps, RCDS would not need to do this.
+>
+> RCDS is Research Computing, VMs like this were primarily intended for
+> supporting the University's research mission. Providing VMs for
+> non-research use is only because UI folks don't have another fast,
+> cost-free alternative. There is the perception that if we don't
+> provide it, people will simply host apps externally wherever and
+> we'll lose track of where our institutional data is being scattered
+> and hosted across the internet.
+>
+> Ideally, OIT would have a very simple hosting environment, allowing
+> fast deployment of agentically-developed apps for all users who need
+> it.
+
+**10. Anti-fit: what should never be on an RCDS VM?**
+
+> RCDS infrastructure is never intended for high-risk data and
+> Public-facing apps/VMs hosted at RCDS should only have LOW risk data.
+
+## Open after this session
+
+- **Q11 (per-app mapping corrections) was not answered** — which of the
+  ten workloads currently mapped to this environment are mismapped is
+  deferred to the full remapping pass after all five environments are
+  defined.
+- The session created a new open question, recorded on the profile:
+  which current external-facing tenants exceed the Low-risk rule? No
+  per-tenant classification review against the exposure rule has been
+  done.

--- a/lib/deployment-targets.ts
+++ b/lib/deployment-targets.ts
@@ -1,25 +1,32 @@
 // ============================================================
-// Deployment targets — per-target characteristics
+// Deployment targets — per-environment definitions
 // ============================================================
-// The five deployment targets settled in the 2026-08-05 definitional
-// session, characterized along the dimensions that drive target
-// selection. The vocabulary (typed values, labels, the OIT-managed
-// flag) lives in lib/project-governance.ts; this module carries the
-// reference facts a surface renders and the harmonization work
-// classifies against.
+// The five deployment targets from the 2026-08-05 definitional session,
+// restructured 2026-08-06 into typed environment definitions: facts are
+// fields, prose is reserved for what is genuinely narrative, and
+// `"unknown"` is a first-class value everywhere. The vocabulary (typed
+// values, labels, the OIT-managed flag) lives in
+// lib/project-governance.ts; this module carries the reference facts a
+// surface renders and the harmonization work classifies against.
+//
+// Definition discipline: environments are being defined one at a time
+// in working sessions with their operators — nobody at the university
+// had defined them before. `definition.status` says whether a profile
+// carries a named human's verified answers ("defined", with the raw
+// interview record under docs/environments/) or this repo's inference
+// from documents ("repo-inferred"). Surfaces must render the
+// difference. Unknown fields stay unknown until a session fills them —
+// do not invent values.
 //
 // The selection model the five targets encode is a two-step decision:
 // form factor first (report-shaped → Databricks dashboard; transactional
 // module fitting the template → Nexus; otherwise a standalone app),
-// then hosting by operator and risk (OIT-managed for institutional-data
-// production; RCDS VM as transitional staging). This maps onto the UTR
-// tracks (lib/utr.ts): Track D requests are Databricks-shaped, Tracks
-// B/C land on Nexus or a standalone target.
+// then hosting by operator and risk. This maps onto the UTR tracks
+// (lib/utr.ts): Track D requests are Databricks-shaped, Tracks B/C
+// land on Nexus or a standalone target.
 //
 // Honesty rule: `maturity` states what the target IS today, not what
-// it should become. Only Nexus and the RCDS VM have running workloads;
-// nothing has landed on OCI or OIT Kubernetes, and OIT's Databricks
-// service is aspirational until their implementation completes.
+// it should become.
 
 import type { DeploymentEnvironment } from "./project-governance";
 
@@ -67,6 +74,137 @@ export const TARGET_MATURITY_CHIP: Record<TargetMaturity, string> = {
   transitional: "border-amber-300 bg-amber-50 text-amber-700",
 };
 
+// ---- Definition provenance -------------------------------------------
+
+/**
+ * Whether this profile carries a named operator's verified answers or
+ * this repo's inference from documents. Surfaces render the difference;
+ * the raw interview records live under docs/environments/.
+ */
+export type EnvironmentDefinitionMeta =
+  | {
+      status: "defined";
+      definedBy: { name: string; role: string; date: string };
+    }
+  | { status: "repo-inferred" };
+
+// ---- Structured facts -------------------------------------------------
+
+/** Whether the environment exists today or is an intention. */
+export type EnvironmentExistence =
+  | "operating"
+  | "partial"
+  | "intended"
+  | "unknown";
+
+export const ENVIRONMENT_EXISTENCE_LABEL: Record<
+  EnvironmentExistence,
+  string
+> = {
+  operating: "Operating today",
+  partial: "Partially stood up",
+  intended: "Intended — not yet stood up",
+  unknown: "Unknown",
+};
+
+/** The operational concerns whose ownership discriminates environments. */
+export type Responsibility =
+  | "os-and-patching"
+  | "backups"
+  | "monitoring"
+  | "network-and-firewall"
+  | "dns-and-certificates"
+  | "reverse-proxy"
+  | "app-deployment"
+  | "app-maintenance"
+  | "data-compliance";
+
+export const RESPONSIBILITY_LABEL: Record<Responsibility, string> = {
+  "os-and-patching": "OS & patching",
+  backups: "Backups",
+  monitoring: "Monitoring",
+  "network-and-firewall": "Network & firewall",
+  "dns-and-certificates": "DNS & certificates",
+  "reverse-proxy": "Reverse proxy",
+  "app-deployment": "App deployment",
+  "app-maintenance": "App maintenance",
+  "data-compliance": "Data compliance",
+};
+
+export type ResponsibilityHolder = "provider" | "tenant" | "shared" | "unknown";
+
+export const RESPONSIBILITY_HOLDER_LABEL: Record<ResponsibilityHolder, string> =
+  {
+    provider: "Provider",
+    tenant: "Tenant",
+    shared: "Shared",
+    unknown: "Unknown",
+  };
+
+export type RiskCeiling = "low" | "moderate" | "high";
+
+export interface EnvironmentAccess {
+  /** Who says yes — a named human or office, or "Unknown". */
+  approvalAuthority: string;
+  formality: "informal" | "formal-process" | "unknown";
+  cost: "none" | "chargeback" | "unknown";
+  /** Provisioning turnaround, as the operator states it. */
+  turnaround: string;
+}
+
+export interface EnvironmentDataRule {
+  /** Ceiling for anything reachable from the public internet. */
+  externalFacing: RiskCeiling | "prohibited" | "unknown";
+  /** Ceiling for internal-only exposure. */
+  internalOnly: RiskCeiling | "unknown";
+  /** How the rule is actually enforced, as stated — not as hoped. */
+  enforcement: string;
+}
+
+export interface EnvironmentNetwork {
+  exposureOptions: string;
+  firewall: string;
+  sso: string;
+}
+
+export interface EnvironmentResilience {
+  backups: string;
+  offsiteDr: boolean | "unknown";
+}
+
+export type EnvironmentStack =
+  | "any-container"
+  | "template-stack"
+  | "platform-artifact"
+  | "unknown";
+
+export const ENVIRONMENT_STACK_LABEL: Record<EnvironmentStack, string> = {
+  "any-container": "Any containerized stack",
+  "template-stack": "Template stack only",
+  "platform-artifact": "Platform-native artifacts",
+  unknown: "Unknown",
+};
+
+/**
+ * The environment's role in the institutional hosting story — typed so
+ * the mismatch ledger can compute from it rather than restate it.
+ */
+export type StrategicRole = "destination" | "stopgap" | "aspiration" | "unknown";
+
+export interface EnvironmentValue {
+  /** The positive reason work should land here — the operator's own
+   * claim where defined. */
+  headline: string;
+  /** The class of work for which this is the permanent right home;
+   * null when the environment claims none. */
+  permanentNiche: string | null;
+  strategicRole: StrategicRole;
+  /** What should never land here. */
+  antiFit: string[];
+}
+
+// ---- Profile ----------------------------------------------------------
+
 export interface DeploymentTargetProfile {
   value: DeploymentTarget;
   name: string;
@@ -74,21 +212,24 @@ export interface DeploymentTargetProfile {
   formFactor: "platform-artifact" | "standalone-app";
   /** What actually ships to this target. */
   shipUnit: string;
+
+  definition: EnvironmentDefinitionMeta;
+  existence: EnvironmentExistence;
+  responsibilities: Record<Responsibility, ResponsibilityHolder>;
+  access: EnvironmentAccess;
+  dataRule: EnvironmentDataRule;
+  network: EnvironmentNetwork;
+  capacity?: { typicalSpecs?: string; hardware?: string };
+  resilience: EnvironmentResilience;
+  stack: EnvironmentStack;
+  valueProposition: EnvironmentValue;
+
   /** The workload shapes that belong here. */
   fits: string[];
-  /** Who runs the runtime the workload lands on. */
-  operator: string;
-  /** Who performs the deployment. */
-  deployer: string;
   /** The governance path a workload travels to get here. */
   governancePath: string;
-  /** Standards and obligations that bind once here. */
-  standardsBinding: string;
-  /** Stack limits the target imposes. */
-  techConstraint: string;
-  /** Data classification / access posture. */
-  dataPosture: string;
-  /** Realistic time-to-production, with the gating factor named. */
+  /** Realistic path-to-production time, with the gating factor named.
+   * Distinct from access.turnaround (provisioning). */
   timeToDeploy: string;
   maturity: TargetMaturity;
   /** The evidence behind the maturity claim. */
@@ -107,22 +248,55 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
     formFactor: "platform-artifact",
     shipUnit:
       "A dashboard or governed data product inside OIT's Databricks lakehouse workspace — no application to host.",
+    definition: { status: "repo-inferred" },
+    existence: "partial",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "provider",
+      monitoring: "provider",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "provider",
+      "app-deployment": "unknown",
+      "app-maintenance": "unknown",
+      "data-compliance": "unknown",
+    },
+    access: {
+      approvalAuthority: "Unknown — the service is not yet defined",
+      formality: "unknown",
+      cost: "unknown",
+      turnaround: "Unknown",
+    },
+    dataRule: {
+      externalFacing: "unknown",
+      internalOnly: "unknown",
+      enforcement:
+        "Unknown — platform-level entitlements expected, not yet confirmed",
+    },
+    network: {
+      exposureOptions: "Unknown — internal dashboards expected",
+      firewall: "Unknown",
+      sso: "Unknown",
+    },
+    resilience: { backups: "Platform-managed (Databricks)", offsiteDr: "unknown" },
+    stack: "platform-artifact",
+    valueProposition: {
+      headline:
+        "Governed institutional data with per-user entitlements — report-shaped delivery without an application to run or host.",
+      permanentNiche: "Reports, dashboards, and governed data products",
+      strategicRole: "aspiration",
+      antiFit: [
+        "Transactional workflows",
+        "Anything needing a custom application UI",
+      ],
+    },
     fits: [
       "Report-shaped requests and recurring metrics",
       "BI over governed institutional data",
       "Cross-system reconciliation views (the survey's numbers-don't-agree theme)",
     ],
-    operator:
-      "OIT — the workspace is OIT-controlled in its entirety (Application Administration; Randy Wood TPM per the FY2027 EA portfolio). Distinct from the IIDS lakehouse pilot, which serves AI4RA.",
-    deployer: "Undefined until OIT defines the service.",
     governancePath:
       "UTR Track D (data & report access): classification and entitlement screen, data steward review. The Governance Decision Worksheets already treat a new governed data product as a governance trigger.",
-    standardsBinding:
-      "Data classification enforced at the platform level; no application code, so no application security gate.",
-    techConstraint:
-      "Medallion architecture with data marts. Dashboard tooling undecided — PowerBI, Tableau, or custom is an open question.",
-    dataPosture:
-      "Potentially the highest-leverage target: governed lakehouse with per-user entitlements. Contents unconfirmed — Banner assumed but not verified.",
     timeToDeploy:
       "Fast for report-shaped needs once the platform is live and the data is in the lake; currently blocked on OIT's implementation finishing.",
     maturity: "aspirational",
@@ -142,27 +316,60 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
     formFactor: "platform-artifact",
     shipUnit:
       "A module inside the shared React + FastAPI Nexus application at nexus.uidaho.edu.",
+    definition: { status: "repo-inferred" },
+    existence: "operating",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "provider",
+      monitoring: "provider",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "provider",
+      "app-deployment": "shared",
+      "app-maintenance": "unknown",
+      "data-compliance": "unknown",
+    },
+    access: {
+      approvalAuthority: "OIT, via the Builder Guide pathway",
+      formality: "formal-process",
+      cost: "unknown",
+      turnaround: "Unknown — one traversal completed to date",
+    },
+    dataRule: {
+      externalFacing: "unknown",
+      internalOnly: "unknown",
+      enforcement:
+        "Unknown — Stage 3 security gate at entry; payroll data is carried in practice, formal rating unconfirmed",
+    },
+    network: {
+      exposureOptions: "SSO-gated internal enterprise app",
+      firewall: "Unknown",
+      sso: "Built in — the platform is SSO-gated",
+    },
+    resilience: { backups: "Unknown", offsiteDr: "unknown" },
+    stack: "template-stack",
+    valueProposition: {
+      headline:
+        "A security-hardened, SSO-gated, OIT-operated runtime — enterprise legitimacy for a staff workflow without standing up an application.",
+      permanentNiche: "Transactional staff workflow modules",
+      strategicRole: "destination",
+      antiFit: ["Applications that don't fit the template stack"],
+    },
     fits: [
       "Transactional staff workflows: validated intake, review queues, dashboards",
       "Banner-adjacent business processes (read and verify)",
       "SSO-gated internal enterprise apps",
     ],
-    operator:
-      "OIT-managed secure infrastructure; the platform was built collaboratively by OIT and IIDS (Kali Armitage, Colin Addington).",
-    deployer:
-      "Builders write module code; OIT gates pull requests and operates production.",
     governancePath:
       "The full six-stage Builder Guide pathway with the Stage 3 security gate and OIT acceptance; UTR Tracks B/C.",
-    standardsBinding:
-      "OIT Enterprise AI Development Framework stack; the draft OIT SDLC standard once adopted. OIT-managed production satisfies the ADR 0001 accessibility rule.",
-    techConstraint: "The Nexus template stack only — React + FastAPI.",
-    dataPosture:
-      "Moderate-risk institutional data proven in production: Retroactive Payment Requests verifies submissions against Banner.",
     timeToDeploy:
       "The slowest gate today — recurring security-review tickets and PR approval steps are the reported friction — but the one sanctioned enterprise path with a completed traversal.",
     maturity: "available",
     maturityNote:
       "Retroactive Payment Requests in production for Payroll since July 2026; OpenERA and UCM Daily Register entering Stage 1.",
+    openQuestions: [
+      "Definition session pending — architecture of a module, Banner access mechanics, post-launch maintenance ownership, formal data rating, and onboarding throughput are all unverified.",
+    ],
     exampleSlugs: [
       "retroactive-payment-requests",
       "openera",
@@ -176,24 +383,58 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
     formFactor: "standalone-app",
     shipUnit:
       "A containerized standalone application on Oracle Cloud Infrastructure, in OIT-provisioned capacity.",
+    definition: { status: "repo-inferred" },
+    existence: "intended",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "unknown",
+      monitoring: "unknown",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "unknown",
+      "app-deployment": "provider",
+      "app-maintenance": "unknown",
+      "data-compliance": "unknown",
+    },
+    access: {
+      approvalAuthority: "OIT, via the pathway's acceptance gate",
+      formality: "formal-process",
+      cost: "unknown",
+      turnaround: "Unknown — no workload has traversed this path",
+    },
+    dataRule: {
+      externalFacing: "unknown",
+      internalOnly: "unknown",
+      enforcement: "Draft OIT SDLC standard once adopted; unverified",
+    },
+    network: {
+      exposureOptions: "Unknown",
+      firewall: "Unknown",
+      sso: "Unknown",
+    },
+    resilience: { backups: "Unknown", offsiteDr: "unknown" },
+    stack: "any-container",
+    valueProposition: {
+      headline:
+        "OIT-operated production for containerized apps that don't fit a platform — the institutional accessibility rule satisfied without the template constraint.",
+      permanentNiche: "Standalone institutional applications",
+      strategicRole: "destination",
+      antiFit: [],
+    },
     fits: [
       "Apps that don't fit the Nexus template (different stack, own database, public-facing)",
       "AI-heavy applications needing OIT-managed production",
     ],
-    operator: "OIT.",
-    deployer:
-      "OIT DevOps deploys to production; builders do not deploy directly. Named owner, runbook, and documented decommission path required before go-live.",
     governancePath:
       "The six-stage Builder Guide pathway and OIT acceptance gate; UTR Tracks B/C.",
-    standardsBinding:
-      "Draft OIT SDLC standard once adopted (managed hosts, pipeline scanning, central scan reporting). OIT-managed production satisfies the ADR 0001 accessibility rule.",
-    techConstraint: "Any containerized stack.",
-    dataPosture: "Institutional data per classification, OIT-managed.",
     timeToDeploy:
       "Unknown — no project has traversed this path; expect pathway-gate timelines comparable to Nexus.",
     maturity: "unproven",
     maturityNote:
       "Named in the OIT drafts as an approved platform; no workload has landed there.",
+    openQuestions: [
+      "Definition session pending — whether this is OKE (Kubernetes) or other OCI compute, and whether the offering exists beyond the drafts, are unverified.",
+    ],
     exampleSlugs: [],
   },
   {
@@ -202,50 +443,126 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
     formFactor: "standalone-app",
     shipUnit:
       "A containerized standalone application in an OIT-provisioned namespace on the on-premises Kubernetes platform.",
+    definition: { status: "repo-inferred" },
+    existence: "unknown",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "unknown",
+      monitoring: "unknown",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "unknown",
+      "app-deployment": "provider",
+      "app-maintenance": "unknown",
+      "data-compliance": "unknown",
+    },
+    access: {
+      approvalAuthority: "OIT, via the pathway's acceptance gate",
+      formality: "formal-process",
+      cost: "unknown",
+      turnaround: "Unknown — no workload has traversed this path",
+    },
+    dataRule: {
+      externalFacing: "unknown",
+      internalOnly: "unknown",
+      enforcement: "Draft OIT SDLC standard once adopted; unverified",
+    },
+    network: {
+      exposureOptions: "Unknown",
+      firewall: "Unknown",
+      sso: "Unknown",
+    },
+    resilience: { backups: "Unknown", offsiteDr: "unknown" },
+    stack: "any-container",
+    valueProposition: {
+      headline:
+        "OIT-operated production with on-premises residency — for workloads that must stay on campus hardware.",
+      permanentNiche: "Standalone institutional applications requiring on-prem residency",
+      strategicRole: "destination",
+      antiFit: [],
+    },
     fits: [
       "Standalone apps where on-prem residency matters",
       "Workloads wanting adjacency to on-prem AI compute (MindRouter, DGX Stack)",
     ],
-    operator: "OIT.",
-    deployer:
-      "OIT DevOps deploys to production; builders do not deploy directly. Named owner, runbook, and documented decommission path required before go-live.",
     governancePath:
       "The six-stage Builder Guide pathway and OIT acceptance gate; UTR Tracks B/C.",
-    standardsBinding:
-      "Draft OIT SDLC standard once adopted. OIT-managed production satisfies the ADR 0001 accessibility rule.",
-    techConstraint: "Any containerized stack.",
-    dataPosture: "Institutional data per classification, OIT-managed.",
     timeToDeploy: "Unknown — no project has traversed this path.",
     maturity: "unproven",
     maturityNote:
       "Named in the OIT drafts as an approved platform; no workload has landed there.",
+    openQuestions: [
+      "Definition session pending — whether an on-prem cluster exists today, or is a line in the drafts, is unverified.",
+    ],
     exampleSlugs: [],
   },
   // Defined with Luke Sheneman (RCDS), 2026-08-06 — the first environment
-  // of the definitional pass. Supersedes the repo-inferred v1 profile.
+  // of the definitional pass. Raw interview: docs/environments/rcds-vm.md.
   {
     value: "rcds-vm",
     name: "Standalone app on an RCDS VM",
     formFactor: "standalone-app",
     shipUnit:
       "Containerized apps on an RCDS-provisioned, RCDS-managed VM. One VM per person, multiple apps per VM; hostnames under insight.uidaho.edu, nkn.uidaho.edu, or other RCDS subdomains.",
+    definition: {
+      status: "defined",
+      definedBy: { name: "Luke Sheneman", role: "RCDS", date: "2026-08-06" },
+    },
+    existence: "operating",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "provider",
+      monitoring: "provider",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "provider",
+      "app-deployment": "tenant",
+      "app-maintenance": "tenant",
+      "data-compliance": "tenant",
+    },
+    access: {
+      approvalAuthority: "Luke Sheneman (RCDS)",
+      formality: "informal",
+      cost: "none",
+      turnaround: "Hours to days, depending on RCDS backlog",
+    },
+    dataRule: {
+      externalFacing: "low",
+      internalOnly: "moderate",
+      enforcement:
+        "Screened at intake; tenant honor afterward — no ongoing audit. RCDS can disable a VM at any time.",
+    },
+    network: {
+      exposureOptions:
+        "Per-VM internal-only or external-facing; per-app exposure via reverse-proxy rules",
+      firewall:
+        "RCDS-managed Watchguard appliance (stateless filtering), not the campus Palo Alto — relocatable behind it if needed",
+      sso: "Azure AD SSO arranged app-by-app with RCDS and OIT",
+    },
+    capacity: {
+      typicalSpecs: "4–8 vCPU · 16 GB RAM · 256 GB disk · 10 Gbps",
+      hardware:
+        "Dell M640 blades (1 TB RAM, 28 cores each) in an RCDS-managed VRTX chassis, UI Library basement",
+    },
+    resilience: { backups: "Snapshots + NFS backup", offsiteDr: false },
+    stack: "any-container",
+    valueProposition: {
+      headline:
+        "Hosting this week, at no cost, with the OS layer managed for you — the only environment a builder can reach without a formal process.",
+      permanentNiche: "Research-mission tools",
+      strategicRole: "stopgap",
+      antiFit: [
+        "High-risk data, ever",
+        "Above-Low-risk data on anything external-facing",
+      ],
+    },
     fits: [
       "Research-mission tools — the service's intended and permanent purpose",
       "Agentically-developed apps needing hosting this week at no cost — the stopgap for OIT's missing simple-hosting service",
       "Pilots iterating with their unit before entering the OIT pathway",
     ],
-    operator:
-      "RCDS (Luke Sheneman). RCDS holds root and sudo exclusively and owns the OS layer, patching, backups, monitoring, host and upstream firewalls, the reverse proxy, DNS, and SSL certificates. Builders get non-root, docker-group access — this is a managed container-hosting service, not a self-managed VM.",
-    deployer:
-      "Builders deploy and manage their own containers on their VM. Provisioning is a conversation with Luke Sheneman — no formal process, no cost, approval on judgment, hours-to-days depending on backlog.",
     governancePath:
       "Outside the OIT pathway. Request-and-discussion with RCDS covers what's allowable and whether the VM is internal-only or external-facing. The Builder Guide's term for apps here is 'staged on IIDS infrastructure' — pre-Stage-1.",
-    standardsBinding:
-      "The data rule (Sheneman, 2026-08-06): external-facing VMs carry Low-risk data only; internal-only VMs may carry low-to-moderate. Compliance is the tenant's responsibility — RCDS does not audit apps on an ongoing basis, and can disable a VM at any time. The ADR 0001 accessibility rule is NOT satisfied by the environment — accessibility falls on the project.",
-    techConstraint:
-      "Any Docker stack. Typical VM: 4–8 vCPU, 16 GB RAM, 256 GB disk, 10 Gbps networking (Dell M640 blades in an RCDS-managed VRTX chassis, UI Library basement). Each VM is configured internal-only or external-facing; per-app exposure via reverse-proxy rules. Behind an RCDS-managed Watchguard appliance (stateless filtering), not the campus Palo Alto — relocatable behind it if needed. Azure AD SSO is arranged app-by-app with RCDS and OIT. Snapshots and NFS backups exist; backups are not off-sited, so no true DR.",
-    dataPosture:
-      "External-facing: Low risk only. Internal-only: low to moderate. Enforcement is at intake and by tenant honor afterward — no continuous audit. MindRouter traffic from these VMs crosses the Palo Alto border firewall like any other client; same-chassis placement confers no privileged AI adjacency.",
     timeToDeploy:
       "Provisioning in hours to days (RCDS backlog); container deploys same-day thereafter.",
     maturity: "transitional",

--- a/lib/deployment-targets.ts
+++ b/lib/deployment-targets.ts
@@ -221,30 +221,39 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
       "Named in the OIT drafts as an approved platform; no workload has landed there.",
     exampleSlugs: [],
   },
+  // Defined with Luke Sheneman (RCDS), 2026-08-06 — the first environment
+  // of the definitional pass. Supersedes the repo-inferred v1 profile.
   {
     value: "rcds-vm",
     name: "Standalone app on an RCDS VM",
     formFactor: "standalone-app",
     shipUnit:
-      "A Docker-composed stack on an IIDS/RCDS self-managed VM — the insight.uidaho.edu class.",
+      "Containerized apps on an RCDS-provisioned, RCDS-managed VM. One VM per person, multiple apps per VM; hostnames under insight.uidaho.edu, nkn.uidaho.edu, or other RCDS subdomains.",
     fits: [
-      "Pilots and staged applications iterating with their unit before entering the pathway",
-      "Research-adjacent work outside enterprise governance",
-      "AI-enabled apps needing MindRouter/DGX adjacency during development",
+      "Research-mission tools — the service's intended and permanent purpose",
+      "Agentically-developed apps needing hosting this week at no cost — the stopgap for OIT's missing simple-hosting service",
+      "Pilots iterating with their unit before entering the OIT pathway",
     ],
-    operator: "IIDS/RCDS self-managed.",
-    deployer: "Builders deploy directly — same-day deploys.",
+    operator:
+      "RCDS (Luke Sheneman). RCDS holds root and sudo exclusively and owns the OS layer, patching, backups, monitoring, host and upstream firewalls, the reverse proxy, DNS, and SSL certificates. Builders get non-root, docker-group access — this is a managed container-hosting service, not a self-managed VM.",
+    deployer:
+      "Builders deploy and manage their own containers on their VM. Provisioning is a conversation with Luke Sheneman — no formal process, no cost, approval on judgment, hours-to-days depending on backlog.",
     governancePath:
-      "Outside the OIT pathway. The Builder Guide's term for apps here is 'staged on IIDS infrastructure' — pre-Stage-1.",
+      "Outside the OIT pathway. Request-and-discussion with RCDS covers what's allowable and whether the VM is internal-only or external-facing. The Builder Guide's term for apps here is 'staged on IIDS infrastructure' — pre-Stage-1.",
     standardsBinding:
-      "No OIT acceptance gate. The ADR 0001 accessibility rule is NOT satisfied by the environment — accessibility falls on the project.",
-    techConstraint: "Any Docker-composed stack (10.x address space, not 172.x).",
+      "The data rule (Sheneman, 2026-08-06): external-facing VMs carry Low-risk data only; internal-only VMs may carry low-to-moderate. Compliance is the tenant's responsibility — RCDS does not audit apps on an ongoing basis, and can disable a VM at any time. The ADR 0001 accessibility rule is NOT satisfied by the environment — accessibility falls on the project.",
+    techConstraint:
+      "Any Docker stack. Typical VM: 4–8 vCPU, 16 GB RAM, 256 GB disk, 10 Gbps networking (Dell M640 blades in an RCDS-managed VRTX chassis, UI Library basement). Each VM is configured internal-only or external-facing; per-app exposure via reverse-proxy rules. Behind an RCDS-managed Watchguard appliance (stateless filtering), not the campus Palo Alto — relocatable behind it if needed. Azure AD SSO is arranged app-by-app with RCDS and OIT. Snapshots and NFS backups exist; backups are not off-sited, so no true DR.",
     dataPosture:
-      "The lowest ceiling — not a home for high-risk institutional data per the draft SDLC standard's managed-hosts posture.",
-    timeToDeploy: "Fastest — hours, not stages.",
+      "External-facing: Low risk only. Internal-only: low to moderate. Enforcement is at intake and by tenant honor afterward — no continuous audit. MindRouter traffic from these VMs crosses the Palo Alto border firewall like any other client; same-chassis placement confers no privileged AI adjacency.",
+    timeToDeploy:
+      "Provisioning in hours to days (RCDS backlog); container deploys same-day thereafter.",
     maturity: "transitional",
     maturityNote:
-      "Nine portfolio projects run here today, but the target is staging by decision (2026-08-05): projects are expected to move through the pathway to an OIT-managed target or Databricks, not to stay.",
+      "Sheneman (2026-08-06): 'There is nothing special about RCDS VMs for this purpose. It is serving an immediate unmet need' — if OIT provided fast, free app hosting, RCDS would not need to. The service exists partly so institutional data doesn't scatter to external hosts. Research-mission workloads are the intended, permanent use; everything else is transitional by the service's own definition.",
+    openQuestions: [
+      "Which current external-facing tenants exceed the Low-risk data rule? A per-tenant classification review against the exposure rule has not been done.",
+    ],
     exampleSlugs: [
       "stratplan",
       "openera",

--- a/lib/project-governance.ts
+++ b/lib/project-governance.ts
@@ -50,7 +50,7 @@ export const DEPLOYMENT_ENVIRONMENTS = [
     label: "Standalone app — RCDS VM (transitional)",
     oitManaged: false,
     description:
-      "A Docker-composed application on an IIDS/RCDS self-managed VM (the insight.uidaho.edu class). Staging and pilot hosting, not a long-term destination — projects here are pre-pathway.",
+      "Containerized apps on an RCDS-provisioned, RCDS-managed VM (RCDS holds root and owns OS, firewalls, proxy, DNS, and backups; builders deploy containers). External-facing VMs carry Low-risk data only; internal-only VMs low-to-moderate. A stopgap for OIT's missing simple-hosting service — permanent home only for research-mission work.",
   },
   // ---- Rollup + meta values ------------------------------------------
   {


### PR DESCRIPTION
## Summary
- Redefines the RCDS VM environment from Luke Sheneman's definition session (2026-08-06) — environment 1 of the definitional pass. Key corrections: managed container-hosting service (not self-managed VM), tenant-enforced data rule (external-facing = Low risk only), no privileged AI adjacency from same-chassis placement, Watchguard not campus Palo Alto, no off-site DR.
- Restructures `DeploymentTargetProfile` from prose into typed definitions: responsibility matrix, access facts, exposure-dependent data rule with enforcement mode, network/capacity/resilience/stack facts, and a value model — with `unknown` as a first-class value everywhere.
- Adds per-profile provenance: RCDS is `defined` (raw interview record at `docs/environments/rcds-vm.md`); the other four environments are demoted to `repo-inferred` with invented specifics replaced by explicit unknowns. The Landscape bands badge the difference.
- The schema doubles as the interview instrument for the four remaining definition sessions.

## Test plan
- [x] `npm run build`
- [x] `npm run verify:portfolio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)