### PR TITLE
Add Vandalizer workflow as the sixth deployment target

### DIFF
--- a/app/utr-landscape/page.tsx
+++ b/app/utr-landscape/page.tsx
@@ -19,7 +19,7 @@ export const dynamic = "force-dynamic";
 export const metadata = {
   title: "UTR Landscape — Institutional AI Initiative",
   description:
-    "Every project and open technology request at the University of Idaho, harmonized against the five deployment targets institutional work can land on — and the mismatches between demand and supply.",
+    "Every project and open technology request at the University of Idaho, harmonized against the six deployment targets institutional work can land on — and the mismatches between demand and supply.",
 };
 
 const linkCls =
@@ -219,8 +219,8 @@ export default async function UtrLandscapePage() {
           <span className="font-semibold text-brand-black">
             {totals.openRequests} open requests
           </span>{" "}
-          — mapped against the five deployment targets institutional work
-          can land on. The targets are not equal: one is proven, two are
+          — mapped against the six deployment targets institutional work
+          can land on. The targets are not equal: two are proven, two are
           approved but untried, one is an aspiration, and one is a staging
           ground. The mismatches between demand and that supply are the
           coordination agenda.
@@ -257,15 +257,15 @@ export default async function UtrLandscapePage() {
         </ul>
       </section>
 
-      {/* ── The five targets ────────────────────────────── */}
+      {/* ── The six targets ─────────────────────────────── */}
       <section>
         <h2 className="text-2xl font-black tracking-tight text-brand-black">
-          The five targets
+          The six targets
         </h2>
         <p className="mt-2 max-w-3xl text-sm leading-relaxed text-ink-muted">
-          Form factor first — a report lands on the lakehouse, a
-          transactional module lands on Nexus — then hosting by operator
-          and risk for everything standalone.
+          Form factor first — a report lands on the lakehouse, document
+          work lands on Vandalizer, a transactional module lands on Nexus
+          — then hosting by operator and risk for everything standalone.
         </p>
         <div className="mt-5 space-y-5">
           {landscape.bands.map((band) => (
@@ -274,10 +274,10 @@ export default async function UtrLandscapePage() {
         </div>
       </section>
 
-      {/* ── Outside the five targets ────────────────────── */}
+      {/* ── Outside the six targets ─────────────────────── */}
       <section id="unclassified" className="scroll-mt-8">
         <h2 className="text-2xl font-black tracking-tight text-brand-black">
-          Outside the five targets
+          Outside the six targets
         </h2>
         <dl className="mt-5 space-y-6">
           {pools.externalHosted.length > 0 && (

--- a/db/migrations/026_vandalizer_workflow_target.sql
+++ b/db/migrations/026_vandalizer_workflow_target.sql
@@ -1,0 +1,79 @@
+-- Migration 026: Vandalizer workflow — the sixth deployment target
+--
+-- Adds 'vandalizer-workflow' to the deployment vocabulary established
+-- by Migrations 024 (applications) and 025 (tech_requests): a third
+-- platform-hosted form factor alongside the Databricks dashboard and
+-- the Nexus module. The ship unit is an extraction workflow, document
+-- collection, or workspace inside Vandalizer (vandalizer.uidaho.edu) —
+-- no application to host. Every UI person already has access (affirmed
+-- 2026-08-07), so document-shaped requests can classify here instead of
+-- being forced to a standalone target or left unclassified.
+--
+-- MindRouter is deliberately NOT a target: it is an inference gateway
+-- applications call — a dependency, not a place work lands. A request
+-- fully met by existing platform capability closes as
+-- routed-to-existing (Migration 018 vocabulary), with or without a
+-- target classification.
+--
+-- Typed source of truth: lib/project-governance.ts (vocabulary),
+-- lib/deployment-targets.ts (per-target characteristics), lib/utr.ts
+-- (request-classifiable subset). Per Migrations 024/025 discipline, the
+-- CHECKs here and those modules change together.
+
+BEGIN;
+
+ALTER TABLE applications
+  DROP CONSTRAINT applications_proposed_deployment_environment_check;
+
+ALTER TABLE applications
+  ADD CONSTRAINT applications_proposed_deployment_environment_check
+    CHECK (proposed_deployment_environment IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'vandalizer-workflow',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'platform',
+      'external-hosted',
+      'not-applicable',
+      'to-be-determined'
+    ));
+
+ALTER TABLE applications
+  DROP CONSTRAINT applications_current_deployment_environment_check;
+
+ALTER TABLE applications
+  ADD CONSTRAINT applications_current_deployment_environment_check
+    CHECK (current_deployment_environment IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'vandalizer-workflow',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'platform',
+      'external-hosted',
+      'not-applicable'
+    ));
+
+ALTER TABLE tech_requests
+  DROP CONSTRAINT tech_requests_proposed_deployment_target_check;
+
+ALTER TABLE tech_requests
+  ADD CONSTRAINT tech_requests_proposed_deployment_target_check
+    CHECK (proposed_deployment_target IN (
+      'databricks-dashboard',
+      'nexus-module',
+      'vandalizer-workflow',
+      'standalone-oci',
+      'standalone-oit-k8s',
+      'rcds-vm',
+      'oit-managed-tbd',
+      'external-hosted',
+      'not-applicable'
+    ));
+
+COMMIT;

--- a/docs/adr/0008-utr-landscape.md
+++ b/docs/adr/0008-utr-landscape.md
@@ -153,3 +153,28 @@ the landing critique arc, taken after the surface exists.
 - When targets firm up (Databricks service defined, first OCI/K8s
   landing), updating `lib/deployment-targets.ts` reflows the ledger
   automatically — the surface argues from data it does not own.
+
+## Amendment — sixth target (2026-08-07)
+
+The five-target supply model gained a sixth: **Vandalizer workflow**
+(`vandalizer-workflow`), a third platform-hosted form factor alongside
+the Databricks dashboard and the Nexus module. The trigger was the
+question of requests satisfiable by existing IIDS platforms: document-
+extraction- and document-Q&A-shaped requests were being forced to a
+standalone target or left unclassified when their honest destination is
+a workflow inside the already-operating, universally-accessible
+Vandalizer platform (Migration 026 widens the CHECKs; the form-factor
+step of the selection model gains a document branch).
+
+Two boundaries drawn in the same decision:
+
+- **MindRouter is not a target.** It is an inference gateway
+  applications call — a dependency, not a place work lands. A request
+  met by "just use chat" closes as `routed-to-existing` with no target;
+  a new app calling MindRouter classifies to wherever the app lands.
+- **`routed-to-existing` and target classification are complementary,
+  not competing.** A request fully met by Vandalizer as it stands
+  closes as `routed-to-existing` (interest-pool link to the
+  `vandalizer` entry); a request needing a *new* workflow built inside
+  the platform classifies to `vandalizer-workflow` and stays in the
+  landscape's demand picture.

--- a/docs/environments/README.md
+++ b/docs/environments/README.md
@@ -21,3 +21,4 @@ its session is pending.
 | Standalone on OCI | pending | — |
 | Standalone on OIT on-prem Kubernetes | pending | — |
 | Databricks dashboard | pending — value proposition affirmed (Barrie Robison, 2026-08-07); full question set on the profile's `openQuestions` | — |
+| Vandalizer workflow | added 2026-08-07 — universal UI access affirmed (Barrie Robison); operator session deliberately deferred | — |

--- a/lib/deployment-targets.ts
+++ b/lib/deployment-targets.ts
@@ -1,10 +1,11 @@
 // ============================================================
 // Deployment targets — per-environment definitions
 // ============================================================
-// The five deployment targets from the 2026-08-05 definitional session,
-// restructured 2026-08-06 into typed environment definitions: facts are
-// fields, prose is reserved for what is genuinely narrative, and
-// `"unknown"` is a first-class value everywhere. The vocabulary (typed
+// The deployment targets from the 2026-08-05 definitional session
+// (five), plus the Vandalizer workflow (2026-08-07), restructured
+// 2026-08-06 into typed environment definitions: facts are fields,
+// prose is reserved for what is genuinely narrative, and `"unknown"`
+// is a first-class value everywhere. The vocabulary (typed
 // values, labels, the OIT-managed flag) lives in
 // lib/project-governance.ts; this module carries the reference facts a
 // surface renders and the harmonization work classifies against.
@@ -18,24 +19,28 @@
 // difference. Unknown fields stay unknown until a session fills them —
 // do not invent values.
 //
-// The selection model the five targets encode is a two-step decision:
-// form factor first (report-shaped → Databricks dashboard; transactional
-// module fitting the template → Nexus; otherwise a standalone app),
-// then hosting by operator and risk. This maps onto the UTR tracks
-// (lib/utr.ts): Track D requests are Databricks-shaped, Tracks B/C
-// land on Nexus or a standalone target.
+// The selection model the targets encode is a two-step decision:
+// form factor first (report-shaped → Databricks dashboard;
+// document-extraction- or document-Q&A-shaped → Vandalizer workflow;
+// transactional module fitting the template → Nexus; otherwise a
+// standalone app), then hosting by operator and risk. This maps onto
+// the UTR tracks (lib/utr.ts): Track D requests are Databricks-shaped,
+// Tracks B/C land on Nexus or a standalone target, and document-shaped
+// requests from any track may resolve to a Vandalizer workflow — often
+// closing as routed-to-existing rather than becoming a build.
 //
 // Honesty rule: `maturity` states what the target IS today, not what
 // it should become.
 
 import type { DeploymentEnvironment } from "./project-governance";
 
-/** The five concrete targets — the subset of the vocabulary that names
+/** The six concrete targets — the subset of the vocabulary that names
  * a real place work can land (excludes rollup + meta values). */
 export type DeploymentTarget = Extract<
   DeploymentEnvironment,
   | "databricks-dashboard"
   | "nexus-module"
+  | "vandalizer-workflow"
   | "standalone-oci"
   | "standalone-oit-k8s"
   | "rcds-vm"
@@ -389,6 +394,85 @@ export const DEPLOYMENT_TARGETS: DeploymentTargetProfile[] = [
       "ucm-daily-register",
       "out-of-state-tax-tracking",
     ],
+  },
+  // Added 2026-08-07: the sixth target, prompted by the question of
+  // requests satisfiable by existing IIDS platforms. Universal UI
+  // access affirmed by Barrie Robison in that session; an operator
+  // session (John Brunsfeld) was deliberately deferred as unnecessary
+  // at this stage. MindRouter was considered and excluded — it is an
+  // inference gateway apps call (a dependency), not a place work lands.
+  {
+    value: "vandalizer-workflow",
+    name: "Vandalizer workflow",
+    formFactor: "platform-artifact",
+    shipUnit:
+      "An extraction workflow, document collection, or workspace inside the multi-tenant Vandalizer platform at vandalizer.uidaho.edu — no application to host.",
+    definition: { status: "repo-inferred" },
+    existence: "operating",
+    responsibilities: {
+      "os-and-patching": "provider",
+      backups: "provider",
+      monitoring: "provider",
+      "network-and-firewall": "provider",
+      "dns-and-certificates": "provider",
+      "reverse-proxy": "provider",
+      "app-deployment": "tenant",
+      "app-maintenance": "tenant",
+      "data-compliance": "tenant",
+    },
+    access: {
+      approvalAuthority:
+        "None — every UI person already has access (Barrie Robison, 2026-08-07)",
+      formality: "informal",
+      cost: "none",
+      turnaround: "Immediate — self-service with UI credentials",
+    },
+    dataRule: {
+      externalFacing: "low",
+      internalOnly: "unknown",
+      enforcement:
+        "Inherited from the host environment: the platform runs on an external-facing RCDS VM, whose rule caps external-facing at Low risk. Per-collection practice unverified.",
+    },
+    network: {
+      exposureOptions:
+        "SSO-gated web app at vandalizer.uidaho.edu, reachable from the public internet",
+      firewall: "Inherits the host RCDS VM's Watchguard appliance",
+      sso: "UI sign-in — access is universal at UI",
+    },
+    resilience: {
+      backups: "Inherited from the host RCDS VM (snapshots + NFS backup)",
+      offsiteDr: false,
+    },
+    stack: "platform-artifact",
+    valueProposition: {
+      headline:
+        "AI document intelligence every UI person can use today — structured extraction, reusable workflows, and citation-backed Q&A with no build, no approval, and no hosting.",
+      permanentNiche: "Document-extraction and document-Q&A work",
+      strategicRole: "destination",
+      antiFit: [
+        "Transactional workflows",
+        "Report/BI-shaped work over institutional data systems (→ Databricks)",
+        "Anything needing a custom application UI",
+      ],
+    },
+    fits: [
+      "Document-heavy requests: structured extraction from RFAs, awards, contracts, compliance filings",
+      "Citation-backed Q&A over a document collection",
+      "Reusable extraction workflows a unit runs repeatedly",
+    ],
+    governancePath:
+      "None for access — the platform is universally available at UI. Data governance rides on what is uploaded: document classification is the tenant's responsibility. A request fully met here closes as routed-to-existing with an interest link to the vandalizer portfolio entry.",
+    timeToDeploy:
+      "Same day — sign in and build; no provisioning, no pathway gates.",
+    maturity: "available",
+    maturityNote:
+      "In production at UI and Southern Utah University under the AI4RA NSF GRANTED partnership; universal UI access affirmed (Barrie Robison, 2026-08-07).",
+    openQuestions: [
+      "Do research-administration document collections (awards, contracts) fit the Low-risk ceiling inherited from the external-facing RCDS VM host? Per-collection classification review not done.",
+      "Is workflow-building genuinely self-service for a non-technical requestor, or does effective use need IIDS/OSP help? (Deferred operator question — John Brunsfeld.)",
+      "Where does a document process outgrow the platform — the line between a workflow here and work that should classify to a standalone app?",
+    ],
+    exampleSlugs: [],
   },
   {
     value: "standalone-oci",

--- a/lib/project-governance.ts
+++ b/lib/project-governance.ts
@@ -1,22 +1,23 @@
 // Project-level governance fields that cut across the portfolio, registry,
 // and public project detail pages.
 //
-// Deployment values follow the five-target model settled in the
-// 2026-08-05 definitional session (superseding the hosting-only
-// vocabulary from Migration 012): two platform-hosted form factors
-// (Databricks dashboard, Nexus module) plus three standalone-app
-// hosting locations (OCI, OIT on-prem Kubernetes, RCDS VM). The RCDS VM
-// is transitional — a staging home until a project enters the OIT
-// pathway, not a destination. Per-target characteristics live in
-// lib/deployment-targets.ts; Azure was dropped with zero uses and can
-// be re-added the day OIT actually lands something there.
+// Deployment values follow the six-target model: the five targets
+// settled in the 2026-08-05 definitional session (superseding the
+// hosting-only vocabulary from Migration 012) plus the Vandalizer
+// workflow added 2026-08-07 — three platform-hosted form factors
+// (Databricks dashboard, Nexus module, Vandalizer workflow) plus three
+// standalone-app hosting locations (OCI, OIT on-prem Kubernetes, RCDS
+// VM). The RCDS VM is transitional — a staging home until a project
+// enters the OIT pathway, not a destination. Per-target characteristics
+// live in lib/deployment-targets.ts; Azure was dropped with zero uses
+// and can be re-added the day OIT actually lands something there.
 //
 // `oitManaged` drives ADR 0001 sub-decision #5: production operated on
 // an OIT-managed environment satisfies the accessibility rule even
 // without an anonymous URL (lib/portfolio-verification.ts).
 
 export const DEPLOYMENT_ENVIRONMENTS = [
-  // ---- The five targets ----------------------------------------------
+  // ---- The six targets -----------------------------------------------
   {
     value: "databricks-dashboard",
     label: "Databricks dashboard (OIT lakehouse)",
@@ -30,6 +31,13 @@ export const DEPLOYMENT_ENVIRONMENTS = [
     oitManaged: true,
     description:
       "A module inside Nexus, the shared React + FastAPI application platform on OIT-managed secure infrastructure. Reached through the six-stage Builder Guide pathway.",
+  },
+  {
+    value: "vandalizer-workflow",
+    label: "Vandalizer workflow",
+    oitManaged: false,
+    description:
+      "An extraction workflow, document collection, or workspace inside Vandalizer, the multi-tenant AI document-intelligence platform at vandalizer.uidaho.edu — no application to host. Every UI person already has access; document-shaped needs land here self-service.",
   },
   {
     value: "standalone-oci",

--- a/lib/utr-landscape.ts
+++ b/lib/utr-landscape.ts
@@ -2,8 +2,9 @@
 // UTR Landscape — the destination-harmonized activity model
 // ============================================================
 // ADR 0008, PR 3: one read model joining the two activity populations
-// (projects in flight, open requests) against the five-target supply
-// model, plus the computed mismatch ledger the surface leads with.
+// (projects in flight, open requests) against the deployment-target
+// supply model (lib/deployment-targets.ts), plus the computed mismatch
+// ledger the surface leads with.
 //
 // Pure by design: `buildUtrLandscape()` takes its sources as arguments
 // and touches no I/O, so the page composes it from lib/work.ts +
@@ -135,7 +136,7 @@ export interface TargetBand {
 }
 
 /**
- * Activity that classifies outside the five targets. Each pool is a
+ * Activity that classifies outside the concrete targets. Each pool is a
  * deliberate bucket, not a leftover: vendor-hosted demand shapes the
  * Track A story, `oit-managed-tbd` records a made decision awaiting a
  * platform pick, `noDeployment` is request substance that never

--- a/lib/utr.ts
+++ b/lib/utr.ts
@@ -227,6 +227,7 @@ export type RequestDeploymentTarget = Extract<
   DeploymentEnvironment,
   | "databricks-dashboard"
   | "nexus-module"
+  | "vandalizer-workflow"
   | "standalone-oci"
   | "standalone-oit-k8s"
   | "rcds-vm"
@@ -238,6 +239,7 @@ export type RequestDeploymentTarget = Extract<
 export const REQUEST_DEPLOYMENT_TARGETS: RequestDeploymentTarget[] = [
   "databricks-dashboard",
   "nexus-module",
+  "vandalizer-workflow",
   "standalone-oci",
   "standalone-oit-k8s",
   "rcds-vm",

--- a/scripts/infer-request-targets.ts
+++ b/scripts/infer-request-targets.ts
@@ -75,6 +75,7 @@ const TARGET_DEFS = (
   [
     "databricks-dashboard",
     "nexus-module",
+    "vandalizer-workflow",
     "standalone-oci",
     "standalone-oit-k8s",
     "rcds-vm",
@@ -89,7 +90,7 @@ const TARGET_DEFS = (
 const SYSTEM_PROMPT = `You classify technology requests at the University of Idaho by the deployment target the requested capability would land on if pursued. Given a request's title, origin, requesting unit, intake track (when assigned), and prose description, return ONLY a JSON object with exactly these fields:
 
 {
-  "target": "databricks-dashboard" | "nexus-module" | "standalone-oci" | "standalone-oit-k8s" | "rcds-vm" | "oit-managed-tbd" | "external-hosted" | "not-applicable" | null,
+  "target": "databricks-dashboard" | "nexus-module" | "vandalizer-workflow" | "standalone-oci" | "standalone-oit-k8s" | "rcds-vm" | "oit-managed-tbd" | "external-hosted" | "not-applicable" | null,
   "rationale": string
 }
 
@@ -99,7 +100,7 @@ ${TARGET_DEFS}
 
 Classify with a two-step decision — form factor first, then hosting:
 
-1. Form factor. Is the substance of the request a report, dashboard, metric, or recurring data product over institutional data? → "databricks-dashboard". Is it a transactional staff workflow (validated intake, review queue, approvals, records over Banner-adjacent data) that fits a template web module? → "nexus-module". Is it the purchase, license, or subscription of an existing commercial product? → "external-hosted" (the vendor hosts it). Is it access to existing data, a report that already exists, a policy question, or otherwise nothing that deploys? → "not-applicable".
+1. Form factor. Is the substance of the request a report, dashboard, metric, or recurring data product over institutional data? → "databricks-dashboard". Is it document extraction, document review, or Q&A over a collection of documents (RFAs, awards, contracts, compliance filings)? → "vandalizer-workflow" (the existing AI document-intelligence platform; no build needed). Is it a transactional staff workflow (validated intake, review queue, approvals, records over Banner-adjacent data) that fits a template web module? → "nexus-module". Is it the purchase, license, or subscription of an existing commercial product? → "external-hosted" (the vendor hosts it). Is it access to existing data, a report that already exists, a policy question, or otherwise nothing that deploys? → "not-applicable".
 2. Hosting, only for builds that don't fit the above: a standalone application needing OIT-managed production goes to "standalone-oci" or "standalone-oit-k8s" (prefer "oit-managed-tbd" unless the text itself indicates on-prem residency, AI-compute adjacency, or a specific platform); an early pilot that would iterate on IIDS research infrastructure before entering the OIT pathway is "rcds-vm".
 
 Intake-track correlation (a hint, not a rule — the description wins):


### PR DESCRIPTION
Prompted by the question: what do we do with requests or ideas that could be accomplished with Vandalizer or MindRouter?

**The answer this PR encodes:**

- **Vandalizer becomes a target** (`vandalizer-workflow`) — a third platform-hosted form factor alongside the Databricks dashboard and the Nexus module. Ship unit: an extraction workflow, document collection, or workspace inside the multi-tenant platform at vandalizer.uidaho.edu. It's the *available* counterpart to the aspirational Databricks: in production at UI + SUU, universal UI access (affirmed by Barrie Robison, 2026-08-07), no approval, no cost, same-day. The selection model's form-factor step gains a document branch; the inference prompt classifies document-shaped requests here.
- **MindRouter is deliberately not a target** — it's an inference gateway apps call: a dependency, not a place work lands. Recorded in the ADR 0008 amendment.
- **`routed-to-existing` stays the disposition** for requests fully met by a platform as it stands; classification to `vandalizer-workflow` covers requests needing a new workflow built inside it. Complementary, not competing.

**Changes:** vocabulary (`project-governance.ts`), full profile with open questions (`deployment-targets.ts`), request classification (`utr.ts`, `infer-request-targets.ts`), Migration 026 (widens the three CHECKs), /utr-landscape copy five → six, ADR 0008 amendment, environments README row. The operator session with John Brunsfeld was deliberately deferred — profile stays `repo-inferred` with three real open questions (notably: does RA document content fit the Low-risk ceiling inherited from the external-facing RCDS VM host?).

`npm run build` and `npm run verify:portfolio` pass (29 projects, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)